### PR TITLE
Remove redundant `public` specifiers from Jack-generated interfaces

### DIFF
--- a/src/rb/templates/databases_iface.erb
+++ b/src/rb/templates/databases_iface.erb
@@ -24,6 +24,6 @@ import <%= JACK_NAMESPACE %>.GenericDatabases;
 
 public interface IDatabases extends GenericDatabases {
   <% project_defn.databases.each do |db| %>
-  public I<%= db.name %> <%= db.getter %>;
+  I<%= db.name %> <%= db.getter %>;
   <% end %>
 }

--- a/src/rb/templates/db_interface.erb
+++ b/src/rb/templates/db_interface.erb
@@ -25,10 +25,10 @@ import <%= "#{root_package}.iface.#{model_defn.iface_name};" %>
 import <%= project_defn.databases_namespace %>.IDatabases;
 
 public interface I<%= db_name %> extends IDb {
-  public IDatabases getDatabases();
+  IDatabases getDatabases();
 
 <% model_defns.each do |model_defn| %>
-  public <%="#{model_defn.iface_name} #{model_defn.persistence_getter}" %>;
+  <%="#{model_defn.iface_name} #{model_defn.persistence_getter}" %>;
 <% end%>
 
 }

--- a/src/rb/templates/persistence_interface.erb
+++ b/src/rb/templates/persistence_interface.erb
@@ -27,18 +27,18 @@ import java.util.List;
 import <%= JACK_NAMESPACE %>.IModelPersistence;
 
 public interface <%= model_defn.iface_name %> extends IModelPersistence<<%= model_defn.model_name %>> {
-  public <%= model_defn.model_name %> create(<%= create_signature_full %>) throws IOException;
+  <%= model_defn.model_name %> create(<%= create_signature_full %>) throws IOException;
   <% unless create_signature_small.nil? %>
-  public <%= model_defn.model_name %> create(<%= create_signature_small %>) throws IOException;
+  <%= model_defn.model_name %> create(<%= create_signature_small %>) throws IOException;
   <% end %>
 
-  public <%= model_defn.model_name %> createDefaultInstance() throws IOException;
+  <%= model_defn.model_name %> createDefaultInstance() throws IOException;
 
   <% model_defn.fields.each do |field_defn| %>
-  public List<<%= model_defn.model_name %>> findBy<%= field_defn.name.camelcase %>(<%= field_defn.java_type %> value)  throws IOException;
+  List<<%= model_defn.model_name %>> findBy<%= field_defn.name.camelcase %>(<%= field_defn.java_type %> value)  throws IOException;
   <% end %>
 
-  public <%= model_defn.query_builder_name %> query();
+  <%= model_defn.query_builder_name %> query();
 
-  public <%= model_defn.delete_builder_name %> delete();
+  <%= model_defn.delete_builder_name %> delete();
 }


### PR DESCRIPTION
The `public` specifier Jack puts on its interface methods is unnecessary and
clutters the output code. This change removes that.

@bpodgursky 