### PR TITLE
Move createQuery up to IDb interface

### DIFF
--- a/src/java/com/rapleaf/jack/IDb.java
+++ b/src/java/com/rapleaf/jack/IDb.java
@@ -14,6 +14,8 @@
 // limitations under the License.
 package com.rapleaf.jack;
 
+import com.rapleaf.jack.queries.GenericQuery;
+
 import java.io.IOException;
 import java.io.Serializable;
 
@@ -39,4 +41,6 @@ public interface IDb extends Serializable {
   public void rollback();
 
   public void resetConnection();
+
+  GenericQuery.Builder createQuery();
 }

--- a/src/rb/templates/db_interface.erb
+++ b/src/rb/templates/db_interface.erb
@@ -25,7 +25,6 @@ import <%= "#{root_package}.iface.#{model_defn.iface_name};" %>
 import <%= project_defn.databases_namespace %>.IDatabases;
 
 public interface I<%= db_name %> extends IDb {
-  public GenericQuery.Builder createQuery();
   public IDatabases getDatabases();
 
 <% model_defns.each do |model_defn| %>


### PR DESCRIPTION
This allows us to write code that operates on any DB. Our use case is generic status setting across models.