### PR TITLE
Fix of DATETIME

### DIFF
--- a/src/java/com/rapleaf/jack/queries/Functions.java
+++ b/src/java/com/rapleaf/jack/queries/Functions.java
@@ -9,7 +9,7 @@ import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
 public class Functions {
-  private static final DateTimeFormatter datetimeFormat = DateTimeFormat.forPattern("yyyy-MM-dd hh:mm:ss");
+  private static final DateTimeFormatter datetimeFormat = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss");
   private static final DateTimeFormatter dateFormat = DateTimeFormat.forPattern("yyyy-MM-dd");
 
   public static String DATETIME(long datetime) {


### PR DESCRIPTION
There is a bug in function `DATETIME`. It uses `hh` to convert a long value to a datetime literal. In `DateTimeFormat`, however, `hh` means clockhour of halfday, which ranges from 1 to 12. It will incorrectly create an AM datetime literal for a PM time.

Instead, `HH` should be used, which ranges from 0 to 23.

@SLieve and @jrhizor, this is why your queries returned nothing. Sorry about the inconvenience.
