### PR TITLE
make BelongsTo associations immediately reflect changes in foreign key

### DIFF
--- a/src/java/com/rapleaf/jack/BelongsToAssociation.java
+++ b/src/java/com/rapleaf/jack/BelongsToAssociation.java
@@ -5,7 +5,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+// http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,10 +17,9 @@ package com.rapleaf.jack;
 import java.io.IOException;
 import java.io.Serializable;
 
-
 public class BelongsToAssociation<T extends ModelWithId> implements Serializable {
   private final IModelPersistence<T> persistence;
-  private final Long id;
+  private Long id;
   private T cache;
 
   public BelongsToAssociation(IModelPersistence<T> persistence, Long id) {
@@ -29,11 +28,20 @@ public class BelongsToAssociation<T extends ModelWithId> implements Serializable
   }
 
   public T get() throws IOException {
-    if (id == null) return null;
+    if (id == null)
+      return null;
     if (cache == null) {
       cache = persistence.find(id);
     }
     return cache;
+  }
+
+  public void setOwnerId(Long id) {
+    this.id = id;
+  }
+
+  public void setOwnerId(Integer id) {
+    this.id = id == null ? null : id.longValue();
   }
 
   public void clearCache() throws IOException {

--- a/src/java/com/rapleaf/jack/test_project/database_1/models/Comment.java
+++ b/src/java/com/rapleaf/jack/test_project/database_1/models/Comment.java
@@ -101,6 +101,9 @@ public class Comment extends ModelWithId<Comment, IDatabases> {
 
   public void setCommenterId(int newval){
     this.__commenter_id = newval;
+    if(__assoc_user != null){
+      this.__assoc_user.setOwnerId(newval);
+    }
     cachedHashCode = 0;
   }
 
@@ -110,6 +113,9 @@ public class Comment extends ModelWithId<Comment, IDatabases> {
 
   public void setCommentedOnId(long newval){
     this.__commented_on_id = newval;
+    if(__assoc_post != null){
+      this.__assoc_post.setOwnerId(newval);
+    }
     cachedHashCode = 0;
   }
 

--- a/src/java/com/rapleaf/jack/test_project/database_1/models/Image.java
+++ b/src/java/com/rapleaf/jack/test_project/database_1/models/Image.java
@@ -67,6 +67,9 @@ public class Image extends ModelWithId<Image, IDatabases> {
 
   public void setUserId(Integer newval){
     this.__user_id = newval;
+    if(__assoc_user != null){
+      this.__assoc_user.setOwnerId(newval);
+    }
     cachedHashCode = 0;
   }
 

--- a/src/java/com/rapleaf/jack/test_project/database_1/models/Post.java
+++ b/src/java/com/rapleaf/jack/test_project/database_1/models/Post.java
@@ -109,6 +109,9 @@ public class Post extends ModelWithId<Post, IDatabases> {
 
   public void setUserId(Integer newval){
     this.__user_id = newval;
+    if(__assoc_user != null){
+      this.__assoc_user.setOwnerId(newval);
+    }
     cachedHashCode = 0;
   }
 

--- a/src/rb/field_defn.rb
+++ b/src/rb/field_defn.rb
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 class FieldDefn
-  attr_accessor :name, :data_type, :args, :ordinal, :default_value
+  attr_accessor :name, :data_type, :args, :ordinal, :default_value, :association
   def initialize(name, data_type, ordinal, args = {})
     @name = name
     @data_type = data_type
     @args = args
     @ordinal = ordinal
+    @association = nil
     
     @nullable = true
     if args[":null"] && args[":null"] == "false"

--- a/src/rb/jack.rb
+++ b/src/rb/jack.rb
@@ -46,6 +46,11 @@ class Jack
       by_table_name.values.each do |model_defn|
         model_defn.associations.each do |assoc_defn|
           assoc_defn.find_model(model_defns_by_namespace_table_names)
+          model_defn.fields.each do |field_defn|
+            if assoc_defn.foreign_key == field_defn.name
+              field_defn.association = assoc_defn
+            end
+          end
         end
         model_defn.associations.reject!{|assoc_defn| assoc_defn.defunct}
         model_defn.validate

--- a/src/rb/templates/model.erb
+++ b/src/rb/templates/model.erb
@@ -114,6 +114,11 @@ public class <%=model_defn.model_name%> extends ModelWithId<<%= model_defn.model
 
   public void set<%= field_defn.name.camelcase %>(<%= field_defn.java_type %> newval){
     this.__<%= field_defn.name %> = newval;
+    <% if field_defn.association != nil and field_defn.association.type == "belongs_to" %>
+    if(<%= field_defn.association.field_name %> != null){
+      this.<%= field_defn.association.field_name %>.setOwnerId(newval);
+    }
+    <% end %>
     cachedHashCode = 0;
   }
 <% end %>


### PR DESCRIPTION
setting the id of a field with a BelongsTo association now immediately modifys the associations, meaning that the sequence
model = new Model()
model.setSomeFieldId(id)
mode.getSomeField()

now produces the correct result
