### PR TITLE
Support where clauses for ids

### DIFF
--- a/src/java/com/rapleaf/jack/queries/WhereConstraint.java
+++ b/src/java/com/rapleaf/jack/queries/WhereConstraint.java
@@ -36,6 +36,10 @@ public class WhereConstraint<T> implements QueryCondition {
     return column.getField();
   }
 
+  public boolean isId() {
+    return column.getField() == null;
+  }
+
   public IWhereOperator<T> getOperator() {
     return operator;
   }

--- a/src/rb/templates/persistence_impl.erb
+++ b/src/rb/templates/persistence_impl.erb
@@ -159,18 +159,22 @@ public class <%= model_defn.impl_name %> extends AbstractDatabaseModel<<%= model
     <% else %>
     int index = 0;
     for (WhereConstraint constraint : whereClause.getWhereConstraints()) {
-      <%= model_defn.model_name %>._Fields field = (<%= model_defn.model_name %>._Fields)constraint.getField();
       for (Object parameter : constraint.getParameters()) {
         if (parameter == null) {
           continue;
         }
         try {
-          switch (field) {
-      <% model_defn.fields.each do |field_defn| %>
-            case <%= field_defn.name %>:
-              preparedStatement.set<%=field_defn.prep_stmt_type%>(++index, <%=field_defn.prep_stmt_modifier("(#{field_defn.java_type(true)}) parameter")%>);
-              break;
-      <% end %>
+          if (constraint.isId()) {
+            preparedStatement.setLong(++index, (Long)parameter);
+          } else {
+            <%= model_defn.model_name %>._Fields field = (<%= model_defn.model_name %>._Fields)constraint.getField();
+            switch (field) {
+        <% model_defn.fields.each do |field_defn| %>
+              case <%= field_defn.name %>:
+                preparedStatement.set<%=field_defn.prep_stmt_type%>(++index, <%=field_defn.prep_stmt_modifier("(#{field_defn.java_type(true)}) parameter")%>);
+                break;
+        <% end %>
+            }
           }
         } catch (SQLException e) {
           throw new IOException(e);

--- a/src/rb/templates/query_builder_impl.erb
+++ b/src/rb/templates/query_builder_impl.erb
@@ -3,6 +3,7 @@ package <%= root_package %>.query;
 import java.util.Set;
 
 import <%= JACK_NAMESPACE %>.queries.AbstractQueryBuilder;
+import <%= JACK_NAMESPACE %>.queries.Column;
 import <%= JACK_NAMESPACE %>.queries.FieldSelector;
 import <%= JACK_NAMESPACE %>.queries.where_operators.IWhereOperator;
 import <%= JACK_NAMESPACE %>.queries.where_operators.JackMatchers;
@@ -43,7 +44,7 @@ public class <%= model_defn.query_builder_name %> extends AbstractQueryBuilder<<
   }
 
   public <%= model_defn.query_builder_name %> whereId(IWhereOperator<Long> operator) {
-    addWhereConstraint(new WhereConstraint<Long>(Column fromId(null), operator, null));
+    addWhereConstraint(new WhereConstraint<Long>(Column.fromId(null), operator, null));
     return this;
   }
 

--- a/src/rb/templates/query_builder_impl.erb
+++ b/src/rb/templates/query_builder_impl.erb
@@ -42,6 +42,11 @@ public class <%= model_defn.query_builder_name %> extends AbstractQueryBuilder<<
     return this;
   }
 
+  public <%= model_defn.query_builder_name %> whereId(IWhereOperator<Long> operator) {
+    addWhereConstraint(new WhereConstraint<Long>(Column fromId(null), operator, null));
+    return this;
+  }
+
   public <%= model_defn.query_builder_name %> limit(int offset, int nResults) {
     setLimit(new LimitCriterion(offset, nResults));
     return this;
@@ -61,18 +66,18 @@ public class <%= model_defn.query_builder_name %> extends AbstractQueryBuilder<<
     this.addOrder(new OrderCriterion(QueryOrder.ASC));
     return this;
   }
-  
+
   public <%= model_defn.query_builder_name %> order(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(queryOrder));
     return this;
   }
-  
+
   public <%= model_defn.query_builder_name %> orderById() {
     this.addOrder(new OrderCriterion(QueryOrder.ASC));
     return this;
   }
-  
-  public <%= model_defn.query_builder_name %> orderById(QueryOrder queryOrder) {    
+
+  public <%= model_defn.query_builder_name %> orderById(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(queryOrder));
     return this;
   }
@@ -88,12 +93,12 @@ public class <%= model_defn.query_builder_name %> extends AbstractQueryBuilder<<
     addWhereConstraint(new WhereConstraint<<%= field_defn.java_type(true) %>>(<%= model_defn.model_name %>._Fields.<%= field_defn.name %>, operator));
     return this;
   }
-  
+
   public <%= model_defn.query_builder_name %> orderBy<%= field_defn.name.camelcase() %>() {
     this.addOrder(new OrderCriterion(<%= model_defn.model_name %>._Fields.<%= field_defn.name %>, QueryOrder.ASC));
     return this;
   }
-  
+
   public <%= model_defn.query_builder_name %> orderBy<%= field_defn.name.camelcase() %>(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(<%= model_defn.model_name %>._Fields.<%= field_defn.name %>, queryOrder));
     return this;

--- a/test/java/com/rapleaf/jack/TestModelQuery.java
+++ b/test/java/com/rapleaf/jack/TestModelQuery.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import junit.framework.TestCase;
 
@@ -21,7 +22,19 @@ import com.rapleaf.jack.test_project.database_1.models.User;
 import static com.rapleaf.jack.queries.AggregatorFunctions.max;
 import static com.rapleaf.jack.queries.QueryOrder.ASC;
 import static com.rapleaf.jack.queries.QueryOrder.DESC;
-import static com.rapleaf.jack.queries.where_operators.JackMatchers.*;
+import static com.rapleaf.jack.queries.where_operators.JackMatchers.between;
+import static com.rapleaf.jack.queries.where_operators.JackMatchers.contains;
+import static com.rapleaf.jack.queries.where_operators.JackMatchers.endsWith;
+import static com.rapleaf.jack.queries.where_operators.JackMatchers.equalTo;
+import static com.rapleaf.jack.queries.where_operators.JackMatchers.greaterThan;
+import static com.rapleaf.jack.queries.where_operators.JackMatchers.greaterThanOrEqualTo;
+import static com.rapleaf.jack.queries.where_operators.JackMatchers.in;
+import static com.rapleaf.jack.queries.where_operators.JackMatchers.lessThan;
+import static com.rapleaf.jack.queries.where_operators.JackMatchers.lessThanOrEqualTo;
+import static com.rapleaf.jack.queries.where_operators.JackMatchers.notBetween;
+import static com.rapleaf.jack.queries.where_operators.JackMatchers.notEqualTo;
+import static com.rapleaf.jack.queries.where_operators.JackMatchers.notIn;
+import static com.rapleaf.jack.queries.where_operators.JackMatchers.startsWith;
 
 
 public class TestModelQuery extends TestCase {
@@ -210,6 +223,29 @@ public class TestModelQuery extends TestCase {
         .find();
     assertEquals(1, result.size());
     assertTrue(result.contains(sampleUsers[3]));
+  }
+
+  public void testQueryWhereId() throws IOException, SQLException {
+    IUserPersistence users = dbs.getDatabase1().users();
+    users.deleteAll();
+
+    User userA = users.createDefaultInstance().setHandle("A");
+    User userB = users.createDefaultInstance().setHandle("B");
+    User userC = users.createDefaultInstance().setHandle("C");
+    userA.save();
+    userB.save();
+    userC.save();
+
+    List<User> result = users.query().whereId(JackMatchers.equalTo(userB.getId())).find();
+
+    assertEquals(1, result.size());
+    assertTrue(result.contains(userB));
+
+    result = users.query().whereId(JackMatchers.in(Lists.newArrayList(userA.getId(), userC.getId()))).find();
+
+    assertEquals(2, result.size());
+    assertTrue(result.contains(userA));
+    assertTrue(result.contains(userC));
   }
 
   public void testQueryWithOrder() throws IOException, SQLException {

--- a/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseCommentPersistenceImpl.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseCommentPersistenceImpl.java
@@ -182,25 +182,29 @@ public class BaseCommentPersistenceImpl extends AbstractDatabaseModel<Comment> i
   protected void setStatementParameters(PreparedStatement preparedStatement, WhereClause whereClause) throws IOException {
     int index = 0;
     for (WhereConstraint constraint : whereClause.getWhereConstraints()) {
-      Comment._Fields field = (Comment._Fields)constraint.getField();
       for (Object parameter : constraint.getParameters()) {
         if (parameter == null) {
           continue;
         }
         try {
-          switch (field) {
-            case content:
-              preparedStatement.setString(++index, (String) parameter);
-              break;
-            case commenter_id:
-              preparedStatement.setInt(++index, (Integer) parameter);
-              break;
-            case commented_on_id:
-              preparedStatement.setLong(++index, (Long) parameter);
-              break;
-            case created_at:
-              preparedStatement.setTimestamp(++index, new Timestamp((Long) parameter));
-              break;
+          if (constraint.isId()) {
+            preparedStatement.setLong(++index, (Long)parameter);
+          } else {
+            Comment._Fields field = (Comment._Fields)constraint.getField();
+            switch (field) {
+              case content:
+                preparedStatement.setString(++index, (String) parameter);
+                break;
+              case commenter_id:
+                preparedStatement.setInt(++index, (Integer) parameter);
+                break;
+              case commented_on_id:
+                preparedStatement.setLong(++index, (Long) parameter);
+                break;
+              case created_at:
+                preparedStatement.setTimestamp(++index, new Timestamp((Long) parameter));
+                break;
+            }
           }
         } catch (SQLException e) {
           throw new IOException(e);

--- a/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseImagePersistenceImpl.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseImagePersistenceImpl.java
@@ -160,16 +160,20 @@ public class BaseImagePersistenceImpl extends AbstractDatabaseModel<Image> imple
   protected void setStatementParameters(PreparedStatement preparedStatement, WhereClause whereClause) throws IOException {
     int index = 0;
     for (WhereConstraint constraint : whereClause.getWhereConstraints()) {
-      Image._Fields field = (Image._Fields)constraint.getField();
       for (Object parameter : constraint.getParameters()) {
         if (parameter == null) {
           continue;
         }
         try {
-          switch (field) {
-            case user_id:
-              preparedStatement.setInt(++index, (Integer) parameter);
-              break;
+          if (constraint.isId()) {
+            preparedStatement.setLong(++index, (Long)parameter);
+          } else {
+            Image._Fields field = (Image._Fields)constraint.getField();
+            switch (field) {
+              case user_id:
+                preparedStatement.setInt(++index, (Integer) parameter);
+                break;
+            }
           }
         } catch (SQLException e) {
           throw new IOException(e);

--- a/test/java/com/rapleaf/jack/test_project/database_1/impl/BasePostPersistenceImpl.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/impl/BasePostPersistenceImpl.java
@@ -187,25 +187,29 @@ public class BasePostPersistenceImpl extends AbstractDatabaseModel<Post> impleme
   protected void setStatementParameters(PreparedStatement preparedStatement, WhereClause whereClause) throws IOException {
     int index = 0;
     for (WhereConstraint constraint : whereClause.getWhereConstraints()) {
-      Post._Fields field = (Post._Fields)constraint.getField();
       for (Object parameter : constraint.getParameters()) {
         if (parameter == null) {
           continue;
         }
         try {
-          switch (field) {
-            case title:
-              preparedStatement.setString(++index, (String) parameter);
-              break;
-            case posted_at_millis:
-              preparedStatement.setDate(++index, new Date((Long) parameter));
-              break;
-            case user_id:
-              preparedStatement.setInt(++index, (Integer) parameter);
-              break;
-            case updated_at:
-              preparedStatement.setTimestamp(++index, new Timestamp((Long) parameter));
-              break;
+          if (constraint.isId()) {
+            preparedStatement.setLong(++index, (Long)parameter);
+          } else {
+            Post._Fields field = (Post._Fields)constraint.getField();
+            switch (field) {
+              case title:
+                preparedStatement.setString(++index, (String) parameter);
+                break;
+              case posted_at_millis:
+                preparedStatement.setDate(++index, new Date((Long) parameter));
+                break;
+              case user_id:
+                preparedStatement.setInt(++index, (Integer) parameter);
+                break;
+              case updated_at:
+                preparedStatement.setTimestamp(++index, new Timestamp((Long) parameter));
+                break;
+            }
           }
         } catch (SQLException e) {
           throw new IOException(e);

--- a/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseUserPersistenceImpl.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseUserPersistenceImpl.java
@@ -235,43 +235,47 @@ public class BaseUserPersistenceImpl extends AbstractDatabaseModel<User> impleme
   protected void setStatementParameters(PreparedStatement preparedStatement, WhereClause whereClause) throws IOException {
     int index = 0;
     for (WhereConstraint constraint : whereClause.getWhereConstraints()) {
-      User._Fields field = (User._Fields)constraint.getField();
       for (Object parameter : constraint.getParameters()) {
         if (parameter == null) {
           continue;
         }
         try {
-          switch (field) {
-            case handle:
-              preparedStatement.setString(++index, (String) parameter);
-              break;
-            case created_at_millis:
-              preparedStatement.setLong(++index, (Long) parameter);
-              break;
-            case num_posts:
-              preparedStatement.setInt(++index, (Integer) parameter);
-              break;
-            case some_date:
-              preparedStatement.setDate(++index, new Date((Long) parameter));
-              break;
-            case some_datetime:
-              preparedStatement.setTimestamp(++index, new Timestamp((Long) parameter));
-              break;
-            case bio:
-              preparedStatement.setString(++index, (String) parameter);
-              break;
-            case some_binary:
-              preparedStatement.setBytes(++index, (byte[]) parameter);
-              break;
-            case some_float:
-              preparedStatement.setDouble(++index, (Double) parameter);
-              break;
-            case some_decimal:
-              preparedStatement.setDouble(++index, (Double) parameter);
-              break;
-            case some_boolean:
-              preparedStatement.setBoolean(++index, (Boolean) parameter);
-              break;
+          if (constraint.isId()) {
+            preparedStatement.setLong(++index, (Long)parameter);
+          } else {
+            User._Fields field = (User._Fields)constraint.getField();
+            switch (field) {
+              case handle:
+                preparedStatement.setString(++index, (String) parameter);
+                break;
+              case created_at_millis:
+                preparedStatement.setLong(++index, (Long) parameter);
+                break;
+              case num_posts:
+                preparedStatement.setInt(++index, (Integer) parameter);
+                break;
+              case some_date:
+                preparedStatement.setDate(++index, new Date((Long) parameter));
+                break;
+              case some_datetime:
+                preparedStatement.setTimestamp(++index, new Timestamp((Long) parameter));
+                break;
+              case bio:
+                preparedStatement.setString(++index, (String) parameter);
+                break;
+              case some_binary:
+                preparedStatement.setBytes(++index, (byte[]) parameter);
+                break;
+              case some_float:
+                preparedStatement.setDouble(++index, (Double) parameter);
+                break;
+              case some_decimal:
+                preparedStatement.setDouble(++index, (Double) parameter);
+                break;
+              case some_boolean:
+                preparedStatement.setBoolean(++index, (Boolean) parameter);
+                break;
+            }
           }
         } catch (SQLException e) {
           throw new IOException(e);

--- a/test/java/com/rapleaf/jack/test_project/database_1/query/CommentQueryBuilder.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/query/CommentQueryBuilder.java
@@ -3,6 +3,7 @@ package com.rapleaf.jack.test_project.database_1.query;
 import java.util.Set;
 
 import com.rapleaf.jack.queries.AbstractQueryBuilder;
+import com.rapleaf.jack.queries.Column;
 import com.rapleaf.jack.queries.FieldSelector;
 import com.rapleaf.jack.queries.where_operators.IWhereOperator;
 import com.rapleaf.jack.queries.where_operators.JackMatchers;
@@ -42,6 +43,11 @@ public class CommentQueryBuilder extends AbstractQueryBuilder<Comment> {
     return this;
   }
 
+  public CommentQueryBuilder whereId(IWhereOperator<Long> operator) {
+    addWhereConstraint(new WhereConstraint<Long>(Column.fromId(null), operator, null));
+    return this;
+  }
+
   public CommentQueryBuilder limit(int offset, int nResults) {
     setLimit(new LimitCriterion(offset, nResults));
     return this;
@@ -61,18 +67,18 @@ public class CommentQueryBuilder extends AbstractQueryBuilder<Comment> {
     this.addOrder(new OrderCriterion(QueryOrder.ASC));
     return this;
   }
-  
+
   public CommentQueryBuilder order(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(queryOrder));
     return this;
   }
-  
+
   public CommentQueryBuilder orderById() {
     this.addOrder(new OrderCriterion(QueryOrder.ASC));
     return this;
   }
-  
-  public CommentQueryBuilder orderById(QueryOrder queryOrder) {    
+
+  public CommentQueryBuilder orderById(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(queryOrder));
     return this;
   }
@@ -86,12 +92,12 @@ public class CommentQueryBuilder extends AbstractQueryBuilder<Comment> {
     addWhereConstraint(new WhereConstraint<String>(Comment._Fields.content, operator));
     return this;
   }
-  
+
   public CommentQueryBuilder orderByContent() {
     this.addOrder(new OrderCriterion(Comment._Fields.content, QueryOrder.ASC));
     return this;
   }
-  
+
   public CommentQueryBuilder orderByContent(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(Comment._Fields.content, queryOrder));
     return this;
@@ -106,12 +112,12 @@ public class CommentQueryBuilder extends AbstractQueryBuilder<Comment> {
     addWhereConstraint(new WhereConstraint<Integer>(Comment._Fields.commenter_id, operator));
     return this;
   }
-  
+
   public CommentQueryBuilder orderByCommenterId() {
     this.addOrder(new OrderCriterion(Comment._Fields.commenter_id, QueryOrder.ASC));
     return this;
   }
-  
+
   public CommentQueryBuilder orderByCommenterId(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(Comment._Fields.commenter_id, queryOrder));
     return this;
@@ -126,12 +132,12 @@ public class CommentQueryBuilder extends AbstractQueryBuilder<Comment> {
     addWhereConstraint(new WhereConstraint<Long>(Comment._Fields.commented_on_id, operator));
     return this;
   }
-  
+
   public CommentQueryBuilder orderByCommentedOnId() {
     this.addOrder(new OrderCriterion(Comment._Fields.commented_on_id, QueryOrder.ASC));
     return this;
   }
-  
+
   public CommentQueryBuilder orderByCommentedOnId(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(Comment._Fields.commented_on_id, queryOrder));
     return this;
@@ -146,12 +152,12 @@ public class CommentQueryBuilder extends AbstractQueryBuilder<Comment> {
     addWhereConstraint(new WhereConstraint<Long>(Comment._Fields.created_at, operator));
     return this;
   }
-  
+
   public CommentQueryBuilder orderByCreatedAt() {
     this.addOrder(new OrderCriterion(Comment._Fields.created_at, QueryOrder.ASC));
     return this;
   }
-  
+
   public CommentQueryBuilder orderByCreatedAt(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(Comment._Fields.created_at, queryOrder));
     return this;

--- a/test/java/com/rapleaf/jack/test_project/database_1/query/ImageQueryBuilder.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/query/ImageQueryBuilder.java
@@ -3,6 +3,7 @@ package com.rapleaf.jack.test_project.database_1.query;
 import java.util.Set;
 
 import com.rapleaf.jack.queries.AbstractQueryBuilder;
+import com.rapleaf.jack.queries.Column;
 import com.rapleaf.jack.queries.FieldSelector;
 import com.rapleaf.jack.queries.where_operators.IWhereOperator;
 import com.rapleaf.jack.queries.where_operators.JackMatchers;
@@ -42,6 +43,11 @@ public class ImageQueryBuilder extends AbstractQueryBuilder<Image> {
     return this;
   }
 
+  public ImageQueryBuilder whereId(IWhereOperator<Long> operator) {
+    addWhereConstraint(new WhereConstraint<Long>(Column.fromId(null), operator, null));
+    return this;
+  }
+
   public ImageQueryBuilder limit(int offset, int nResults) {
     setLimit(new LimitCriterion(offset, nResults));
     return this;
@@ -61,18 +67,18 @@ public class ImageQueryBuilder extends AbstractQueryBuilder<Image> {
     this.addOrder(new OrderCriterion(QueryOrder.ASC));
     return this;
   }
-  
+
   public ImageQueryBuilder order(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(queryOrder));
     return this;
   }
-  
+
   public ImageQueryBuilder orderById() {
     this.addOrder(new OrderCriterion(QueryOrder.ASC));
     return this;
   }
-  
-  public ImageQueryBuilder orderById(QueryOrder queryOrder) {    
+
+  public ImageQueryBuilder orderById(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(queryOrder));
     return this;
   }
@@ -86,12 +92,12 @@ public class ImageQueryBuilder extends AbstractQueryBuilder<Image> {
     addWhereConstraint(new WhereConstraint<Integer>(Image._Fields.user_id, operator));
     return this;
   }
-  
+
   public ImageQueryBuilder orderByUserId() {
     this.addOrder(new OrderCriterion(Image._Fields.user_id, QueryOrder.ASC));
     return this;
   }
-  
+
   public ImageQueryBuilder orderByUserId(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(Image._Fields.user_id, queryOrder));
     return this;

--- a/test/java/com/rapleaf/jack/test_project/database_1/query/PostQueryBuilder.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/query/PostQueryBuilder.java
@@ -3,6 +3,7 @@ package com.rapleaf.jack.test_project.database_1.query;
 import java.util.Set;
 
 import com.rapleaf.jack.queries.AbstractQueryBuilder;
+import com.rapleaf.jack.queries.Column;
 import com.rapleaf.jack.queries.FieldSelector;
 import com.rapleaf.jack.queries.where_operators.IWhereOperator;
 import com.rapleaf.jack.queries.where_operators.JackMatchers;
@@ -42,6 +43,11 @@ public class PostQueryBuilder extends AbstractQueryBuilder<Post> {
     return this;
   }
 
+  public PostQueryBuilder whereId(IWhereOperator<Long> operator) {
+    addWhereConstraint(new WhereConstraint<Long>(Column.fromId(null), operator, null));
+    return this;
+  }
+
   public PostQueryBuilder limit(int offset, int nResults) {
     setLimit(new LimitCriterion(offset, nResults));
     return this;
@@ -61,18 +67,18 @@ public class PostQueryBuilder extends AbstractQueryBuilder<Post> {
     this.addOrder(new OrderCriterion(QueryOrder.ASC));
     return this;
   }
-  
+
   public PostQueryBuilder order(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(queryOrder));
     return this;
   }
-  
+
   public PostQueryBuilder orderById() {
     this.addOrder(new OrderCriterion(QueryOrder.ASC));
     return this;
   }
-  
-  public PostQueryBuilder orderById(QueryOrder queryOrder) {    
+
+  public PostQueryBuilder orderById(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(queryOrder));
     return this;
   }
@@ -86,12 +92,12 @@ public class PostQueryBuilder extends AbstractQueryBuilder<Post> {
     addWhereConstraint(new WhereConstraint<String>(Post._Fields.title, operator));
     return this;
   }
-  
+
   public PostQueryBuilder orderByTitle() {
     this.addOrder(new OrderCriterion(Post._Fields.title, QueryOrder.ASC));
     return this;
   }
-  
+
   public PostQueryBuilder orderByTitle(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(Post._Fields.title, queryOrder));
     return this;
@@ -106,12 +112,12 @@ public class PostQueryBuilder extends AbstractQueryBuilder<Post> {
     addWhereConstraint(new WhereConstraint<Long>(Post._Fields.posted_at_millis, operator));
     return this;
   }
-  
+
   public PostQueryBuilder orderByPostedAtMillis() {
     this.addOrder(new OrderCriterion(Post._Fields.posted_at_millis, QueryOrder.ASC));
     return this;
   }
-  
+
   public PostQueryBuilder orderByPostedAtMillis(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(Post._Fields.posted_at_millis, queryOrder));
     return this;
@@ -126,12 +132,12 @@ public class PostQueryBuilder extends AbstractQueryBuilder<Post> {
     addWhereConstraint(new WhereConstraint<Integer>(Post._Fields.user_id, operator));
     return this;
   }
-  
+
   public PostQueryBuilder orderByUserId() {
     this.addOrder(new OrderCriterion(Post._Fields.user_id, QueryOrder.ASC));
     return this;
   }
-  
+
   public PostQueryBuilder orderByUserId(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(Post._Fields.user_id, queryOrder));
     return this;
@@ -146,12 +152,12 @@ public class PostQueryBuilder extends AbstractQueryBuilder<Post> {
     addWhereConstraint(new WhereConstraint<Long>(Post._Fields.updated_at, operator));
     return this;
   }
-  
+
   public PostQueryBuilder orderByUpdatedAt() {
     this.addOrder(new OrderCriterion(Post._Fields.updated_at, QueryOrder.ASC));
     return this;
   }
-  
+
   public PostQueryBuilder orderByUpdatedAt(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(Post._Fields.updated_at, queryOrder));
     return this;

--- a/test/java/com/rapleaf/jack/test_project/database_1/query/UserQueryBuilder.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/query/UserQueryBuilder.java
@@ -3,6 +3,7 @@ package com.rapleaf.jack.test_project.database_1.query;
 import java.util.Set;
 
 import com.rapleaf.jack.queries.AbstractQueryBuilder;
+import com.rapleaf.jack.queries.Column;
 import com.rapleaf.jack.queries.FieldSelector;
 import com.rapleaf.jack.queries.where_operators.IWhereOperator;
 import com.rapleaf.jack.queries.where_operators.JackMatchers;
@@ -42,6 +43,11 @@ public class UserQueryBuilder extends AbstractQueryBuilder<User> {
     return this;
   }
 
+  public UserQueryBuilder whereId(IWhereOperator<Long> operator) {
+    addWhereConstraint(new WhereConstraint<Long>(Column.fromId(null), operator, null));
+    return this;
+  }
+
   public UserQueryBuilder limit(int offset, int nResults) {
     setLimit(new LimitCriterion(offset, nResults));
     return this;
@@ -61,18 +67,18 @@ public class UserQueryBuilder extends AbstractQueryBuilder<User> {
     this.addOrder(new OrderCriterion(QueryOrder.ASC));
     return this;
   }
-  
+
   public UserQueryBuilder order(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(queryOrder));
     return this;
   }
-  
+
   public UserQueryBuilder orderById() {
     this.addOrder(new OrderCriterion(QueryOrder.ASC));
     return this;
   }
-  
-  public UserQueryBuilder orderById(QueryOrder queryOrder) {    
+
+  public UserQueryBuilder orderById(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(queryOrder));
     return this;
   }
@@ -86,12 +92,12 @@ public class UserQueryBuilder extends AbstractQueryBuilder<User> {
     addWhereConstraint(new WhereConstraint<String>(User._Fields.handle, operator));
     return this;
   }
-  
+
   public UserQueryBuilder orderByHandle() {
     this.addOrder(new OrderCriterion(User._Fields.handle, QueryOrder.ASC));
     return this;
   }
-  
+
   public UserQueryBuilder orderByHandle(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(User._Fields.handle, queryOrder));
     return this;
@@ -106,12 +112,12 @@ public class UserQueryBuilder extends AbstractQueryBuilder<User> {
     addWhereConstraint(new WhereConstraint<Long>(User._Fields.created_at_millis, operator));
     return this;
   }
-  
+
   public UserQueryBuilder orderByCreatedAtMillis() {
     this.addOrder(new OrderCriterion(User._Fields.created_at_millis, QueryOrder.ASC));
     return this;
   }
-  
+
   public UserQueryBuilder orderByCreatedAtMillis(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(User._Fields.created_at_millis, queryOrder));
     return this;
@@ -126,12 +132,12 @@ public class UserQueryBuilder extends AbstractQueryBuilder<User> {
     addWhereConstraint(new WhereConstraint<Integer>(User._Fields.num_posts, operator));
     return this;
   }
-  
+
   public UserQueryBuilder orderByNumPosts() {
     this.addOrder(new OrderCriterion(User._Fields.num_posts, QueryOrder.ASC));
     return this;
   }
-  
+
   public UserQueryBuilder orderByNumPosts(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(User._Fields.num_posts, queryOrder));
     return this;
@@ -146,12 +152,12 @@ public class UserQueryBuilder extends AbstractQueryBuilder<User> {
     addWhereConstraint(new WhereConstraint<Long>(User._Fields.some_date, operator));
     return this;
   }
-  
+
   public UserQueryBuilder orderBySomeDate() {
     this.addOrder(new OrderCriterion(User._Fields.some_date, QueryOrder.ASC));
     return this;
   }
-  
+
   public UserQueryBuilder orderBySomeDate(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(User._Fields.some_date, queryOrder));
     return this;
@@ -166,12 +172,12 @@ public class UserQueryBuilder extends AbstractQueryBuilder<User> {
     addWhereConstraint(new WhereConstraint<Long>(User._Fields.some_datetime, operator));
     return this;
   }
-  
+
   public UserQueryBuilder orderBySomeDatetime() {
     this.addOrder(new OrderCriterion(User._Fields.some_datetime, QueryOrder.ASC));
     return this;
   }
-  
+
   public UserQueryBuilder orderBySomeDatetime(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(User._Fields.some_datetime, queryOrder));
     return this;
@@ -186,12 +192,12 @@ public class UserQueryBuilder extends AbstractQueryBuilder<User> {
     addWhereConstraint(new WhereConstraint<String>(User._Fields.bio, operator));
     return this;
   }
-  
+
   public UserQueryBuilder orderByBio() {
     this.addOrder(new OrderCriterion(User._Fields.bio, QueryOrder.ASC));
     return this;
   }
-  
+
   public UserQueryBuilder orderByBio(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(User._Fields.bio, queryOrder));
     return this;
@@ -206,12 +212,12 @@ public class UserQueryBuilder extends AbstractQueryBuilder<User> {
     addWhereConstraint(new WhereConstraint<byte[]>(User._Fields.some_binary, operator));
     return this;
   }
-  
+
   public UserQueryBuilder orderBySomeBinary() {
     this.addOrder(new OrderCriterion(User._Fields.some_binary, QueryOrder.ASC));
     return this;
   }
-  
+
   public UserQueryBuilder orderBySomeBinary(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(User._Fields.some_binary, queryOrder));
     return this;
@@ -226,12 +232,12 @@ public class UserQueryBuilder extends AbstractQueryBuilder<User> {
     addWhereConstraint(new WhereConstraint<Double>(User._Fields.some_float, operator));
     return this;
   }
-  
+
   public UserQueryBuilder orderBySomeFloat() {
     this.addOrder(new OrderCriterion(User._Fields.some_float, QueryOrder.ASC));
     return this;
   }
-  
+
   public UserQueryBuilder orderBySomeFloat(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(User._Fields.some_float, queryOrder));
     return this;
@@ -246,12 +252,12 @@ public class UserQueryBuilder extends AbstractQueryBuilder<User> {
     addWhereConstraint(new WhereConstraint<Double>(User._Fields.some_decimal, operator));
     return this;
   }
-  
+
   public UserQueryBuilder orderBySomeDecimal() {
     this.addOrder(new OrderCriterion(User._Fields.some_decimal, QueryOrder.ASC));
     return this;
   }
-  
+
   public UserQueryBuilder orderBySomeDecimal(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(User._Fields.some_decimal, queryOrder));
     return this;
@@ -266,12 +272,12 @@ public class UserQueryBuilder extends AbstractQueryBuilder<User> {
     addWhereConstraint(new WhereConstraint<Boolean>(User._Fields.some_boolean, operator));
     return this;
   }
-  
+
   public UserQueryBuilder orderBySomeBoolean() {
     this.addOrder(new OrderCriterion(User._Fields.some_boolean, QueryOrder.ASC));
     return this;
   }
-  
+
   public UserQueryBuilder orderBySomeBoolean(QueryOrder queryOrder) {
     this.addOrder(new OrderCriterion(User._Fields.some_boolean, queryOrder));
     return this;


### PR DESCRIPTION
Make it possible to do:
```
MyModel.query().whereId(myWhereClause).find()
```

Today it is only supported for non-id fields