### PR TITLE
Lazy load table metadata

### DIFF
--- a/src/java/com/rapleaf/jack/LazyLoadPersistence.java
+++ b/src/java/com/rapleaf/jack/LazyLoadPersistence.java
@@ -1,0 +1,39 @@
+package com.rapleaf.jack;
+
+public abstract class LazyLoadPersistence<T extends IModelPersistence, D extends GenericDatabases> {
+
+  private final BaseDatabaseConnection conn;
+  private final D databases;
+
+  private volatile T persistence;
+
+  private boolean disableCaching;
+
+  public LazyLoadPersistence(BaseDatabaseConnection conn, D databases) {
+    this.conn = conn;
+    this.databases = databases;
+
+    this.persistence = null;
+    this.disableCaching = false;
+  }
+
+  public T get() {
+    if (persistence == null) {
+      synchronized (this) {
+        this.persistence = build(conn, databases);
+      }
+    }
+
+    if (disableCaching) {
+      persistence.disableCaching();
+    }
+
+    return persistence;
+  }
+
+  public void disableCaching() {
+    disableCaching = true;
+  }
+
+  protected abstract T build(BaseDatabaseConnection conn, D databases);
+}

--- a/src/java/com/rapleaf/jack/LazyLoadPersistence.java
+++ b/src/java/com/rapleaf/jack/LazyLoadPersistence.java
@@ -20,7 +20,9 @@ public abstract class LazyLoadPersistence<T extends IModelPersistence, D extends
   public T get() {
     if (persistence == null) {
       synchronized (this) {
-        this.persistence = build(conn, databases);
+        if (persistence == null) {
+          this.persistence = build(conn, databases);
+        }
       }
     }
 

--- a/src/java/com/rapleaf/jack/LazyLoadPersistence.java
+++ b/src/java/com/rapleaf/jack/LazyLoadPersistence.java
@@ -33,6 +33,9 @@ public abstract class LazyLoadPersistence<T extends IModelPersistence, D extends
 
   public void disableCaching() {
     disableCaching = true;
+    if (persistence != null) {
+      persistence.disableCaching();
+    }
   }
 
   protected abstract T build(BaseDatabaseConnection conn, D databases);

--- a/src/rb/templates/db_impl.erb
+++ b/src/rb/templates/db_impl.erb
@@ -17,7 +17,6 @@
 package <%= root_package %>.impl;
 
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicReference;
 
 import <%= root_package %>.I<%=db_name%>;
 import <%= JACK_NAMESPACE %>.queries.GenericQuery;
@@ -34,15 +33,19 @@ public class <%=db_name%>Impl implements I<%=db_name%> {
   private final BaseDatabaseConnection conn;
   private final IDatabases databases;
 
+  private boolean disableCaching;
+
 <% model_defns.each do |model_defn| %>
-  private final AtomicReference<<%= model_defn.iface_name %>> <%= model_defn.table_name %>;
+  private volatile <%= model_defn.iface_name %> <%= model_defn.table_name %>;
 <% end %>
 
   public <%=db_name%>Impl(BaseDatabaseConnection conn, IDatabases databases) {
     this.conn = conn;
     this.databases = databases;
+    this.disableCaching = false;
+    
   <% model_defns.each do |model_defn| %>
-    this.<%= model_defn.table_name %> = new AtomicReference<<%= model_defn.iface_name %>>(new <%= model_defn.impl_name %>(conn, databases));
+    this.<%= model_defn.table_name %> = null;
   <% end %>
 }
 
@@ -53,7 +56,18 @@ public class <%=db_name%>Impl implements I<%=db_name%> {
   <% model_defns.each do |model_defn| %>
 
   public <%= model_defn.iface_name %> <%= model_defn.persistence_getter %>{
-    return <%= model_defn.table_name %>.get();
+    if (<%= model_defn.table_name %> == null) {
+      synchronized (this) {
+        <%= model_defn.iface_name %> <%= model_defn.table_name %>Tmp = new <%= model_defn.impl_name %>(conn, databases);
+        this.<%= model_defn.table_name %> = <%= model_defn.table_name %>Tmp;
+      }
+    }
+    
+    if (disableCaching) {
+      <%= model_defn.table_name %>.disableCaching();
+    }
+    
+    return <%= model_defn.table_name %>;
   }
   <% end %>
 
@@ -70,9 +84,7 @@ public class <%=db_name%>Impl implements I<%=db_name%> {
   }
 
   public void disableCaching() {
-  <% model_defns.each do |model_defn| %>
-    <%= model_defn.persistence_getter %>.disableCaching();
-  <% end %>
+    disableCaching = true;
   }
 
   public void setAutoCommit(boolean autoCommit) {

--- a/src/rb/templates/db_impl.erb
+++ b/src/rb/templates/db_impl.erb
@@ -47,7 +47,7 @@ public class <%=db_name%>Impl implements I<%=db_name%> {
   <% model_defns.each do |model_defn| %>
     this.<%= model_defn.table_name %> = null;
   <% end %>
-}
+  }
 
   public GenericQuery.Builder createQuery() {
     return GenericQuery.create(conn);

--- a/src/rb/templates/db_impl.erb
+++ b/src/rb/templates/db_impl.erb
@@ -85,6 +85,12 @@ public class <%=db_name%>Impl implements I<%=db_name%> {
 
   public void disableCaching() {
     disableCaching = true;
+
+    <% model_defns.each do |model_defn| %>
+    if (<%= model_defn.table_name %> != null) {
+      <%= model_defn.table_name %>.disableCaching();
+    }
+    <% end %>
   }
 
   public void setAutoCommit(boolean autoCommit) {

--- a/src/rb/templates/db_impl.erb
+++ b/src/rb/templates/db_impl.erb
@@ -17,6 +17,7 @@
 package <%= root_package %>.impl;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import <%= root_package %>.I<%=db_name%>;
 import <%= JACK_NAMESPACE %>.queries.GenericQuery;
@@ -34,16 +35,16 @@ public class <%=db_name%>Impl implements I<%=db_name%> {
   private final IDatabases databases;
 
 <% model_defns.each do |model_defn| %>
-  private final <%= model_defn.iface_name %> <%= model_defn.table_name %>;
+  private final AtomicReference<<%= model_defn.iface_name %>> <%= model_defn.table_name %>;
 <% end %>
 
   public <%=db_name%>Impl(BaseDatabaseConnection conn, IDatabases databases) {
     this.conn = conn;
     this.databases = databases;
   <% model_defns.each do |model_defn| %>
-    this.<%= model_defn.table_name %> = new <%= model_defn.impl_name %>(conn, databases);
+    this.<%= model_defn.table_name %> = new AtomicReference<<%= model_defn.iface_name %>>(new <%= model_defn.impl_name %>(conn, databases));
   <% end %>
-  }
+}
 
   public GenericQuery.Builder createQuery() {
     return GenericQuery.create(conn);
@@ -52,7 +53,7 @@ public class <%=db_name%>Impl implements I<%=db_name%> {
   <% model_defns.each do |model_defn| %>
 
   public <%= model_defn.iface_name %> <%= model_defn.persistence_getter %>{
-    return <%= model_defn.table_name %>;
+    return <%= model_defn.table_name %>.get();
   }
   <% end %>
 
@@ -60,7 +61,7 @@ public class <%=db_name%>Impl implements I<%=db_name%> {
     boolean success = true;
     try {
   <% model_defns.each do |model_defn| %>
-    success &= <%= model_defn.table_name %>.deleteAll();
+    success &= <%= model_defn.persistence_getter %>.deleteAll();
   <% end %>
     } catch (IOException e) {
       throw e;
@@ -70,7 +71,7 @@ public class <%=db_name%>Impl implements I<%=db_name%> {
 
   public void disableCaching() {
   <% model_defns.each do |model_defn| %>
-    <%= model_defn.table_name %>.disableCaching();
+    <%= model_defn.persistence_getter %>.disableCaching();
   <% end %>
   }
 

--- a/src/rb/templates/db_impl.erb
+++ b/src/rb/templates/db_impl.erb
@@ -18,7 +18,8 @@ package <%= root_package %>.impl;
 
 import java.io.IOException;
 
-import <%= root_package %>.I<%=db_name%>;
+import <%= root_package %>.I<%= db_name%>;
+import <%= JACK_NAMESPACE %>.LazyLoadPersistence;
 import <%= JACK_NAMESPACE %>.queries.GenericQuery;
 import <%= JACK_NAMESPACE %>.BaseDatabaseConnection;
 
@@ -33,19 +34,21 @@ public class <%=db_name%>Impl implements I<%=db_name%> {
   private final BaseDatabaseConnection conn;
   private final IDatabases databases;
 
-  private boolean disableCaching;
-
 <% model_defns.each do |model_defn| %>
-  private volatile <%= model_defn.iface_name %> <%= model_defn.table_name %>;
+  private final LazyLoadPersistence<<%= model_defn.iface_name %>, IDatabases> <%= model_defn.table_name %>;
 <% end %>
 
   public <%=db_name%>Impl(BaseDatabaseConnection conn, IDatabases databases) {
     this.conn = conn;
     this.databases = databases;
-    this.disableCaching = false;
     
   <% model_defns.each do |model_defn| %>
-    this.<%= model_defn.table_name %> = null;
+    this.<%= model_defn.table_name %> = new LazyLoadPersistence<<%= model_defn.iface_name %>, IDatabases>(conn, databases) {
+      @Override
+      protected <%= model_defn.iface_name %> build(BaseDatabaseConnection conn, IDatabases databases) {
+        return new <%= model_defn.impl_name %>(conn, databases);
+      }
+    };
   <% end %>
   }
 
@@ -56,18 +59,7 @@ public class <%=db_name%>Impl implements I<%=db_name%> {
   <% model_defns.each do |model_defn| %>
 
   public <%= model_defn.iface_name %> <%= model_defn.persistence_getter %>{
-    if (<%= model_defn.table_name %> == null) {
-      synchronized (this) {
-        <%= model_defn.iface_name %> <%= model_defn.table_name %>Tmp = new <%= model_defn.impl_name %>(conn, databases);
-        this.<%= model_defn.table_name %> = <%= model_defn.table_name %>Tmp;
-      }
-    }
-    
-    if (disableCaching) {
-      <%= model_defn.table_name %>.disableCaching();
-    }
-    
-    return <%= model_defn.table_name %>;
+    return <%= model_defn.table_name %>.get();
   }
   <% end %>
 
@@ -84,13 +76,9 @@ public class <%=db_name%>Impl implements I<%=db_name%> {
   }
 
   public void disableCaching() {
-    disableCaching = true;
-
-    <% model_defns.each do |model_defn| %>
-    if (<%= model_defn.table_name %> != null) {
-      <%= model_defn.table_name %>.disableCaching();
-    }
-    <% end %>
+  <% model_defns.each do |model_defn| %>
+    <%= model_defn.table_name %>.get().disableCaching();
+  <% end %>
   }
 
   public void setAutoCommit(boolean autoCommit) {

--- a/test/java/com/rapleaf/jack/test_project/database_1/impl/Database1Impl.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/impl/Database1Impl.java
@@ -118,6 +118,18 @@ public class Database1Impl implements IDatabase1 {
 
   public void disableCaching() {
     disableCaching = true;
+    if (comments != null) {
+      comments.disableCaching();
+    }
+    if (images != null) {
+      images.disableCaching();
+    }
+    if (posts != null) {
+      posts.disableCaching();
+    }
+    if (users != null) {
+      users.disableCaching();
+    }
   }
 
   public void setAutoCommit(boolean autoCommit) {

--- a/test/java/com/rapleaf/jack/test_project/database_1/impl/Database1Impl.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/impl/Database1Impl.java
@@ -37,7 +37,7 @@ public class Database1Impl implements IDatabase1 {
     this.images = null;
     this.posts = null;
     this.users = null;
-}
+  }
 
   public GenericQuery.Builder createQuery() {
     return GenericQuery.create(conn);

--- a/test/java/com/rapleaf/jack/test_project/database_1/impl/Database1Impl.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/impl/Database1Impl.java
@@ -7,6 +7,7 @@
 package com.rapleaf.jack.test_project.database_1.impl;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.rapleaf.jack.test_project.database_1.IDatabase1;
 import com.rapleaf.jack.queries.GenericQuery;
@@ -22,47 +23,47 @@ public class Database1Impl implements IDatabase1 {
   
   private final BaseDatabaseConnection conn;
   private final IDatabases databases;
-  private final ICommentPersistence comments;
-  private final IImagePersistence images;
-  private final IPostPersistence posts;
-  private final IUserPersistence users;
+  private final AtomicReference<ICommentPersistence> comments;
+  private final AtomicReference<IImagePersistence> images;
+  private final AtomicReference<IPostPersistence> posts;
+  private final AtomicReference<IUserPersistence> users;
 
   public Database1Impl(BaseDatabaseConnection conn, IDatabases databases) {
     this.conn = conn;
     this.databases = databases;
-    this.comments = new BaseCommentPersistenceImpl(conn, databases);
-    this.images = new BaseImagePersistenceImpl(conn, databases);
-    this.posts = new BasePostPersistenceImpl(conn, databases);
-    this.users = new BaseUserPersistenceImpl(conn, databases);
-  }
+    this.comments = new AtomicReference<ICommentPersistence>(new BaseCommentPersistenceImpl(conn, databases));
+    this.images = new AtomicReference<IImagePersistence>(new BaseImagePersistenceImpl(conn, databases));
+    this.posts = new AtomicReference<IPostPersistence>(new BasePostPersistenceImpl(conn, databases));
+    this.users = new AtomicReference<IUserPersistence>(new BaseUserPersistenceImpl(conn, databases));
+}
 
   public GenericQuery.Builder createQuery() {
     return GenericQuery.create(conn);
   }
 
   public ICommentPersistence comments(){
-    return comments;
+    return comments.get();
   }
 
   public IImagePersistence images(){
-    return images;
+    return images.get();
   }
 
   public IPostPersistence posts(){
-    return posts;
+    return posts.get();
   }
 
   public IUserPersistence users(){
-    return users;
+    return users.get();
   }
 
   public boolean deleteAll() throws IOException {
     boolean success = true;
     try {
-    success &= comments.deleteAll();
-    success &= images.deleteAll();
-    success &= posts.deleteAll();
-    success &= users.deleteAll();
+    success &= comments().deleteAll();
+    success &= images().deleteAll();
+    success &= posts().deleteAll();
+    success &= users().deleteAll();
     } catch (IOException e) {
       throw e;
     }
@@ -70,10 +71,10 @@ public class Database1Impl implements IDatabase1 {
   }
 
   public void disableCaching() {
-    comments.disableCaching();
-    images.disableCaching();
-    posts.disableCaching();
-    users.disableCaching();
+    comments().disableCaching();
+    images().disableCaching();
+    posts().disableCaching();
+    users().disableCaching();
   }
 
   public void setAutoCommit(boolean autoCommit) {

--- a/test/java/com/rapleaf/jack/test_project/database_1/models/Comment.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/models/Comment.java
@@ -33,7 +33,7 @@ import com.rapleaf.jack.util.JackUtility;
 
 public class Comment extends ModelWithId<Comment, IDatabases> implements Comparable<Comment>{
   
-  public static final long serialVersionUID = 6213989608937906012L;
+  public static final long serialVersionUID = 8036617193786054443L;
 
   public static class Tbl extends AbstractTable {
     public final Column ID;
@@ -456,7 +456,7 @@ public class Comment extends ModelWithId<Comment, IDatabases> implements Compara
   
   public static class Attributes extends AttributesWithId {
     
-    public static final long serialVersionUID = -2156535913590481279L;
+    public static final long serialVersionUID = 5448907628943892063L;
 
     // Fields
     private String __content;

--- a/test/java/com/rapleaf/jack/test_project/database_1/models/Image.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/models/Image.java
@@ -33,7 +33,7 @@ import com.rapleaf.jack.util.JackUtility;
 
 public class Image extends ModelWithId<Image, IDatabases> implements Comparable<Image>{
   
-  public static final long serialVersionUID = -3351451520429699622L;
+  public static final long serialVersionUID = 2502129457421563432L;
 
   public static class Tbl extends AbstractTable {
     public final Column ID;
@@ -290,7 +290,7 @@ public class Image extends ModelWithId<Image, IDatabases> implements Comparable<
   
   public static class Attributes extends AttributesWithId {
     
-    public static final long serialVersionUID = 5384617403533794948L;
+    public static final long serialVersionUID = 1258217664023344706L;
 
     // Fields
     private Integer __user_id;

--- a/test/java/com/rapleaf/jack/test_project/database_1/models/Post.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/models/Post.java
@@ -33,7 +33,7 @@ import com.rapleaf.jack.util.JackUtility;
 
 public class Post extends ModelWithId<Post, IDatabases> implements Comparable<Post>{
   
-  public static final long serialVersionUID = -399049548729901546L;
+  public static final long serialVersionUID = -1518028829029140792L;
 
   public static class Tbl extends AbstractTable {
     public final Column ID;
@@ -411,7 +411,7 @@ public class Post extends ModelWithId<Post, IDatabases> implements Comparable<Po
   
   public static class Attributes extends AttributesWithId {
     
-    public static final long serialVersionUID = -452436965662476312L;
+    public static final long serialVersionUID = -1641110165272227035L;
 
     // Fields
     private String __title;

--- a/test/java/com/rapleaf/jack/test_project/database_1/models/User.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/models/User.java
@@ -33,7 +33,7 @@ import com.rapleaf.jack.util.JackUtility;
 
 public class User extends ModelWithId<User, IDatabases> implements Comparable<User>{
   
-  public static final long serialVersionUID = -966057050205502149L;
+  public static final long serialVersionUID = 2764180304945930907L;
 
   public static class Tbl extends AbstractTable {
     public final Column ID;
@@ -613,7 +613,7 @@ public class User extends ModelWithId<User, IDatabases> implements Comparable<Us
   
   public static class Attributes extends AttributesWithId {
     
-    public static final long serialVersionUID = 7482296567648746981L;
+    public static final long serialVersionUID = 5810949180036000899L;
 
     // Fields
     private String __handle;

--- a/test/test_project/database_1/db/schema.rb
+++ b/test/test_project/database_1/db/schema.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.

--- a/test/test_project/database_2/db/schema.rb
+++ b/test/test_project/database_2/db/schema.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.


### PR DESCRIPTION
This change will make it easier to delete table from the DB so that you don't have to synchronize the migration with the java code deploy.

The code will only fail if you try to *use* a table which doesn't exist in the db instead of failing on Database instantiation.

