### PR TITLE
Retrieve Model and Attributes from Record

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,4 +9,4 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (>= 3.0.0)
-  i18n
+  i18n (= 0.5.0)

--- a/src/java/com/rapleaf/jack/queries/AbstractTable.java
+++ b/src/java/com/rapleaf/jack/queries/AbstractTable.java
@@ -12,16 +12,16 @@ import com.rapleaf.jack.ModelWithId;
 public class AbstractTable implements Table {
   protected final String name;
   protected final String alias;
-  protected final Class<? extends AttributesWithId> attributeType;
+  protected final Class<? extends AttributesWithId> attributesType;
   protected final Class<? extends ModelWithId> modelType;
   protected final Set<Column> allColumns;
 
-  protected AbstractTable(String name, String alias, Class<? extends AttributesWithId> attributeType, Class<? extends ModelWithId> modelType) {
+  protected AbstractTable(String name, String alias, Class<? extends AttributesWithId> attributesType, Class<? extends ModelWithId> modelType) {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(name), "Table name cannot be null or empty.");
     Preconditions.checkArgument(!Strings.isNullOrEmpty(alias), "Table alias cannot be null or empty.");
     this.name = name;
     this.alias = alias;
-    this.attributeType = attributeType;
+    this.attributesType = attributesType;
     this.modelType = modelType;
     this.allColumns = Sets.newHashSet();
   }
@@ -46,9 +46,8 @@ public class AbstractTable implements Table {
     return name + " AS " + alias;
   }
 
-  @Override
-  public Class<? extends AttributesWithId> getAttributeType() {
-    return attributeType;
+  public Class<? extends AttributesWithId> getAttributesType() {
+    return attributesType;
   }
 
   @Override

--- a/src/java/com/rapleaf/jack/queries/AbstractTable.java
+++ b/src/java/com/rapleaf/jack/queries/AbstractTable.java
@@ -6,16 +6,23 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
 
+import com.rapleaf.jack.AttributesWithId;
+import com.rapleaf.jack.ModelWithId;
+
 public class AbstractTable implements Table {
   protected final String table;
   protected final String alias;
+  protected final Class<? extends AttributesWithId> attributeType;
+  protected final Class<? extends ModelWithId> modelType;
   protected final Set<Column> allColumns;
 
-  protected AbstractTable(String table, String alias) {
+  protected AbstractTable(String table, String alias, Class<? extends AttributesWithId> attributeType, Class<? extends ModelWithId> modelType) {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(table), "Table name cannot be null or empty.");
     Preconditions.checkArgument(!Strings.isNullOrEmpty(alias), "Table alias cannot be null or empty.");
     this.table = table;
     this.alias = alias;
+    this.attributeType = attributeType;
+    this.modelType = modelType;
     this.allColumns = Sets.newHashSet();
   }
 
@@ -27,5 +34,15 @@ public class AbstractTable implements Table {
   @Override
   public String getSqlKeyword() {
     return table + " AS " + alias;
+  }
+
+  @Override
+  public Class<? extends AttributesWithId> getAttributeType() {
+    return attributeType;
+  }
+
+  @Override
+  public Class<? extends ModelWithId> getModelType() {
+    return modelType;
   }
 }

--- a/src/java/com/rapleaf/jack/queries/AbstractTable.java
+++ b/src/java/com/rapleaf/jack/queries/AbstractTable.java
@@ -10,20 +10,30 @@ import com.rapleaf.jack.AttributesWithId;
 import com.rapleaf.jack.ModelWithId;
 
 public class AbstractTable implements Table {
-  protected final String table;
+  protected final String name;
   protected final String alias;
   protected final Class<? extends AttributesWithId> attributeType;
   protected final Class<? extends ModelWithId> modelType;
   protected final Set<Column> allColumns;
 
-  protected AbstractTable(String table, String alias, Class<? extends AttributesWithId> attributeType, Class<? extends ModelWithId> modelType) {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(table), "Table name cannot be null or empty.");
+  protected AbstractTable(String name, String alias, Class<? extends AttributesWithId> attributeType, Class<? extends ModelWithId> modelType) {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(name), "Table name cannot be null or empty.");
     Preconditions.checkArgument(!Strings.isNullOrEmpty(alias), "Table alias cannot be null or empty.");
-    this.table = table;
+    this.name = name;
     this.alias = alias;
     this.attributeType = attributeType;
     this.modelType = modelType;
     this.allColumns = Sets.newHashSet();
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getAlias() {
+    return alias;
   }
 
   @Override
@@ -33,7 +43,7 @@ public class AbstractTable implements Table {
 
   @Override
   public String getSqlKeyword() {
-    return table + " AS " + alias;
+    return name + " AS " + alias;
   }
 
   @Override

--- a/src/java/com/rapleaf/jack/queries/AbstractTable.java
+++ b/src/java/com/rapleaf/jack/queries/AbstractTable.java
@@ -9,14 +9,14 @@ import com.google.common.collect.Sets;
 import com.rapleaf.jack.AttributesWithId;
 import com.rapleaf.jack.ModelWithId;
 
-public class AbstractTable implements Table {
+public class AbstractTable<A extends AttributesWithId, M extends ModelWithId> implements Table<A, M> {
   protected final String name;
   protected final String alias;
-  protected final Class<? extends AttributesWithId> attributesType;
-  protected final Class<? extends ModelWithId> modelType;
+  protected final Class<A> attributesType;
+  protected final Class<M> modelType;
   protected final Set<Column> allColumns;
 
-  protected AbstractTable(String name, String alias, Class<? extends AttributesWithId> attributesType, Class<? extends ModelWithId> modelType) {
+  protected AbstractTable(String name, String alias, Class<A> attributesType, Class<M> modelType) {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(name), "Table name cannot be null or empty.");
     Preconditions.checkArgument(!Strings.isNullOrEmpty(alias), "Table alias cannot be null or empty.");
     this.name = name;
@@ -46,12 +46,12 @@ public class AbstractTable implements Table {
     return name + " AS " + alias;
   }
 
-  public Class<? extends AttributesWithId> getAttributesType() {
+  public Class<A> getAttributesType() {
     return attributesType;
   }
 
   @Override
-  public Class<? extends ModelWithId> getModelType() {
+  public Class<M> getModelType() {
     return modelType;
   }
 }

--- a/src/java/com/rapleaf/jack/queries/GenericQuery.java
+++ b/src/java/com/rapleaf/jack/queries/GenericQuery.java
@@ -232,7 +232,7 @@ public class GenericQuery {
       return null;
     }
 
-    Record record = new Record(selectedColumns.size());
+    Record record = new Record(includedTables, selectedColumns.size());
     for (Column column : selectedColumns) {
       String sqlKeyword = column.getSqlKeyword();
       Object value = queryResultSet.getObject(sqlKeyword);

--- a/src/java/com/rapleaf/jack/queries/GenericQuery.java
+++ b/src/java/com/rapleaf/jack/queries/GenericQuery.java
@@ -237,7 +237,7 @@ public class GenericQuery {
       return null;
     }
 
-    Record record = new Record(includedTables, selectedColumns.size());
+    Record record = new Record(selectedColumns.size());
     for (Column column : selectedColumns) {
       String sqlKeyword = column.getSqlKeyword();
       Object value = queryResultSet.getObject(sqlKeyword);

--- a/src/java/com/rapleaf/jack/queries/Record.java
+++ b/src/java/com/rapleaf/jack/queries/Record.java
@@ -1,6 +1,7 @@
 package com.rapleaf.jack.queries;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
 import java.util.Date;
 import java.util.Map;
@@ -8,6 +9,7 @@ import java.util.Map;
 import com.google.common.collect.Maps;
 
 import com.rapleaf.jack.AttributesWithId;
+import com.rapleaf.jack.GenericDatabases;
 import com.rapleaf.jack.ModelWithId;
 import com.rapleaf.jack.util.JackUtility;
 
@@ -124,8 +126,16 @@ public class Record {
     return attribute;
   }
 
-  public <M extends ModelWithId> M getModel(Class<M> modelType) {
-    return null;
+  @SuppressWarnings("unchecked")
+  public <M extends ModelWithId, D extends GenericDatabases> M getModel(Table tableType, D databases) {
+    try {
+      Constructor<M> constructor = (Constructor<M>)(tableType.getModelType().getConstructor(tableType.getAttributeType(), databases.getClass().getInterfaces()[0]));
+      M model = constructor.newInstance(getAttributes(tableType), databases);
+      model.setCreated(true);
+      return model;
+    } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException | InstantiationException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   private Object checkTypeAndReturnObject(Column column, Class clazz) {

--- a/src/java/com/rapleaf/jack/queries/Record.java
+++ b/src/java/com/rapleaf/jack/queries/Record.java
@@ -82,7 +82,7 @@ public class Record {
     String tableName = tableType.getAlias();
     Constructor<A> constructor;
     try {
-      constructor = ((Class<A>)tableType.getAttributeType()).getConstructor(Long.TYPE);
+      constructor = ((Class<A>)tableType.getAttributesType()).getConstructor(Long.TYPE);
     } catch (NoSuchMethodException e) {
       throw new RuntimeException(e);
     }
@@ -129,7 +129,7 @@ public class Record {
   @SuppressWarnings("unchecked")
   public <M extends ModelWithId, D extends GenericDatabases> M getModel(Table tableType, D databases) {
     try {
-      Constructor<M> constructor = (Constructor<M>)(tableType.getModelType().getConstructor(tableType.getAttributeType(), databases.getClass().getInterfaces()[0]));
+      Constructor<M> constructor = (Constructor<M>)(tableType.getModelType().getConstructor(tableType.getAttributesType(), databases.getClass().getInterfaces()[0]));
       M model = constructor.newInstance(getAttributes(tableType), databases);
       model.setCreated(true);
       return model;

--- a/src/java/com/rapleaf/jack/queries/Record.java
+++ b/src/java/com/rapleaf/jack/queries/Record.java
@@ -77,12 +77,11 @@ public class Record {
     return value == null ? null : (Boolean)value;
   }
 
-  @SuppressWarnings("unchecked")
-  public <A extends AttributesWithId> A getAttributes(Table tableType) {
+  public <A extends AttributesWithId, M extends ModelWithId> A getAttributes(Table<A, M> tableType) {
     String tableName = tableType.getAlias();
     Constructor<A> constructor;
     try {
-      constructor = ((Class<A>)tableType.getAttributesType()).getConstructor(Long.TYPE);
+      constructor = tableType.getAttributesType().getConstructor(Long.TYPE);
     } catch (NoSuchMethodException e) {
       throw new RuntimeException(e);
     }
@@ -130,15 +129,14 @@ public class Record {
     return attribute;
   }
 
-  @SuppressWarnings("unchecked")
-  public <M extends ModelWithId, D extends GenericDatabases> M getModel(Table tableType, D databases) {
+  public <A extends AttributesWithId, M extends ModelWithId, D extends GenericDatabases> M getModel(Table<A, M> tableType, D databases) {
     try {
       AttributesWithId attributes = getAttributes(tableType);
       if (attributes == null) {
         return null;
       }
 
-      Constructor<M> constructor = (Constructor<M>)(tableType.getModelType().getConstructor(tableType.getAttributesType(), databases.getClass().getInterfaces()[0]));
+      Constructor<M> constructor = (tableType.getModelType().getConstructor(tableType.getAttributesType(), databases.getClass().getInterfaces()[0]));
       M model = constructor.newInstance(attributes, databases);
       model.setCreated(true);
       return model;

--- a/src/java/com/rapleaf/jack/queries/Record.java
+++ b/src/java/com/rapleaf/jack/queries/Record.java
@@ -2,7 +2,6 @@ package com.rapleaf.jack.queries;
 
 import java.lang.reflect.Constructor;
 import java.math.BigDecimal;
-import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
 
@@ -13,11 +12,9 @@ import com.rapleaf.jack.ModelWithId;
 import com.rapleaf.jack.util.JackUtility;
 
 public class Record {
-  private final Collection<Table> tables;
   private final Map<Column, Object> columns;
 
-  Record(Collection<Table> tables, int columnCount) {
-    this.tables = tables;
+  Record(int columnCount) {
     this.columns = Maps.newHashMapWithExpectedSize(columnCount);
   }
 
@@ -78,19 +75,14 @@ public class Record {
     return value == null ? null : (Boolean)value;
   }
 
-  public <A extends AttributesWithId> A getAttribute(Class<A> attributesType) {
-    Constructor<A> constructor = null;
-    String tableName = null;
-    for (Table table : tables) {
-      if (table.getAttributeType().equals(attributesType)) {
-        tableName = table.getAlias();
-        try {
-          constructor = ((Class<A>)table.getAttributeType()).getConstructor(Long.TYPE);
-        } catch (NoSuchMethodException e) {
-          throw new RuntimeException(e);
-        }
-        break;
-      }
+  @SuppressWarnings("unchecked")
+  public <A extends AttributesWithId> A getAttribute(Table tableType) {
+    String tableName = tableType.getAlias();
+    Constructor<A> constructor;
+    try {
+      constructor = ((Class<A>)tableType.getAttributeType()).getConstructor(Long.TYPE);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
     }
 
     if (constructor == null || tableName == null) {

--- a/src/java/com/rapleaf/jack/queries/Record.java
+++ b/src/java/com/rapleaf/jack/queries/Record.java
@@ -106,6 +106,10 @@ public class Record {
       }
     }
 
+    if (id == null) {
+      return null;
+    }
+
     A attribute;
     try {
       attribute = constructor.newInstance(id);
@@ -129,8 +133,13 @@ public class Record {
   @SuppressWarnings("unchecked")
   public <M extends ModelWithId, D extends GenericDatabases> M getModel(Table tableType, D databases) {
     try {
+      AttributesWithId attributes = getAttributes(tableType);
+      if (attributes == null) {
+        return null;
+      }
+
       Constructor<M> constructor = (Constructor<M>)(tableType.getModelType().getConstructor(tableType.getAttributesType(), databases.getClass().getInterfaces()[0]));
-      M model = constructor.newInstance(getAttributes(tableType), databases);
+      M model = constructor.newInstance(attributes, databases);
       model.setCreated(true);
       return model;
     } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException | InstantiationException e) {

--- a/src/java/com/rapleaf/jack/queries/Record.java
+++ b/src/java/com/rapleaf/jack/queries/Record.java
@@ -76,7 +76,7 @@ public class Record {
   }
 
   @SuppressWarnings("unchecked")
-  public <A extends AttributesWithId> A getAttribute(Table tableType) {
+  public <A extends AttributesWithId> A getAttributes(Table tableType) {
     String tableName = tableType.getAlias();
     Constructor<A> constructor;
     try {

--- a/src/java/com/rapleaf/jack/queries/Records.java
+++ b/src/java/com/rapleaf/jack/queries/Records.java
@@ -91,7 +91,7 @@ public class Records implements Iterable<Record> {
   public <T extends AttributesWithId> List<T> getAttributes(Table tableType) {
     List<T> results = Lists.newArrayList();
     for (Record record : records) {
-      results.add((T)record.getAttribute(tableType));
+      results.add((T)record.getAttributes(tableType));
     }
     return results;
   }

--- a/src/java/com/rapleaf/jack/queries/Records.java
+++ b/src/java/com/rapleaf/jack/queries/Records.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.google.common.collect.Lists;
 
 import com.rapleaf.jack.AttributesWithId;
+import com.rapleaf.jack.GenericDatabases;
 import com.rapleaf.jack.ModelWithId;
 
 public class Records implements Iterable<Record> {
@@ -96,10 +97,11 @@ public class Records implements Iterable<Record> {
     return results;
   }
 
-  public <T extends ModelWithId> List<T> getModels(Class<T> modelType) {
+  @SuppressWarnings("unchecked")
+  public <T extends ModelWithId, D extends GenericDatabases> List<T> getModels(Table tableType, D databases) {
     List<T> results = Lists.newArrayList();
     for (Record record : records) {
-      results.add(record.getModel(modelType));
+      results.add((T)record.getModel(tableType, databases));
     }
     return results;
   }

--- a/src/java/com/rapleaf/jack/queries/Records.java
+++ b/src/java/com/rapleaf/jack/queries/Records.java
@@ -87,10 +87,11 @@ public class Records implements Iterable<Record> {
     return results;
   }
 
-  public <T extends AttributesWithId> List<T> getAttributes(Class<T> attributesType) {
+  @SuppressWarnings("unchecked")
+  public <T extends AttributesWithId> List<T> getAttributes(Table tableType) {
     List<T> results = Lists.newArrayList();
     for (Record record : records) {
-      results.add(record.getAttribute(attributesType));
+      results.add((T)record.getAttribute(tableType));
     }
     return results;
   }

--- a/src/java/com/rapleaf/jack/queries/Records.java
+++ b/src/java/com/rapleaf/jack/queries/Records.java
@@ -88,20 +88,18 @@ public class Records implements Iterable<Record> {
     return results;
   }
 
-  @SuppressWarnings("unchecked")
-  public <T extends AttributesWithId> List<T> getAttributes(Table tableType) {
-    List<T> results = Lists.newArrayList();
+  public <A extends AttributesWithId, M extends ModelWithId> List<A> getAttributes(Table<A, M> tableType) {
+    List<A> results = Lists.newArrayList();
     for (Record record : records) {
-      results.add((T)record.getAttributes(tableType));
+      results.add(record.getAttributes(tableType));
     }
     return results;
   }
 
-  @SuppressWarnings("unchecked")
-  public <T extends ModelWithId, D extends GenericDatabases> List<T> getModels(Table tableType, D databases) {
-    List<T> results = Lists.newArrayList();
+  public <A extends AttributesWithId, M extends ModelWithId, D extends GenericDatabases> List<M> getModels(Table<A, M> tableType, D databases) {
+    List<M> results = Lists.newArrayList();
     for (Record record : records) {
-      results.add((T)record.getModel(tableType, databases));
+      results.add(record.getModel(tableType, databases));
     }
     return results;
   }

--- a/src/java/com/rapleaf/jack/queries/Records.java
+++ b/src/java/com/rapleaf/jack/queries/Records.java
@@ -87,18 +87,19 @@ public class Records implements Iterable<Record> {
     return results;
   }
 
-  @SuppressWarnings("unchecked")
-  public <T extends AttributesWithId> List<T> getAttributes(Table tableType) {
+  public <T extends AttributesWithId> List<T> getAttributes(Class<T> attributesType) {
     List<T> results = Lists.newArrayList();
     for (Record record : records) {
-      results.add((T)record.getAttribute(tableType));
+      results.add(record.getAttribute(attributesType));
     }
     return results;
   }
 
-  public <T extends ModelWithId> List<T> getModels() {
+  public <T extends ModelWithId> List<T> getModels(Class<T> modelType) {
     List<T> results = Lists.newArrayList();
-
+    for (Record record : records) {
+      results.add(record.getModel(modelType));
+    }
     return results;
   }
 

--- a/src/java/com/rapleaf/jack/queries/Records.java
+++ b/src/java/com/rapleaf/jack/queries/Records.java
@@ -5,6 +5,9 @@ import java.util.List;
 
 import com.google.common.collect.Lists;
 
+import com.rapleaf.jack.AttributesWithId;
+import com.rapleaf.jack.ModelWithId;
+
 public class Records implements Iterable<Record> {
   private final List<Record> records;
 
@@ -81,6 +84,21 @@ public class Records implements Iterable<Record> {
     for (Record record : records) {
       results.add(record.getBoolean(column));
     }
+    return results;
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T extends AttributesWithId> List<T> getAttributes(Table tableType) {
+    List<T> results = Lists.newArrayList();
+    for (Record record : records) {
+      results.add((T)record.getAttribute(tableType));
+    }
+    return results;
+  }
+
+  public <T extends ModelWithId> List<T> getModels() {
+    List<T> results = Lists.newArrayList();
+
     return results;
   }
 

--- a/src/java/com/rapleaf/jack/queries/Table.java
+++ b/src/java/com/rapleaf/jack/queries/Table.java
@@ -7,12 +7,16 @@ import com.rapleaf.jack.ModelWithId;
 
 public interface Table {
 
+  public String getName();
+
+  public String getAlias();
+
   public Set<Column> getAllColumns();
 
   public String getSqlKeyword();
 
   public Class<? extends AttributesWithId> getAttributeType();
 
-  public Class<? extends ModelWithId> getModelType();
+  public <M extends ModelWithId> Class<M> getModelType();
 
 }

--- a/src/java/com/rapleaf/jack/queries/Table.java
+++ b/src/java/com/rapleaf/jack/queries/Table.java
@@ -15,7 +15,7 @@ public interface Table {
 
   public String getSqlKeyword();
 
-  public Class<? extends AttributesWithId> getAttributeType();
+  public <A extends AttributesWithId> Class<A> getAttributeType();
 
   public <M extends ModelWithId> Class<M> getModelType();
 

--- a/src/java/com/rapleaf/jack/queries/Table.java
+++ b/src/java/com/rapleaf/jack/queries/Table.java
@@ -15,7 +15,7 @@ public interface Table {
 
   public String getSqlKeyword();
 
-  public <A extends AttributesWithId> Class<A> getAttributeType();
+  public <A extends AttributesWithId> Class<A> getAttributesType();
 
   public <M extends ModelWithId> Class<M> getModelType();
 

--- a/src/java/com/rapleaf/jack/queries/Table.java
+++ b/src/java/com/rapleaf/jack/queries/Table.java
@@ -5,7 +5,7 @@ import java.util.Set;
 import com.rapleaf.jack.AttributesWithId;
 import com.rapleaf.jack.ModelWithId;
 
-public interface Table {
+public interface Table<A extends AttributesWithId, M extends ModelWithId> {
 
   public String getName();
 
@@ -15,8 +15,8 @@ public interface Table {
 
   public String getSqlKeyword();
 
-  public <A extends AttributesWithId> Class<A> getAttributesType();
+  public Class<A> getAttributesType();
 
-  public <M extends ModelWithId> Class<M> getModelType();
+  public Class<M> getModelType();
 
 }

--- a/src/java/com/rapleaf/jack/queries/Table.java
+++ b/src/java/com/rapleaf/jack/queries/Table.java
@@ -2,10 +2,17 @@ package com.rapleaf.jack.queries;
 
 import java.util.Set;
 
+import com.rapleaf.jack.AttributesWithId;
+import com.rapleaf.jack.ModelWithId;
+
 public interface Table {
 
   public Set<Column> getAllColumns();
 
   public String getSqlKeyword();
+
+  public Class<? extends AttributesWithId> getAttributeType();
+
+  public Class<? extends ModelWithId> getModelType();
 
 }

--- a/src/rb/templates/model.erb
+++ b/src/rb/templates/model.erb
@@ -51,7 +51,7 @@ public class <%=model_defn.model_name%> extends ModelWithId<<%= model_defn.model
   
   public static final long serialVersionUID = <%= model_defn.serial_version_uid %>L;
 
-  public static class Tbl extends AbstractTable {
+  public static class Tbl extends AbstractTable<<%= model_defn.model_name %>.Attributes, <%= model_defn.model_name %>> {
     public final Column ID;
     <% model_defn.fields.each do |field_defn| %>
     public final Column <%= field_defn.name.upcase %>;

--- a/src/rb/templates/model.erb
+++ b/src/rb/templates/model.erb
@@ -58,7 +58,7 @@ public class <%=model_defn.model_name%> extends ModelWithId<<%= model_defn.model
     <% end %>
 
     private Tbl(String alias) {
-      super("<%= model_defn.table_name %>", alias);
+      super("<%= model_defn.table_name %>", alias, <%= model_defn.model_name %>.Attributes.class, <%= model_defn.model_name %>.class);
       this.ID = Column.fromId(alias);
       <% model_defn.fields.each do |field_defn| %>
       this.<%= field_defn.name.upcase %> = Column.fromField(alias, _Fields.<%= field_defn.name%>, <%= field_defn.java_type(true) %>.class);

--- a/test/java/com/rapleaf/jack/TestGenericQuery.java
+++ b/test/java/com/rapleaf/jack/TestGenericQuery.java
@@ -934,7 +934,7 @@ public class TestGenericQuery {
     userA = users.create("A", datetime, 1, date, datetime, "Assembly Coder", new byte[]{(byte)1, (byte)2, (byte)3}, 1.1, 1.01, true);
     Record record = db.createQuery().from(User.TBL).orderBy(User.SOME_DATETIME, ASC).fetch().get(0);
     User.Attributes lhs = userA.getAttributes();
-    User.Attributes rhs = record.getAttribute(User.Attributes.class);
+    User.Attributes rhs = record.getAttribute(User.TBL);
 
     assertEquals(lhs.getId(), rhs.getId());
     assertEquals(lhs.getHandle(), rhs.getHandle());

--- a/test/java/com/rapleaf/jack/TestGenericQuery.java
+++ b/test/java/com/rapleaf/jack/TestGenericQuery.java
@@ -49,7 +49,7 @@ public class TestGenericQuery {
   private final IPostPersistence posts = db.posts();
 
   private User userA, userB, userC, userD, userE, userF, userG, userH;
-  private Post postA, postB, postC, postD, postE;
+  private Post postA, postB, postC;
   private Comment commentA, commentB, commentC, commentD;
   private long date, datetime;
   private Records results1, results2;
@@ -103,7 +103,7 @@ public class TestGenericQuery {
     results1 = db.createQuery()
         .from(User.TBL)
         .where(User.BIO.equalTo("Trader"),
-               User.HANDLE.equalTo("B"))
+            User.HANDLE.equalTo("B"))
         .fetch();
     assertEquals(1, results1.size());
     assertTrue(userB.getId() == results1.get(0).getLong(User.ID));
@@ -121,7 +121,7 @@ public class TestGenericQuery {
     results1 = db.createQuery()
         .from(User.TBL)
         .where(User.BIO.equalTo("Trader"),
-               User.NUM_POSTS.equalTo(1).or(User.NUM_POSTS.equalTo(2)).or(User.NUM_POSTS.equalTo(3)))
+            User.NUM_POSTS.equalTo(1).or(User.NUM_POSTS.equalTo(2)).or(User.NUM_POSTS.equalTo(3)))
         .fetch();
     assertEquals(2, results1.size());
     assertEquals(Sets.newHashSet(userA.getId(), userB.getId()), Sets.newHashSet(results1.getLongs(User.ID)));
@@ -129,8 +129,8 @@ public class TestGenericQuery {
     results1 = db.createQuery()
         .from(User.TBL)
         .where(User.NUM_POSTS.between(1, 2),
-               User.BIO.equalTo("CEO")
-                   .or(User.BIO.equalTo("Trader"), User.HANDLE.equalTo("B")))
+            User.BIO.equalTo("CEO")
+                .or(User.BIO.equalTo("Trader"), User.HANDLE.equalTo("B")))
         .fetch();
     assertEquals(2, results1.size());
     assertEquals(Sets.newHashSet(userB.getId(), userC.getId()), Sets.newHashSet(results1.getLongs(User.ID)));
@@ -138,9 +138,9 @@ public class TestGenericQuery {
     results1 = db.createQuery()
         .from(User.TBL)
         .where(User.NUM_POSTS.between(1, 2),
-               User.BIO.equalTo("CEO")
-                   .or(User.BIO.equalTo("Trader"), User.HANDLE.equalTo("B"))
-                   .or(User.BIO.equalTo("Trader"), User.HANDLE.equalTo("A")))
+            User.BIO.equalTo("CEO")
+                .or(User.BIO.equalTo("Trader"), User.HANDLE.equalTo("B"))
+                .or(User.BIO.equalTo("Trader"), User.HANDLE.equalTo("A")))
         .fetch();
     assertEquals(3, results1.size());
     assertEquals(Sets.newHashSet(userA.getId(), userB.getId(), userC.getId()), Sets.newHashSet(results1.getLongs(User.ID)));
@@ -345,7 +345,7 @@ public class TestGenericQuery {
         .fetch();
     assertEquals(1, results1.size());
     assertEquals("Casey", results1.get(0).getString(User.HANDLE));
-    
+
     results1 = db.createQuery().from(User.TBL).where(User.SOME_DATETIME.isNull()).fetch();
     assertEquals(3, results1.size());
 
@@ -532,8 +532,8 @@ public class TestGenericQuery {
     results1 = db.createQuery()
         .from(User.TBL)
         .where(User.HANDLE.equalTo("A"),
-               User.BIO.equalTo("CEO"),
-               User.NUM_POSTS.equalTo(1))
+            User.BIO.equalTo("CEO"),
+            User.NUM_POSTS.equalTo(1))
         .orderBy(User.ID)
         .fetch();
     assertEquals(1, results1.size());
@@ -748,16 +748,14 @@ public class TestGenericQuery {
     userB = users.create("B", datetime, 0, date - 1, datetime, "Byline Editor", new byte[]{(byte)1}, 2.2, 2.02, true);
     userC = users.create("C", datetime, 0, date + 2, datetime, "Code Refactor", new byte[]{(byte)2}, 2.2, 2.02, false);
 
-    postA = posts.create("Post A from User A", datetime, userA.getIntId(), datetime);
+    postA = posts.create("Post A from User B", datetime, userB.getIntId(), datetime);
     postB = posts.create("Post B from User B", datetime, userB.getIntId(), datetime);
-    postC = posts.create("Post C from User B", datetime, userB.getIntId(), datetime);
-    postD = posts.create("Post D from User C", datetime, userC.getIntId(), datetime);
-    postE = posts.create("Post E from User C", datetime, userC.getIntId(), datetime);
+    postC = posts.create("Post C from User C", datetime, userC.getIntId(), datetime);
 
-    commentA = comments.create("Comment A on Post B from User A", userA.getIntId(), postB.getIntId(), datetime);
-    commentB = comments.create("Comment B on Post B from User B", userB.getIntId(), postB.getIntId(), datetime);
-    commentC = comments.create("Comment C on Post C from User B", userB.getIntId(), postC.getIntId(), datetime);
-    commentD = comments.create("Comment D on Post E from User C", userC.getIntId(), postE.getIntId(), datetime);
+    commentA = comments.create("Comment A on Post A from User A", userA.getIntId(), postA.getIntId(), datetime);
+    commentB = comments.create("Comment B on Post A from User B", userB.getIntId(), postA.getIntId(), datetime);
+    commentC = comments.create("Comment C on Post B from User B", userB.getIntId(), postB.getIntId(), datetime);
+    commentD = comments.create("Comment D on Post C from User C", userC.getIntId(), postC.getIntId(), datetime);
 
     results1 = db.createQuery()
         .from(Comment.TBL)
@@ -775,22 +773,22 @@ public class TestGenericQuery {
     Record recordForCommentA = results1.get(0);
     assertEquals(commentA.getContent(), recordForCommentA.getString(Comment.CONTENT));
     assertEquals(userA.getHandle(), recordForCommentA.getString(User.HANDLE));
-    assertEquals(postB.getTitle(), recordForCommentA.getString(Post.TITLE));
+    assertEquals(postA.getTitle(), recordForCommentA.getString(Post.TITLE));
 
     Record recordForCommentC = results1.get(1);
     assertEquals(commentC.getContent(), recordForCommentC.getString(Comment.CONTENT));
     assertEquals(userB.getHandle(), recordForCommentC.getString(User.HANDLE));
-    assertEquals(postC.getTitle(), recordForCommentC.getString(Post.TITLE));
+    assertEquals(postB.getTitle(), recordForCommentC.getString(Post.TITLE));
 
     Record recordForCommentB = results1.get(2);
     assertEquals(commentB.getContent(), recordForCommentB.getString(Comment.CONTENT));
     assertEquals(userB.getHandle(), recordForCommentB.getString(User.HANDLE));
-    assertEquals(postB.getTitle(), recordForCommentB.getString(Post.TITLE));
+    assertEquals(postA.getTitle(), recordForCommentB.getString(Post.TITLE));
 
     Record recordForCommentD = results1.get(3);
     assertEquals(commentD.getContent(), recordForCommentD.getString(Comment.CONTENT));
     assertEquals(userC.getHandle(), recordForCommentD.getString(User.HANDLE));
-    assertEquals(postE.getTitle(), recordForCommentD.getString(Post.TITLE));
+    assertEquals(postC.getTitle(), recordForCommentD.getString(Post.TITLE));
   }
 
   @Test

--- a/test/java/com/rapleaf/jack/TestGenericQuery.java
+++ b/test/java/com/rapleaf/jack/TestGenericQuery.java
@@ -940,7 +940,7 @@ public class TestGenericQuery {
         .fetch()
         .get(0);
     User.Attributes userLhs = userA.getAttributes();
-    User.Attributes userRhs = record.getAttribute(User.TBL);
+    User.Attributes userRhs = record.getAttributes(User.TBL);
 
     assertEquals(userLhs.getId(), userRhs.getId());
     assertEquals(userLhs.getHandle(), userRhs.getHandle());
@@ -954,7 +954,7 @@ public class TestGenericQuery {
     assertEquals(userLhs.isSomeBoolean(), userRhs.isSomeBoolean());
 
     Post.Attributes postLhs = postA.getAttributes();
-    Post.Attributes postRhs = record.getAttribute(Post.TBL);
+    Post.Attributes postRhs = record.getAttributes(Post.TBL);
     assertEquals(postLhs.getId(), postRhs.getId());
     assertEquals(postLhs.getTitle(), postRhs.getTitle());
     assertEquals(postLhs.getPostedAtMillis(), postRhs.getPostedAtMillis());

--- a/test/java/com/rapleaf/jack/TestGenericQuery.java
+++ b/test/java/com/rapleaf/jack/TestGenericQuery.java
@@ -932,20 +932,34 @@ public class TestGenericQuery {
   @Test
   public void testModelAndAttributeFromRecord() throws Exception {
     userA = users.create("A", datetime, 1, date, datetime, "Assembly Coder", new byte[]{(byte)1, (byte)2, (byte)3}, 1.1, 1.01, true);
-    Record record = db.createQuery().from(User.TBL).orderBy(User.SOME_DATETIME, ASC).fetch().get(0);
-    User.Attributes lhs = userA.getAttributes();
-    User.Attributes rhs = record.getAttribute(User.TBL);
+    postA = posts.create("Post A from User A", date, userA.getIntId(), datetime);
+    Record record = db.createQuery()
+        .from(User.TBL)
+        .innerJoin(Post.TBL).on(Post.USER_ID.equalTo(User.ID))
+        .orderBy(User.SOME_DATETIME, ASC)
+        .fetch()
+        .get(0);
+    User.Attributes userLhs = userA.getAttributes();
+    User.Attributes userRhs = record.getAttribute(User.TBL);
 
-    assertEquals(lhs.getId(), rhs.getId());
-    assertEquals(lhs.getHandle(), rhs.getHandle());
-    assertEquals(lhs.getCreatedAtMillis(), rhs.getCreatedAtMillis());
-    assertEquals(lhs.getSomeDate(), rhs.getSomeDate());
-    assertEquals(lhs.getSomeDatetime(), rhs.getSomeDatetime());
-    assertEquals(lhs.getBio(), rhs.getBio());
-    assertArrayEquals(lhs.getSomeBinary(), rhs.getSomeBinary());
-    assertEquals(lhs.getSomeFloat(), rhs.getSomeFloat(), 0.000001);
-    assertEquals(lhs.getSomeDecimal(), rhs.getSomeDecimal());
-    assertEquals(lhs.isSomeBoolean(), rhs.isSomeBoolean());
+    assertEquals(userLhs.getId(), userRhs.getId());
+    assertEquals(userLhs.getHandle(), userRhs.getHandle());
+    assertEquals(userLhs.getCreatedAtMillis(), userRhs.getCreatedAtMillis());
+    assertEquals(userLhs.getSomeDate(), userRhs.getSomeDate());
+    assertEquals(userLhs.getSomeDatetime(), userRhs.getSomeDatetime());
+    assertEquals(userLhs.getBio(), userRhs.getBio());
+    assertArrayEquals(userLhs.getSomeBinary(), userRhs.getSomeBinary());
+    assertEquals(userLhs.getSomeFloat(), userRhs.getSomeFloat(), 0.000001);
+    assertEquals(userLhs.getSomeDecimal(), userRhs.getSomeDecimal());
+    assertEquals(userLhs.isSomeBoolean(), userRhs.isSomeBoolean());
+
+    Post.Attributes postLhs = postA.getAttributes();
+    Post.Attributes postRhs = record.getAttribute(Post.TBL);
+    assertEquals(postLhs.getId(), postRhs.getId());
+    assertEquals(postLhs.getTitle(), postRhs.getTitle());
+    assertEquals(postLhs.getPostedAtMillis(), postRhs.getPostedAtMillis());
+    assertEquals(postLhs.getUserId(), postRhs.getUserId());
+    assertEquals(postLhs.getUpdatedAt(), postRhs.getUpdatedAt());
   }
 
 }

--- a/test/java/com/rapleaf/jack/TestGenericQuery.java
+++ b/test/java/com/rapleaf/jack/TestGenericQuery.java
@@ -928,4 +928,24 @@ public class TestGenericQuery {
     assertEquals(3, results1.size());
     assertEquals(Sets.newHashSet("D", "E", "F"), Sets.newHashSet(results1.getStrings(User.HANDLE)));
   }
+
+  @Test
+  public void testModelAndAttributeFromRecord() throws Exception {
+    userA = users.create("A", datetime, 1, date, datetime, "Assembly Coder", new byte[]{(byte)1, (byte)2, (byte)3}, 1.1, 1.01, true);
+    Record record = db.createQuery().from(User.TBL).orderBy(User.SOME_DATETIME, ASC).fetch().get(0);
+    User.Attributes lhs = userA.getAttributes();
+    User.Attributes rhs = record.getAttribute(User.Attributes.class);
+
+    assertEquals(lhs.getId(), rhs.getId());
+    assertEquals(lhs.getHandle(), rhs.getHandle());
+    assertEquals(lhs.getCreatedAtMillis(), rhs.getCreatedAtMillis());
+    assertEquals(lhs.getSomeDate(), rhs.getSomeDate());
+    assertEquals(lhs.getSomeDatetime(), rhs.getSomeDatetime());
+    assertEquals(lhs.getBio(), rhs.getBio());
+    assertArrayEquals(lhs.getSomeBinary(), rhs.getSomeBinary());
+    assertEquals(lhs.getSomeFloat(), rhs.getSomeFloat(), 0.000001);
+    assertEquals(lhs.getSomeDecimal(), rhs.getSomeDecimal());
+    assertEquals(lhs.isSomeBoolean(), rhs.isSomeBoolean());
+  }
+
 }

--- a/test/java/com/rapleaf/jack/TestGenericQuery.java
+++ b/test/java/com/rapleaf/jack/TestGenericQuery.java
@@ -961,10 +961,16 @@ public class TestGenericQuery {
     assertEquals(postAttrLhs.getUserId(), postAttrRhs.getUserId());
     assertEquals(postAttrLhs.getUpdatedAt(), postAttrRhs.getUpdatedAt());
 
+    Comment.Attributes commentAttr = record.getAttributes(Comment.TBL);
+    assertNull(commentAttr);
+
     User modelFromRecord = record.getModel(User.TBL, db.getDatabases());
     String newHandle = "new handle";
     modelFromRecord.setHandle(newHandle).save();
     assertEquals(users.find(modelFromRecord.getId()).getHandle(), newHandle);
+
+    Comment comment = record.getModel(Comment.TBL, db.getDatabases());
+    assertNull(comment);
   }
 
 }

--- a/test/java/com/rapleaf/jack/TestGenericQuery.java
+++ b/test/java/com/rapleaf/jack/TestGenericQuery.java
@@ -939,27 +939,32 @@ public class TestGenericQuery {
         .orderBy(User.SOME_DATETIME, ASC)
         .fetch()
         .get(0);
-    User.Attributes userLhs = userA.getAttributes();
-    User.Attributes userRhs = record.getAttributes(User.TBL);
+    User.Attributes userAttrLhs = userA.getAttributes();
+    User.Attributes userAttrRhs = record.getAttributes(User.TBL);
 
-    assertEquals(userLhs.getId(), userRhs.getId());
-    assertEquals(userLhs.getHandle(), userRhs.getHandle());
-    assertEquals(userLhs.getCreatedAtMillis(), userRhs.getCreatedAtMillis());
-    assertEquals(userLhs.getSomeDate(), userRhs.getSomeDate());
-    assertEquals(userLhs.getSomeDatetime(), userRhs.getSomeDatetime());
-    assertEquals(userLhs.getBio(), userRhs.getBio());
-    assertArrayEquals(userLhs.getSomeBinary(), userRhs.getSomeBinary());
-    assertEquals(userLhs.getSomeFloat(), userRhs.getSomeFloat(), 0.000001);
-    assertEquals(userLhs.getSomeDecimal(), userRhs.getSomeDecimal());
-    assertEquals(userLhs.isSomeBoolean(), userRhs.isSomeBoolean());
+    assertEquals(userAttrLhs.getId(), userAttrRhs.getId());
+    assertEquals(userAttrLhs.getHandle(), userAttrRhs.getHandle());
+    assertEquals(userAttrLhs.getCreatedAtMillis(), userAttrRhs.getCreatedAtMillis());
+    assertEquals(userAttrLhs.getSomeDate(), userAttrRhs.getSomeDate());
+    assertEquals(userAttrLhs.getSomeDatetime(), userAttrRhs.getSomeDatetime());
+    assertEquals(userAttrLhs.getBio(), userAttrRhs.getBio());
+    assertArrayEquals(userAttrLhs.getSomeBinary(), userAttrRhs.getSomeBinary());
+    assertEquals(userAttrLhs.getSomeFloat(), userAttrRhs.getSomeFloat(), 0.000001);
+    assertEquals(userAttrLhs.getSomeDecimal(), userAttrRhs.getSomeDecimal());
+    assertEquals(userAttrLhs.isSomeBoolean(), userAttrRhs.isSomeBoolean());
 
-    Post.Attributes postLhs = postA.getAttributes();
-    Post.Attributes postRhs = record.getAttributes(Post.TBL);
-    assertEquals(postLhs.getId(), postRhs.getId());
-    assertEquals(postLhs.getTitle(), postRhs.getTitle());
-    assertEquals(postLhs.getPostedAtMillis(), postRhs.getPostedAtMillis());
-    assertEquals(postLhs.getUserId(), postRhs.getUserId());
-    assertEquals(postLhs.getUpdatedAt(), postRhs.getUpdatedAt());
+    Post.Attributes postAttrLhs = postA.getAttributes();
+    Post.Attributes postAttrRhs = record.getAttributes(Post.TBL);
+    assertEquals(postAttrLhs.getId(), postAttrRhs.getId());
+    assertEquals(postAttrLhs.getTitle(), postAttrRhs.getTitle());
+    assertEquals(postAttrLhs.getPostedAtMillis(), postAttrRhs.getPostedAtMillis());
+    assertEquals(postAttrLhs.getUserId(), postAttrRhs.getUserId());
+    assertEquals(postAttrLhs.getUpdatedAt(), postAttrRhs.getUpdatedAt());
+
+    User modelFromRecord = record.getModel(User.TBL, db.getDatabases());
+    String newHandle = "new handle";
+    modelFromRecord.setHandle(newHandle).save();
+    assertEquals(users.find(modelFromRecord.getId()).getHandle(), newHandle);
   }
 
 }

--- a/test/java/com/rapleaf/jack/test_project/database_1/models/Comment.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/models/Comment.java
@@ -43,7 +43,7 @@ public class Comment extends ModelWithId<Comment, IDatabases> implements Compara
     public final Column CREATED_AT;
 
     private Tbl(String alias) {
-      super("comments", alias);
+      super("comments", alias, Comment.Attributes.class, Comment.class);
       this.ID = Column.fromId(alias);
       this.CONTENT = Column.fromField(alias, _Fields.content, String.class);
       this.COMMENTER_ID = Column.fromField(alias, _Fields.commenter_id, Integer.class);

--- a/test/java/com/rapleaf/jack/test_project/database_1/models/Comment.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/models/Comment.java
@@ -7,30 +7,33 @@
 package com.rapleaf.jack.test_project.database_1.models;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.List;
+import java.util.ArrayList;
 
-import com.rapleaf.jack.AssociationType;
+import com.rapleaf.jack.ModelWithId;
 import com.rapleaf.jack.AttributesWithId;
 import com.rapleaf.jack.BelongsToAssociation;
-import com.rapleaf.jack.DefaultAssociationMetadata;
+import com.rapleaf.jack.HasManyAssociation;
+import com.rapleaf.jack.HasOneAssociation;
+import com.rapleaf.jack.ModelIdWrapper;
 import com.rapleaf.jack.IAssociationMetadata;
 import com.rapleaf.jack.IModelAssociationMetadata;
-import com.rapleaf.jack.ModelIdWrapper;
-import com.rapleaf.jack.ModelWithId;
+import com.rapleaf.jack.DefaultAssociationMetadata;
+import com.rapleaf.jack.AssociationType;
 import com.rapleaf.jack.queries.AbstractTable;
 import com.rapleaf.jack.queries.Column;
+
 import com.rapleaf.jack.test_project.IDatabases;
 import com.rapleaf.jack.util.JackUtility;
 
 public class Comment extends ModelWithId<Comment, IDatabases> implements Comparable<Comment>{
   
-  public static final long serialVersionUID = 8036617193786054443L;
+  public static final long serialVersionUID = 6213989608937906012L;
 
   public static class Tbl extends AbstractTable<Comment.Attributes, Comment> {
     public final Column ID;
@@ -453,7 +456,7 @@ public class Comment extends ModelWithId<Comment, IDatabases> implements Compara
   
   public static class Attributes extends AttributesWithId {
     
-    public static final long serialVersionUID = 5448907628943892063L;
+    public static final long serialVersionUID = -2156535913590481279L;
 
     // Fields
     private String __content;

--- a/test/java/com/rapleaf/jack/test_project/database_1/models/Comment.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/models/Comment.java
@@ -7,27 +7,24 @@
 package com.rapleaf.jack.test_project.database_1.models;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.List;
-import java.util.ArrayList;
 
-import com.rapleaf.jack.ModelWithId;
+import com.rapleaf.jack.AssociationType;
 import com.rapleaf.jack.AttributesWithId;
 import com.rapleaf.jack.BelongsToAssociation;
-import com.rapleaf.jack.HasManyAssociation;
-import com.rapleaf.jack.HasOneAssociation;
-import com.rapleaf.jack.ModelIdWrapper;
+import com.rapleaf.jack.DefaultAssociationMetadata;
 import com.rapleaf.jack.IAssociationMetadata;
 import com.rapleaf.jack.IModelAssociationMetadata;
-import com.rapleaf.jack.DefaultAssociationMetadata;
-import com.rapleaf.jack.AssociationType;
+import com.rapleaf.jack.ModelIdWrapper;
+import com.rapleaf.jack.ModelWithId;
 import com.rapleaf.jack.queries.AbstractTable;
 import com.rapleaf.jack.queries.Column;
-
 import com.rapleaf.jack.test_project.IDatabases;
 import com.rapleaf.jack.util.JackUtility;
 
@@ -35,7 +32,7 @@ public class Comment extends ModelWithId<Comment, IDatabases> implements Compara
   
   public static final long serialVersionUID = 8036617193786054443L;
 
-  public static class Tbl extends AbstractTable {
+  public static class Tbl extends AbstractTable<Comment.Attributes, Comment> {
     public final Column ID;
     public final Column CONTENT;
     public final Column COMMENTER_ID;

--- a/test/java/com/rapleaf/jack/test_project/database_1/models/Image.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/models/Image.java
@@ -40,7 +40,7 @@ public class Image extends ModelWithId<Image, IDatabases> implements Comparable<
     public final Column USER_ID;
 
     private Tbl(String alias) {
-      super("images", alias);
+      super("images", alias, Image.Attributes.class, Image.class);
       this.ID = Column.fromId(alias);
       this.USER_ID = Column.fromField(alias, _Fields.user_id, Integer.class);
       Collections.addAll(this.allColumns, ID, USER_ID);

--- a/test/java/com/rapleaf/jack/test_project/database_1/models/Image.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/models/Image.java
@@ -33,7 +33,7 @@ import com.rapleaf.jack.util.JackUtility;
 
 public class Image extends ModelWithId<Image, IDatabases> implements Comparable<Image>{
   
-  public static final long serialVersionUID = 2502129457421563432L;
+  public static final long serialVersionUID = -3351451520429699622L;
 
   public static class Tbl extends AbstractTable<Image.Attributes, Image> {
     public final Column ID;
@@ -290,7 +290,7 @@ public class Image extends ModelWithId<Image, IDatabases> implements Comparable<
   
   public static class Attributes extends AttributesWithId {
     
-    public static final long serialVersionUID = 1258217664023344706L;
+    public static final long serialVersionUID = 5384617403533794948L;
 
     // Fields
     private Integer __user_id;

--- a/test/java/com/rapleaf/jack/test_project/database_1/models/Image.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/models/Image.java
@@ -35,7 +35,7 @@ public class Image extends ModelWithId<Image, IDatabases> implements Comparable<
   
   public static final long serialVersionUID = 2502129457421563432L;
 
-  public static class Tbl extends AbstractTable {
+  public static class Tbl extends AbstractTable<Image.Attributes, Image> {
     public final Column ID;
     public final Column USER_ID;
 

--- a/test/java/com/rapleaf/jack/test_project/database_1/models/Post.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/models/Post.java
@@ -35,7 +35,7 @@ public class Post extends ModelWithId<Post, IDatabases> implements Comparable<Po
   
   public static final long serialVersionUID = -1518028829029140792L;
 
-  public static class Tbl extends AbstractTable {
+  public static class Tbl extends AbstractTable<Post.Attributes, Post> {
     public final Column ID;
     public final Column TITLE;
     public final Column POSTED_AT_MILLIS;

--- a/test/java/com/rapleaf/jack/test_project/database_1/models/Post.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/models/Post.java
@@ -43,7 +43,7 @@ public class Post extends ModelWithId<Post, IDatabases> implements Comparable<Po
     public final Column UPDATED_AT;
 
     private Tbl(String alias) {
-      super("posts", alias);
+      super("posts", alias, Post.Attributes.class, Post.class);
       this.ID = Column.fromId(alias);
       this.TITLE = Column.fromField(alias, _Fields.title, String.class);
       this.POSTED_AT_MILLIS = Column.fromField(alias, _Fields.posted_at_millis, Long.class);

--- a/test/java/com/rapleaf/jack/test_project/database_1/models/Post.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/models/Post.java
@@ -33,7 +33,7 @@ import com.rapleaf.jack.util.JackUtility;
 
 public class Post extends ModelWithId<Post, IDatabases> implements Comparable<Post>{
   
-  public static final long serialVersionUID = -1518028829029140792L;
+  public static final long serialVersionUID = -399049548729901546L;
 
   public static class Tbl extends AbstractTable<Post.Attributes, Post> {
     public final Column ID;
@@ -411,7 +411,7 @@ public class Post extends ModelWithId<Post, IDatabases> implements Comparable<Po
   
   public static class Attributes extends AttributesWithId {
     
-    public static final long serialVersionUID = -1641110165272227035L;
+    public static final long serialVersionUID = -452436965662476312L;
 
     // Fields
     private String __title;

--- a/test/java/com/rapleaf/jack/test_project/database_1/models/User.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/models/User.java
@@ -7,26 +7,29 @@
 package com.rapleaf.jack.test_project.database_1.models;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.List;
+import java.util.ArrayList;
 
-import com.rapleaf.jack.AssociationType;
+import com.rapleaf.jack.ModelWithId;
 import com.rapleaf.jack.AttributesWithId;
-import com.rapleaf.jack.DefaultAssociationMetadata;
+import com.rapleaf.jack.BelongsToAssociation;
 import com.rapleaf.jack.HasManyAssociation;
 import com.rapleaf.jack.HasOneAssociation;
+import com.rapleaf.jack.ModelIdWrapper;
 import com.rapleaf.jack.IAssociationMetadata;
 import com.rapleaf.jack.IModelAssociationMetadata;
-import com.rapleaf.jack.ModelIdWrapper;
-import com.rapleaf.jack.ModelWithId;
+import com.rapleaf.jack.DefaultAssociationMetadata;
+import com.rapleaf.jack.AssociationType;
 import com.rapleaf.jack.queries.AbstractTable;
 import com.rapleaf.jack.queries.Column;
+
 import com.rapleaf.jack.test_project.IDatabases;
+import com.rapleaf.jack.util.JackUtility;
 
 public class User extends ModelWithId<User, IDatabases> implements Comparable<User>{
   

--- a/test/java/com/rapleaf/jack/test_project/database_1/models/User.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/models/User.java
@@ -7,30 +7,33 @@
 package com.rapleaf.jack.test_project.database_1.models;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.List;
+import java.util.ArrayList;
 
-import com.rapleaf.jack.AssociationType;
+import com.rapleaf.jack.ModelWithId;
 import com.rapleaf.jack.AttributesWithId;
-import com.rapleaf.jack.DefaultAssociationMetadata;
+import com.rapleaf.jack.BelongsToAssociation;
 import com.rapleaf.jack.HasManyAssociation;
 import com.rapleaf.jack.HasOneAssociation;
+import com.rapleaf.jack.ModelIdWrapper;
 import com.rapleaf.jack.IAssociationMetadata;
 import com.rapleaf.jack.IModelAssociationMetadata;
-import com.rapleaf.jack.ModelIdWrapper;
-import com.rapleaf.jack.ModelWithId;
+import com.rapleaf.jack.DefaultAssociationMetadata;
+import com.rapleaf.jack.AssociationType;
 import com.rapleaf.jack.queries.AbstractTable;
 import com.rapleaf.jack.queries.Column;
+
 import com.rapleaf.jack.test_project.IDatabases;
+import com.rapleaf.jack.util.JackUtility;
 
 public class User extends ModelWithId<User, IDatabases> implements Comparable<User>{
   
-  public static final long serialVersionUID = 2764180304945930907L;
+  public static final long serialVersionUID = -966057050205502149L;
 
   public static class Tbl extends AbstractTable<User.Attributes, User> {
     public final Column ID;
@@ -610,7 +613,7 @@ public class User extends ModelWithId<User, IDatabases> implements Comparable<Us
   
   public static class Attributes extends AttributesWithId {
     
-    public static final long serialVersionUID = 5810949180036000899L;
+    public static final long serialVersionUID = 7482296567648746981L;
 
     // Fields
     private String __handle;

--- a/test/java/com/rapleaf/jack/test_project/database_1/models/User.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/models/User.java
@@ -7,29 +7,26 @@
 package com.rapleaf.jack.test_project.database_1.models;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.List;
-import java.util.ArrayList;
 
-import com.rapleaf.jack.ModelWithId;
+import com.rapleaf.jack.AssociationType;
 import com.rapleaf.jack.AttributesWithId;
-import com.rapleaf.jack.BelongsToAssociation;
+import com.rapleaf.jack.DefaultAssociationMetadata;
 import com.rapleaf.jack.HasManyAssociation;
 import com.rapleaf.jack.HasOneAssociation;
-import com.rapleaf.jack.ModelIdWrapper;
 import com.rapleaf.jack.IAssociationMetadata;
 import com.rapleaf.jack.IModelAssociationMetadata;
-import com.rapleaf.jack.DefaultAssociationMetadata;
-import com.rapleaf.jack.AssociationType;
+import com.rapleaf.jack.ModelIdWrapper;
+import com.rapleaf.jack.ModelWithId;
 import com.rapleaf.jack.queries.AbstractTable;
 import com.rapleaf.jack.queries.Column;
-
 import com.rapleaf.jack.test_project.IDatabases;
-import com.rapleaf.jack.util.JackUtility;
 
 public class User extends ModelWithId<User, IDatabases> implements Comparable<User>{
   
@@ -49,7 +46,7 @@ public class User extends ModelWithId<User, IDatabases> implements Comparable<Us
     public final Column SOME_BOOLEAN;
 
     private Tbl(String alias) {
-      super("users", alias);
+      super("users", alias, User.Attributes.class, User.class);
       this.ID = Column.fromId(alias);
       this.HANDLE = Column.fromField(alias, _Fields.handle, String.class);
       this.CREATED_AT_MILLIS = Column.fromField(alias, _Fields.created_at_millis, Long.class);

--- a/test/java/com/rapleaf/jack/test_project/database_1/models/User.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/models/User.java
@@ -7,35 +7,32 @@
 package com.rapleaf.jack.test_project.database_1.models;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.List;
-import java.util.ArrayList;
 
-import com.rapleaf.jack.ModelWithId;
+import com.rapleaf.jack.AssociationType;
 import com.rapleaf.jack.AttributesWithId;
-import com.rapleaf.jack.BelongsToAssociation;
+import com.rapleaf.jack.DefaultAssociationMetadata;
 import com.rapleaf.jack.HasManyAssociation;
 import com.rapleaf.jack.HasOneAssociation;
-import com.rapleaf.jack.ModelIdWrapper;
 import com.rapleaf.jack.IAssociationMetadata;
 import com.rapleaf.jack.IModelAssociationMetadata;
-import com.rapleaf.jack.DefaultAssociationMetadata;
-import com.rapleaf.jack.AssociationType;
+import com.rapleaf.jack.ModelIdWrapper;
+import com.rapleaf.jack.ModelWithId;
 import com.rapleaf.jack.queries.AbstractTable;
 import com.rapleaf.jack.queries.Column;
-
 import com.rapleaf.jack.test_project.IDatabases;
-import com.rapleaf.jack.util.JackUtility;
 
 public class User extends ModelWithId<User, IDatabases> implements Comparable<User>{
   
   public static final long serialVersionUID = 2764180304945930907L;
 
-  public static class Tbl extends AbstractTable {
+  public static class Tbl extends AbstractTable<User.Attributes, User> {
     public final Column ID;
     public final Column HANDLE;
     public final Column CREATED_AT_MILLIS;


### PR DESCRIPTION
@bpodgursky, this pull request incorporates your `JackUtil` into the `Record` and `Records` classes. The main change is that the new method takes one `Table` parameter, instead of the model and attributes types. Those information is wrapped in `Table`. So the method call is slightly simplier. A bug fix is also included in this pull request. It turns out that SQL sometimes returns double value as `BigDecimal` or `Float`. These types are put in special checks.

Since `Attributes` is already a plural word, the methods for retrieving attributes are the same for `Record` and `Records`: `Record#getAttributes` returns one `Attributes`, and `Records#getAttributes` returns a list of it.

If the user tries to retrieve the model / attributes of a table whose fields do not exist in the `Record`, `null` will be returned. I think `null` is legitimate since outer join is supported in the generic query. However, I am not sure if it is better to return an `Optional` and use `Optional.absent()` to replace the `null` case. If there is no objection, I will keep returning `null`.

I still have issues with the `UID`. When I use ruby `ree-1.8.7`, the `UID` changes, and there is one more change in `Gemfile.lock`:
```
 DEPENDENCIES
   activesupport (>= 3.0.0)
-  i18n
+  i18n (= 0.5.0)
```
When I use ruby `1.9.3`, the `UID` remains the same, and there is again a change in `Gemfile.lock`:
```
 DEPENDENCIES
   activesupport (>= 3.0.0)
-  i18n
+  i18n (= 0.5.0)
+
+BUNDLED WITH
+   1.10.5
```
It looks like the change in `Gemfile` is inevitable. I suspect that someone used `1.9.3` in a previous pull request and changed the `UID` accidentally. So I should probably push the `UID` change with `ree-1.8.7` this time to revert them back. Will check with `Admin`.

We should probably add a `.ruby-version` file to prevent the confusing.
