### PR TITLE
Add ability to specify update time for testing

### DIFF
--- a/src/java/com/rapleaf/jack/AbstractDatabaseModel.java
+++ b/src/java/com/rapleaf/jack/AbstractDatabaseModel.java
@@ -622,8 +622,8 @@ public abstract class AbstractDatabaseModel<T extends ModelWithId<T, ? extends G
     return (Integer)model.getField(lockFieldName);
   }
 
-  public boolean saveStrict(T model) throws JackException, IOException {
-    Long oldUpdatedAt = handleRailsUpdatedAt(model);
+  public boolean saveStrict(long updateTimeMillis, T model) throws JackException, IOException {
+    Long oldUpdatedAt = handleRailsUpdatedAt(updateTimeMillis, model);
     if (model.isCreated()) {
 
       if (supportsOptimisticLocking(model)) {
@@ -714,8 +714,13 @@ public abstract class AbstractDatabaseModel<T extends ModelWithId<T, ? extends G
 
   @Override
   public boolean save(T model) throws IOException {
+    return save(System.currentTimeMillis(), model);
+  }
+
+  @Override
+  public boolean save(long updateTimeMillis, T model) throws IOException {
     try {
-      return saveStrict(model);
+      return saveStrict(updateTimeMillis, model);
     } catch (JackException e) {
       return false;
     }
@@ -848,10 +853,10 @@ public abstract class AbstractDatabaseModel<T extends ModelWithId<T, ? extends G
     return false;
   }
 
-  private long handleRailsUpdatedAt(T model) {
+  private long handleRailsUpdatedAt(long updateTimeMillis, T model) {
     if (updatedAtCanBeHandled(model)) {
       long oldUpdatedAt = (Long)model.getField("updated_at");
-      model.setField("updated_at", System.currentTimeMillis());
+      model.setField("updated_at", updateTimeMillis);
       // return old value in case save fails and we need to reset
       return oldUpdatedAt;
     }

--- a/src/java/com/rapleaf/jack/IModelPersistence.java
+++ b/src/java/com/rapleaf/jack/IModelPersistence.java
@@ -41,6 +41,17 @@ public interface IModelPersistence<T extends ModelWithId> extends Serializable {
   public boolean save(T model) throws IOException;
 
   /**
+   * Update an existing T instance in the persistence. This method allows you to manually specify an update time
+   * and should only be used for testing.
+   *
+   * @param updateTimeMillis
+   * @param model
+   * @return
+   * @throws IOException
+   */
+  boolean save(long updateTimeMillis, T model) throws IOException;
+
+  /**
    * Find the T instance with specified id, or null if there is no such instance.
    *
    * @param id
@@ -56,7 +67,7 @@ public interface IModelPersistence<T extends ModelWithId> extends Serializable {
   public List<T> find(Set<Long> ids, Map<Enum, Object> fieldsMap) throws IOException;
 
   public List<T> find(ModelQuery query) throws IOException;
-  
+
   public List<T> findWithOrder(ModelQuery query) throws IOException;
 
   public boolean delete(ModelDelete delete) throws IOException;

--- a/test/java/com/rapleaf/jack/TestModelWithID.java
+++ b/test/java/com/rapleaf/jack/TestModelWithID.java
@@ -92,6 +92,15 @@ public class TestModelWithID extends TestCase {
     }
   }
 
+  public void testManualUpdatedAt() throws IOException {
+    postModel.setField("updated_at", 0l);
+    long updateTime = 47l;
+    dbs.getDatabase1().posts().save(updateTime, postModel);
+
+    assertEquals("Check updated_at was updated " + postModel.getField("updated_at"),
+        updateTime, ((Long)postModel.getField("updated_at")).longValue());
+  }
+
   public void testClearAssociations() throws IOException {
 
     assertNull(imageModel.getUser());


### PR DESCRIPTION
For tests that rely on updating the database, it would be extremely helpful
to be able to set an update time for the updated_at column to be set to,
rather than having this hardcoded into the save method. This adds that
while also keeping the default behavior.

@bpodgursky 