### PR TITLE
passing the cause of the recoverable exception to resetConnection

### DIFF
--- a/src/java/com/rapleaf/jack/AbstractDatabaseModel.java
+++ b/src/java/com/rapleaf/jack/AbstractDatabaseModel.java
@@ -140,7 +140,7 @@ public abstract class AbstractDatabaseModel<T extends ModelWithId> implements
         long newId = generatedKeys.getLong(1);
         return newId;
       } catch (SQLRecoverableException e) {
-        conn.resetConnection();
+        conn.resetConnection(e);
         if (++retryCount > MAX_CONNECTION_RETRIES) {
           throw new IOException(e);
         }
@@ -155,7 +155,7 @@ public abstract class AbstractDatabaseModel<T extends ModelWithId> implements
             stmt.close();
           }
         } catch (SQLRecoverableException e) {
-          conn.resetConnection();
+          conn.resetConnection(e);
         } catch (SQLException e) {
         }
       }
@@ -199,7 +199,7 @@ public abstract class AbstractDatabaseModel<T extends ModelWithId> implements
         }
         break;
       } catch (SQLRecoverableException e) {
-        conn.resetConnection();
+        conn.resetConnection(e);
         if (++retryCount > MAX_CONNECTION_RETRIES) {
           throw new IOException(e);
         }
@@ -214,7 +214,7 @@ public abstract class AbstractDatabaseModel<T extends ModelWithId> implements
             stmt.close();
           }
         } catch (SQLRecoverableException e) {
-          conn.resetConnection();
+          conn.resetConnection(e);
         } catch (SQLException e) {
         }
       }
@@ -384,7 +384,7 @@ public abstract class AbstractDatabaseModel<T extends ModelWithId> implements
         }
       }
     } catch (SQLRecoverableException e) {
-      conn.resetConnection();
+      conn.resetConnection(e);
       throw e;
     } finally {
       try {
@@ -393,7 +393,7 @@ public abstract class AbstractDatabaseModel<T extends ModelWithId> implements
         }
         stmt.close();
       } catch (SQLRecoverableException e) {
-        conn.resetConnection();
+        conn.resetConnection(e);
       } catch (SQLException e) {
       }
     }
@@ -526,7 +526,7 @@ public abstract class AbstractDatabaseModel<T extends ModelWithId> implements
         }
         return ret;
       } catch (SQLRecoverableException e) {
-        conn.resetConnection();
+        conn.resetConnection(e);
         if (++retryCount > MAX_CONNECTION_RETRIES) {
           throw new IOException(e);
         }
@@ -541,7 +541,7 @@ public abstract class AbstractDatabaseModel<T extends ModelWithId> implements
             stmt.close();
           }
         } catch (SQLRecoverableException e) {
-          conn.resetConnection();
+          conn.resetConnection(e);
         } catch (SQLException e) {
         }
       }
@@ -605,7 +605,7 @@ public abstract class AbstractDatabaseModel<T extends ModelWithId> implements
           }
           break;
         } catch (SQLRecoverableException e) {
-          conn.resetConnection();
+          conn.resetConnection(e);
           if (++retryCount > MAX_CONNECTION_RETRIES) {
             throw new IOException(e);
           }
@@ -620,7 +620,7 @@ public abstract class AbstractDatabaseModel<T extends ModelWithId> implements
               stmt.close();
             }
           } catch (SQLRecoverableException e) {
-            conn.resetConnection();
+            conn.resetConnection(e);
           } catch (SQLException e) {
           }
         }
@@ -758,7 +758,7 @@ public abstract class AbstractDatabaseModel<T extends ModelWithId> implements
         }
         return results;
       } catch (SQLRecoverableException e) {
-        conn.resetConnection();
+        conn.resetConnection(e);
         if (++retryCount > MAX_CONNECTION_RETRIES) {
           throw new IOException(e);
         }
@@ -773,7 +773,7 @@ public abstract class AbstractDatabaseModel<T extends ModelWithId> implements
             stmt.close();
           }
         } catch (SQLRecoverableException e) {
-          conn.resetConnection();
+          conn.resetConnection(e);
         } catch (SQLException e) {
         }
       }

--- a/src/java/com/rapleaf/jack/BaseDatabaseConnection.java
+++ b/src/java/com/rapleaf/jack/BaseDatabaseConnection.java
@@ -17,14 +17,24 @@ public abstract class BaseDatabaseConnection implements Serializable {
   public abstract Connection getConnection();
 
   /**
-   * Re-establish the connection in case it has been sitting idle for too 
+   * Re-establish the connection in case it has been sitting idle for too
    * long and has been claimed by the server
    */
   public Connection resetConnection() {
+    return resetConnection(null);
+  }
+
+  /**
+   * Re-establish the connection in case it has been sitting idle for too
+   * long and has been claimed by the server
+   * This version specifies a cause and can be used when the reset is
+   * performed as an attempt to recover from an exception
+   */
+  public Connection resetConnection(Throwable cause) {
     if (conn != null) {
       try {
         if (!conn.getAutoCommit()) {
-          throw new RuntimeException("Cannot safely reset connection. May be in the middle of a transaction.");
+          throw new RuntimeException("Cannot safely reset connection. May be in the middle of a transaction.", cause);
         }
         conn.close();
       } catch (SQLException e) {


### PR DESCRIPTION
@seancarr 

I thought it might be cleanest for resetConnection() to optionally take a cause. Open to suggestions, though.