### PR TITLE
Make UID the same on 1.8.7 and 1.9.3

### DIFF
--- a/src/rb/model_defn.rb
+++ b/src/rb/model_defn.rb
@@ -109,13 +109,13 @@ class ModelDefn
   end
   
   def serial_version_uid
-    schema_info = @fields.map{|f| "#{f.name}#{f.data_type}#{f.ordinal}#{f.args.sort_by{|h| h.join}}"}.join
+    schema_info = @fields.map{|f| "#{f.name}#{f.data_type}#{f.ordinal}#{f.args.sort_by{|h| h.join}.join("")}"}.join
     schema_info += @associations.map{|a| "#{a.type}#{a.name}#{a.assoc_model_name}"}.join
     Digest::MD5.digest(schema_info).unpack('q')[0]
   end
 
   def attributes_serial_version_uid
-    schema_info = @fields.map{|f| "#{f.name}#{f.data_type}#{f.ordinal}#{f.args.sort_by{|h| h.join}}"}.join
+    schema_info = @fields.map{|f| "#{f.name}#{f.data_type}#{f.ordinal}#{f.args.sort_by{|h| h.join}.join("")}"}.join
     Digest::MD5.digest(schema_info).unpack('q')[0]
   end
 


### PR DESCRIPTION
I suspect this is all we need. 

```
$ rbenv version
1.9.3-p551 (set by /Users/rgeorge/code/jack/.ruby-version)
rgeorge@Roshans-MacBook-Pro:~/code/jack [constantify-uid] 17:23
$ test/regen_code.sh
6213989608937906012
-2156535913590481279
-3351451520429699622
5384617403533794948
2267084843778072603
2267084843778072603
-399049548729901546
-452436965662476312
-966057050205502149
7482296567648746981
rgeorge@Roshans-MacBook-Pro:~/code/jack [constantify-uid] 17:23
$ rm .ruby-version
rgeorge@Roshans-MacBook-Pro:~/code/jack [constantify-uid] 17:23
$ test/regen_code.sh
6213989608937906012
-2156535913590481279
-3351451520429699622
5384617403533794948
2267084843778072603
2267084843778072603
-399049548729901546
-452436965662476312
-966057050205502149
7482296567648746981
```