### PR TITLE
Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,6 @@ install:
 before_script:
   - export RAILS_ENV=development
   - test/select-dbms.sh mysql
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,26 @@
 
     <plugins>
       <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.7.7.201606060606</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <artifactId>exec-maven-plugin</artifactId>
         <groupId>org.codehaus.mojo</groupId>
         <version>1.3.2</version>


### PR DESCRIPTION
Since we have Travis CI now, we could easily incorporate other badges, like the test coverage:

[![image](https://codecov.io/github/tuliren/jack/coverage.svg?branch=codecov)](https://codecov.io/gh/tuliren/jack/branch/codecov)

This one is not as useful as the build status though.
