### PR TITLE
add support for namespaced models

### DIFF
--- a/src/rb/models_dir_processor.rb
+++ b/src/rb/models_dir_processor.rb
@@ -1,11 +1,11 @@
 # Copyright 2011 Rapleaf
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,22 +15,18 @@
 class ModelsDirProcessor
   def self.process(base_dir, database_defn, model_defns_by_table_name)
     models_dir = base_dir + "/" + database_defn.models_dir
-    Dir.open(models_dir) do |dir|
-      dir.each do |model_file_name|
-        if model_file_name =~ /\.rb$/
-          model_content = File.read(File.expand_path(models_dir) + "/" + model_file_name)
-          if model_content =~ /^\s*(belongs_to)|(has_one)|(has_many)/ || model_content =~ / < ActiveRecord::Base/ && model_content !~ /self.abstract_class = true/
-            lines = model_content.split("\n").reject {|l| l =~ /^\s*#/}
-            process_model(lines, database_defn, model_defns_by_table_name)
-          end
-        end
+    Dir.glob("#{models_dir}/**/*.rb").each do |model_file_name|
+      model_content = File.read(model_file_name)
+      if model_content =~ /^\s*(belongs_to)|(has_one)|(has_many)/ || model_content =~ / < ActiveRecord::Base/ && model_content !~ /self.abstract_class = true/
+        lines = model_content.split("\n").reject {|l| l =~ /^\s*#/}
+        process_model(lines, database_defn, model_defns_by_table_name)
       end
     end
   end
 
   def self.process_model(model_content_lines, database_defn, model_defns_by_table_name)
     class_name = get_class_name(model_content_lines)
-    table_name = class_name.underscore.pluralize
+    table_name = class_name.split('::').last.underscore.pluralize
 
     if md = model_defns_by_table_name[table_name]
       md.associations = parse_associations(model_content_lines, "belongs_to ", md) +
@@ -48,7 +44,7 @@ class ModelsDirProcessor
     raise "coulnd't find an appropriate class name for this model! #{model_content_lines.first}" if class_lines.empty? && arb_lines.empty?
     arb_lines.empty? ? class_lines.first : arb_lines.first.split(" ")[1]
   end
-  
+
   def self.parse_associations(lines, matches, model_defn, not_matches = nil)
     matching_lines = lines.select{|l| l =~ /^\s*#{matches}/}
     if not_matches


### PR DESCRIPTION
@tuliren @bpodgursky -- Can you guys take a look? Tested this with rldb and workflow_db. Caused a minor change in rldb, but I think it's the correct behavior.

The intention here is to add support for namespaced models. We want to do this as we're adding new DBs to avoid naming conflicts.

This PR does two things:

1. Looks for models in recursive subdirs of models dir. Previously only looked for `.rb` files in `app/models`.
2. Strips namespaces from class names (e.g., `MyNamespace::Model` --> `Model`). This assumes that the table naming convention for namespaced models is `MyNamespace::Model` is `models` instead of `my_namespace_models`. I don't see a nice way around this without completely refactoring Jack to not use dumb regex parsing.