### PR TITLE
Fix syntax error generation in database.yml

### DIFF
--- a/test/update_database_yml.sh
+++ b/test/update_database_yml.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-cat $1 | sed "s/username: root/username: $2/" | sed "s/password:/password: $3/" > build/database.yml.tmp
+cat $1 | sed "s/username:.*/username: $2/" | sed "s/password:.*/password: $3/" > build/database.yml.tmp
 cp build/database.yml.tmp $1


### PR DESCRIPTION
If update_database_yml.sh is called multiple times, it will leave
a syntax error in database.yml. This fixes that.

@bpodgursky 