### PR TITLE
add unset associations method

### DIFF
--- a/src/java/com/rapleaf/jack/ModelWithId.java
+++ b/src/java/com/rapleaf/jack/ModelWithId.java
@@ -116,6 +116,8 @@ public abstract class ModelWithId<T extends ModelWithId, D extends GenericDataba
 
   public abstract Set<Enum> getFieldSet();
 
+  public abstract void unsetAssociations();
+
   protected static byte[] copyBinary(final byte[] orig) {
     if (orig == null) {
       return null;

--- a/src/java/com/rapleaf/jack/test_project/database_1/models/Comment.java
+++ b/src/java/com/rapleaf/jack/test_project/database_1/models/Comment.java
@@ -405,4 +405,9 @@ public class Comment extends ModelWithId<Comment, IDatabases> {
       + " created_at: " + __created_at
       + ">";
   }
+
+  public void unsetAssociations(){
+        __assoc_user = null;
+        __assoc_post = null;
+  }
 }

--- a/src/java/com/rapleaf/jack/test_project/database_1/models/Image.java
+++ b/src/java/com/rapleaf/jack/test_project/database_1/models/Image.java
@@ -217,4 +217,8 @@ public class Image extends ModelWithId<Image, IDatabases> {
       + " user_id: " + __user_id
       + ">";
   }
+
+  public void unsetAssociations(){
+        __assoc_user = null;
+  }
 }

--- a/src/java/com/rapleaf/jack/test_project/database_1/models/Post.java
+++ b/src/java/com/rapleaf/jack/test_project/database_1/models/Post.java
@@ -345,4 +345,9 @@ public class Post extends ModelWithId<Post, IDatabases> {
       + " updated_at: " + __updated_at
       + ">";
   }
+
+  public void unsetAssociations(){
+        __assoc_user = null;
+        __assoc_comments = null;
+  }
 }

--- a/src/java/com/rapleaf/jack/test_project/database_1/models/User.java
+++ b/src/java/com/rapleaf/jack/test_project/database_1/models/User.java
@@ -581,4 +581,10 @@ public class User extends ModelWithId<User, IDatabases> {
       + " some_boolean: " + __some_boolean
       + ">";
   }
+
+  public void unsetAssociations(){
+        __assoc_posts = null;
+        __assoc_comments = null;
+        __assoc_image = null;
+  }
 }

--- a/src/rb/templates/model.erb
+++ b/src/rb/templates/model.erb
@@ -375,4 +375,10 @@ public class <%=model_defn.model_name%> extends ModelWithId<<%= model_defn.model
       <% end %>
       + ">";
   }
+
+  public void unsetAssociations(){
+   <% model_defn.associations.each do |assoc| %>
+        <%= assoc.field_name %> = null;
+   <% end %>
+  }
 }

--- a/test/java/com/rapleaf/jack/TestModelWithID.java
+++ b/test/java/com/rapleaf/jack/TestModelWithID.java
@@ -1,14 +1,13 @@
 package com.rapleaf.jack;
 
-import java.io.IOException;
-
-import junit.framework.TestCase;
-
 import com.rapleaf.jack.test_project.DatabasesImpl;
 import com.rapleaf.jack.test_project.IDatabases;
 import com.rapleaf.jack.test_project.database_1.models.Image;
 import com.rapleaf.jack.test_project.database_1.models.Post;
 import com.rapleaf.jack.test_project.database_1.models.User;
+import junit.framework.TestCase;
+
+import java.io.IOException;
 
 public class TestModelWithID extends TestCase {
   private static final DatabaseConnection DATABASE_CONNECTION1 = new DatabaseConnection("database1");
@@ -37,12 +36,14 @@ public class TestModelWithID extends TestCase {
     try {
       postModel.getField("fake_field");
       fail("Non-existent field should have thrown exception on get");
-    } catch (IllegalStateException e) {}
+    } catch (IllegalStateException e) {
+    }
 
     try {
       postModel.setField("fake_field", null);
       fail("Non-existent field should have thrown exception on set");
-    } catch (IllegalStateException e) {}
+    } catch (IllegalStateException e) {
+    }
 
     assertFalse(postModel.hasField("fake_field"));
     assertTrue(postModel.hasField("title"));
@@ -58,8 +59,8 @@ public class TestModelWithID extends TestCase {
     try {
       postModel.setField("title", 3);
       fail("Should have had class cast exception assigning int to string field");
-    } catch (ClassCastException e) {}
-
+    } catch (ClassCastException e) {
+    }
   }
 
   public void testBelongsToAssociations() throws IOException {
@@ -84,4 +85,17 @@ public class TestModelWithID extends TestCase {
     }
   }
 
+  public void testClearAssociations() throws IOException {
+
+    assertNull(imageModel.getUser());
+    imageModel.setUserId(0);
+    assertNotNull(imageModel.getUser());
+    assertEquals(imageModel.getUser(), userModel);
+    imageModel.unsetAssociations();
+    try {
+      imageModel.getUser();
+      fail("A NullPointerException should have been thrown when trying to access the cleared association");
+    } catch (NullPointerException e) {
+    }
+  }
 }


### PR DESCRIPTION
We've found in our applications that, when storing a large number of database models in memory, the associations objects for the models can take up large portion of the memory being used and are not always necessary to have for particular tasks. Providing this method will allow us to get rid of some hacky reflection code we're currently using to get the same functionality.
