### PR TITLE
Lazily load each db in DatabasesImpl

### DIFF
--- a/src/rb/templates/databases_impl.erb
+++ b/src/rb/templates/databases_impl.erb
@@ -26,28 +26,23 @@ import <%= db.namespace %>.impl.<%= db.name %>Impl;
 public class DatabasesImpl implements IDatabases {
 
   <% project_defn.databases.each do |db| %>
-  private final BaseDatabaseConnection <%= db.connection_name %>;
-  <% end %>
-
-  <% project_defn.databases.each do |db| %>
   private I<%= db.name %> <%= db.name.underscore %>;
   <% end %>
 
-  public DatabasesImpl(<%= project_defn.databases.map{|db| ["BaseDatabaseConnection", db.connection_name].join(" ")}.join(", ") %>) {
-    <% project_defn.databases.each do |db| %>
-    this.<%= db.connection_name %> = <%= db.connection_name %>;
-    <% end %>
+  public DatabasesImpl() {
   }
 
-  public DatabasesImpl() {
-    this(<%= project_defn.databases.map{|db| ["new DatabaseConnection(\"", db.name.underscore, "\")"].join("")}.join(", ") %>);
+  public DatabasesImpl(<%= project_defn.databases.map{|db| ["BaseDatabaseConnection", db.connection_name].join(" ")}.join(", ") %>) {
+    <% project_defn.databases.each do |db| %>
+    this.<%= db.name.underscore %> = new <%= db.name %>Impl(<%= db.connection_name %>, this);
+    <% end %>
   }
 
   <% project_defn.databases.each do |db| %>
 
   public I<%= db.name %> <%= db.getter %> {
     if (<%= db.name.underscore %> == null) {
-      this.<%= db.name.underscore %> = new <%= db.name %>Impl(<%= db.connection_name %>, this);
+      this.<%= db.name.underscore %> = new <%= db.name %>Impl(new DatabaseConnection("<%= db.connection_name %>"), this);
     }
     return <%= db.name.underscore %>;
   }

--- a/src/rb/templates/databases_impl.erb
+++ b/src/rb/templates/databases_impl.erb
@@ -24,25 +24,31 @@ import <%= db.namespace %>.impl.<%= db.name %>Impl;
 <% end %>
 
 public class DatabasesImpl implements IDatabases {
+
   <% project_defn.databases.each do |db| %>
-  private final I<%= db.name %> <%= db.name.underscore %>;
+  private final BaseDatabaseConnection <%= db.connection_name %>;
+  <% end %>
+
+  <% project_defn.databases.each do |db| %>
+  private I<%= db.name %> <%= db.name.underscore %>;
   <% end %>
 
   public DatabasesImpl(<%= project_defn.databases.map{|db| ["BaseDatabaseConnection", db.connection_name].join(" ")}.join(", ") %>) {
     <% project_defn.databases.each do |db| %>
-    this.<%= db.name.underscore %> = new <%= db.name %>Impl(<%= db.connection_name %>, this);
+    this.<%= db.connection_name %> = <%= db.connection_name %>;
     <% end %>
   }
 
   public DatabasesImpl() {
-    <% project_defn.databases.each do |db| %>
-    this.<%= db.name.underscore %> = new <%= db.name %>Impl(new DatabaseConnection("<%= db.name.underscore %>"), this);
-    <% end %>
+    this(<%= project_defn.databases.map{|db| ["new DatabaseConnection(\"", db.name.underscore, "\")"].join("")}.join(", ") %>);
   }
 
   <% project_defn.databases.each do |db| %>
 
   public I<%= db.name %> <%= db.getter %> {
+    if (<%= db.name.underscore %> == null) {
+      this.<%= db.name.underscore %> = new <%= db.name %>Impl(<%= db.connection_name %>, this);
+    }
     return <%= db.name.underscore %>;
   }
   <% end %>

--- a/src/rb/templates/databases_impl.erb
+++ b/src/rb/templates/databases_impl.erb
@@ -42,7 +42,7 @@ public class DatabasesImpl implements IDatabases {
 
   public I<%= db.name %> <%= db.getter %> {
     if (<%= db.name.underscore %> == null) {
-      this.<%= db.name.underscore %> = new <%= db.name %>Impl(new DatabaseConnection("<%= db.connection_name %>"), this);
+      this.<%= db.name.underscore %> = new <%= db.name %>Impl(new DatabaseConnection("<%= db.name.underscore %>"), this);
     }
     return <%= db.name.underscore %>;
   }

--- a/test/java/com/rapleaf/jack/test_project/DatabasesImpl.java
+++ b/test/java/com/rapleaf/jack/test_project/DatabasesImpl.java
@@ -12,20 +12,18 @@ import com.rapleaf.jack.test_project.database_1.IDatabase1;
 import com.rapleaf.jack.test_project.database_1.impl.Database1Impl;
 
 public class DatabasesImpl implements IDatabases {
-  private final BaseDatabaseConnection database1_connection;
   private IDatabase1 database1;
 
-  public DatabasesImpl(BaseDatabaseConnection database1_connection) {
-    this.database1_connection = database1_connection;
+  public DatabasesImpl() {
   }
 
-  public DatabasesImpl() {
-    this(new DatabaseConnection("database1"));
+  public DatabasesImpl(BaseDatabaseConnection database1_connection) {
+    this.database1 = new Database1Impl(database1_connection, this);
   }
 
   public IDatabase1 getDatabase1() {
     if (database1 == null) {
-      this.database1 = new Database1Impl(database1_connection, this);
+      this.database1 = new Database1Impl(new DatabaseConnection("database1_connection"), this);
     }
     return database1;
   }

--- a/test/java/com/rapleaf/jack/test_project/DatabasesImpl.java
+++ b/test/java/com/rapleaf/jack/test_project/DatabasesImpl.java
@@ -23,7 +23,7 @@ public class DatabasesImpl implements IDatabases {
 
   public IDatabase1 getDatabase1() {
     if (database1 == null) {
-      this.database1 = new Database1Impl(new DatabaseConnection("database1_connection"), this);
+      this.database1 = new Database1Impl(new DatabaseConnection("database1"), this);
     }
     return database1;
   }

--- a/test/java/com/rapleaf/jack/test_project/DatabasesImpl.java
+++ b/test/java/com/rapleaf/jack/test_project/DatabasesImpl.java
@@ -12,17 +12,21 @@ import com.rapleaf.jack.test_project.database_1.IDatabase1;
 import com.rapleaf.jack.test_project.database_1.impl.Database1Impl;
 
 public class DatabasesImpl implements IDatabases {
-  private final IDatabase1 database1;
+  private final BaseDatabaseConnection database1_connection;
+  private IDatabase1 database1;
 
   public DatabasesImpl(BaseDatabaseConnection database1_connection) {
-    this.database1 = new Database1Impl(database1_connection, this);
+    this.database1_connection = database1_connection;
   }
 
   public DatabasesImpl() {
-    this.database1 = new Database1Impl(new DatabaseConnection("database1"), this);
+    this(new DatabaseConnection("database1"));
   }
 
   public IDatabase1 getDatabase1() {
+    if (database1 == null) {
+      this.database1 = new Database1Impl(database1_connection, this);
+    }
     return database1;
   }
 }


### PR DESCRIPTION
@bpodgursky @tuliren 
This loads each db lazily instead of at construction time, which makes it possible for projects to only include required databases in the database.yml file.