### PR TITLE
Used relationship name in the naming of creation methods for has_one

### DIFF
--- a/src/rb/templates/model.erb
+++ b/src/rb/templates/model.erb
@@ -311,7 +311,7 @@ public class <%=model_defn.model_name%> extends ModelWithId<<%= model_defn.model
   <% model_defn.associations.each do |association| %>
     <% assoc_field = association.assoc_model.fields.reject{|field_defn| field_defn.name != association.foreign_key }.first %>
     <% assoc_field_type = assoc_field.java_type rescue nil %>
-    <% other_model_name = association.type == "belongs_to" ? association.foreign_key.gsub("_id", "").camelcase : association.name.camelcase %>
+    <% association_name = association.type == "belongs_to" ? association.foreign_key.gsub("_id", "").camelcase : association.name.camelcase %>
     <% other_model_field = model_defn.fields.reject{|field_defn| field_defn.name != (association.foreign_key) }.first %>
     <% new_model_name = "new" + association.assoc_model_name %>
     <% if association.type != "has_many" %>
@@ -324,7 +324,7 @@ public class <%=model_defn.model_name%> extends ModelWithId<<%= model_defn.model
       <% signatures.zip(arguments).each do |signature, argument_list| %>
         <% if !signature.nil? %>
 
-  public <%= association.assoc_model_name %> <%= "create" %><%= other_model_name %>(<%= signature %>) throws IOException {
+  public <%= association.assoc_model_name %> <%= "create" %><%= association_name %>(<%= signature %>) throws IOException {
           <% if !assoc_field.nil? %>
     <%= association.assoc_getter_type %> previous = <%= association.assoc_getter %>(); 
     if (previous != null) {


### PR DESCRIPTION
@seancarr 

Tested in db_schemas. Only affects 2 classes and effected methods in these classes weren't being used.

I'm not entirely satisfied with this solution. Would prefer to change some members in AssociationDefn, but I don't know the full implications of such changes. This change is small, simple, and gets us the desired behavior.
