### PR TITLE
Integer COUNT

### DIFF
--- a/src/java/com/rapleaf/jack/queries/AggregatedColumn.java
+++ b/src/java/com/rapleaf/jack/queries/AggregatedColumn.java
@@ -13,12 +13,8 @@ public class AggregatedColumn<T> extends Column<T> {
     this.function = function;
   }
 
-  // TODO: modify COUNT to the following once all production code of generic query has been updated.
-  // public static AggregatedColumn<Integer> COUNT(Column column) {
-  //   return new AggregatedColumn<Integer>(column, Function.COUNT);
-  // }
-  public static <T> AggregatedColumn<T> COUNT(Column<T> column) {
-    return new AggregatedColumn<T>(column, Function.COUNT);
+  public static <T> AggregatedColumn<Integer> COUNT(Column<T> column) {
+    return new AggregatedColumn<Integer>(column, Function.COUNT);
   }
 
   public static <T extends Number> AggregatedColumn<Number> AVG(Column<T> column) {


### PR DESCRIPTION
The return type of COUNT query should be integer. `Integer.MAX_VALUE` is more than two billion, and should be enough to cover the number of entries in a database.
