### PR TITLE
Allowing disabling then re-enabling caching of lazily loaded persistences

### DIFF
--- a/src/java/com/rapleaf/jack/LazyLoadPersistence.java
+++ b/src/java/com/rapleaf/jack/LazyLoadPersistence.java
@@ -7,7 +7,7 @@ public abstract class LazyLoadPersistence<T extends IModelPersistence, D extends
 
   private volatile T persistence;
 
-  private boolean disableCaching;
+  private volatile boolean disableCaching;
 
   public LazyLoadPersistence(BaseDatabaseConnection conn, D databases) {
     this.conn = conn;
@@ -22,12 +22,12 @@ public abstract class LazyLoadPersistence<T extends IModelPersistence, D extends
       synchronized (this) {
         if (persistence == null) {
           this.persistence = build(conn, databases);
+
+          if (disableCaching) {
+            persistence.disableCaching();
+          }
         }
       }
-    }
-
-    if (disableCaching) {
-      persistence.disableCaching();
     }
 
     return persistence;
@@ -35,6 +35,7 @@ public abstract class LazyLoadPersistence<T extends IModelPersistence, D extends
 
   public void disableCaching() {
     disableCaching = true;
+
     if (persistence != null) {
       persistence.disableCaching();
     }

--- a/test/java/com/rapleaf/jack/BaseDatabaseModelTestCase.java
+++ b/test/java/com/rapleaf/jack/BaseDatabaseModelTestCase.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.rapleaf.jack.test_project.database_1.IDatabase1;
 import junit.framework.TestCase;
 
 import com.rapleaf.jack.test_project.IDatabases;
@@ -597,5 +598,15 @@ public abstract class BaseDatabaseModelTestCase extends TestCase {
     assertEquals(post2, posts.get(1));
     assertEquals(post3, posts.get(2));
     assertEquals(post4, posts.get(3));
+  }
+
+  public void testDisableThenEnableCaching() {
+    // Create a new instance to avoid changing caching behavior for other tests
+    IDatabases dbs = this.getDBS();
+    IDatabase1 db1 = dbs.getDatabase1();
+    db1.disableCaching();
+    assertFalse(db1.comments().isCaching());
+    db1.comments().enableCaching();
+    assertTrue(db1.comments().isCaching());
   }
 }

--- a/test/java/com/rapleaf/jack/TestLazyLoadPersistence.java
+++ b/test/java/com/rapleaf/jack/TestLazyLoadPersistence.java
@@ -1,0 +1,45 @@
+package com.rapleaf.jack;
+
+import com.rapleaf.jack.test_project.DatabasesImpl;
+import com.rapleaf.jack.test_project.IDatabases;
+import com.rapleaf.jack.test_project.database_1.iface.ICommentPersistence;
+import com.rapleaf.jack.test_project.database_1.impl.BaseCommentPersistenceImpl;
+import junit.framework.TestCase;
+
+public class TestLazyLoadPersistence extends TestCase {
+
+  private static final DatabaseConnection DATABASE_CONNECTION1 = new DatabaseConnection("database1");
+  private static final IDatabases dbs = new DatabasesImpl(DATABASE_CONNECTION1);
+
+
+  public void testSwitchCachingBehavior() {
+    LazyLoadPersistence<ICommentPersistence, IDatabases> lazyLoadPersistence = this.getLazyLoadPersistence();
+    lazyLoadPersistence.disableCaching();
+    assertFalse(lazyLoadPersistence.get().isCaching());
+    lazyLoadPersistence.get().enableCaching();
+    assertTrue(lazyLoadPersistence.get().isCaching());
+  }
+
+  public void testDisableCachingBeforeInstantiation() {
+    LazyLoadPersistence<ICommentPersistence, IDatabases> lazyLoadPersistence = this.getLazyLoadPersistence();
+    lazyLoadPersistence.disableCaching();
+    assertFalse(lazyLoadPersistence.get().isCaching());
+  }
+
+  public void testDisableCachingAfterInstantiation() {
+    LazyLoadPersistence<ICommentPersistence, IDatabases> lazyLoadPersistence = this.getLazyLoadPersistence();
+    assertTrue(lazyLoadPersistence.get().isCaching());
+    lazyLoadPersistence.disableCaching();
+    assertFalse(lazyLoadPersistence.get().isCaching());
+  }
+
+  private LazyLoadPersistence<ICommentPersistence, IDatabases> getLazyLoadPersistence() {
+    return new LazyLoadPersistence<ICommentPersistence, IDatabases>(DATABASE_CONNECTION1, dbs) {
+      @Override
+      protected ICommentPersistence build(BaseDatabaseConnection conn, IDatabases databases) {
+        return new BaseCommentPersistenceImpl(conn, databases);
+      }
+    };
+  }
+
+}


### PR DESCRIPTION
@tuliren @bpodgursky @michel-tricot: I added some test cases for and fixed an issue in which once caching is disabled on a lazily loaded model persistence, it cannot be re-enabled.