### PR TITLE
Add rudimentary query performance tracking to Jack

### DIFF
--- a/src/java/com/rapleaf/jack/queries/Records.java
+++ b/src/java/com/rapleaf/jack/queries/Records.java
@@ -8,9 +8,11 @@ import com.google.common.collect.Lists;
 import com.rapleaf.jack.AttributesWithId;
 import com.rapleaf.jack.GenericDatabases;
 import com.rapleaf.jack.ModelWithId;
+import com.rapleaf.jack.tracking.QueryStatistics;
 
 public class Records implements Iterable<Record> {
   private final List<Record> records;
+  private QueryStatistics queryStatistics;
 
   Records() {
     this.records = Lists.newArrayList();
@@ -18,6 +20,10 @@ public class Records implements Iterable<Record> {
 
   void addRecord(Record record) {
     records.add(record);
+  }
+
+  void addStatistics(QueryStatistics statistics) {
+    this.queryStatistics = statistics;
   }
 
   public boolean isEmpty() {
@@ -110,6 +116,10 @@ public class Records implements Iterable<Record> {
       results.add(record.getModel(tableType, databases));
     }
     return results;
+  }
+
+  public QueryStatistics getQueryStatistics() {
+    return queryStatistics;
   }
 
   @Override

--- a/src/java/com/rapleaf/jack/tracking/NoOpAction.java
+++ b/src/java/com/rapleaf/jack/tracking/NoOpAction.java
@@ -1,0 +1,6 @@
+package com.rapleaf.jack.tracking;
+
+public class NoOpAction implements PostQueryAction {
+  @Override
+  public void perform(QueryStatistics statistics) { }
+}

--- a/src/java/com/rapleaf/jack/tracking/PostQueryAction.java
+++ b/src/java/com/rapleaf/jack/tracking/PostQueryAction.java
@@ -1,0 +1,5 @@
+package com.rapleaf.jack.tracking;
+
+public interface PostQueryAction {
+  void perform(QueryStatistics statistics);
+}

--- a/src/java/com/rapleaf/jack/tracking/QueryStatistics.java
+++ b/src/java/com/rapleaf/jack/tracking/QueryStatistics.java
@@ -1,0 +1,47 @@
+package com.rapleaf.jack.tracking;
+
+public class QueryStatistics {
+  public final long executionTimeNanos;
+  public final long queryPrepTimeNanos;
+  public final long numTries;
+
+  public QueryStatistics(long executionTimeNanos, long queryPrepTimeNanos, long numTries) {
+    this.executionTimeNanos = executionTimeNanos;
+    this.queryPrepTimeNanos = queryPrepTimeNanos;
+    this.numTries = numTries;
+  }
+
+  public static class Measurer {
+
+    private long queryPrepStart;
+    private long queryPrepEnd;
+    private long queryExecStart;
+    private long queryExecEnd;
+    private long tries = 0;
+
+    public void recordQueryPrepStart() {
+      queryPrepStart = System.nanoTime();
+    }
+
+    public void recordQueryPrepEnd() {
+      queryPrepEnd = System.nanoTime();
+    }
+
+    public void recordQueryExecStart() {
+      queryExecStart = System.nanoTime();
+    }
+
+    public void recordQueryExecEnd() {
+      queryExecEnd = System.nanoTime();
+    }
+
+    public void recordAttempt() {
+      tries++;
+    }
+
+    public QueryStatistics calculate() {
+      return new QueryStatistics(queryExecEnd - queryExecStart, queryPrepEnd - queryPrepStart, tries);
+    }
+  }
+
+}

--- a/src/rb/templates/databases_impl.erb
+++ b/src/rb/templates/databases_impl.erb
@@ -22,6 +22,8 @@ import <%= JACK_NAMESPACE %>.DatabaseConnection;
 import <%= db.namespace %>.I<%= db.name %>;
 import <%= db.namespace %>.impl.<%= db.name %>Impl;
 <% end %>
+import com.rapleaf.jack.tracking.PostQueryAction;
+import com.rapleaf.jack.tracking.NoOpAction;
 
 public class DatabasesImpl implements IDatabases {
 
@@ -33,16 +35,21 @@ public class DatabasesImpl implements IDatabases {
   }
 
   public DatabasesImpl(<%= project_defn.databases.map{|db| ["BaseDatabaseConnection", db.connection_name].join(" ")}.join(", ") %>) {
+    this(new NoOpAction(), <%= project_defn.databases.map{|db| db.connection_name}.join(", ") %>);
+  }
+
+  public DatabasesImpl(PostQueryAction postQueryAction, <%= project_defn.databases.map{|db| ["BaseDatabaseConnection", db.connection_name].join(" ")}.join(", ") %>) {
     <% project_defn.databases.each do |db| %>
-    this.<%= db.name.underscore %> = new <%= db.name %>Impl(<%= db.connection_name %>, this);
+    this.<%= db.name.underscore %> = new <%= db.name %>Impl(<%= db.connection_name %>, this, postQueryAction);
     <% end %>
   }
+
 
   <% project_defn.databases.each do |db| %>
 
   public I<%= db.name %> <%= db.getter %> {
     if (<%= db.name.underscore %> == null) {
-      this.<%= db.name.underscore %> = new <%= db.name %>Impl(new DatabaseConnection("<%= db.name.underscore %>"), this);
+      this.<%= db.name.underscore %> = new <%= db.name %>Impl(new DatabaseConnection("<%= db.name.underscore %>"), this, new NoOpAction());
     }
     return <%= db.name.underscore %>;
   }

--- a/src/rb/templates/db_impl.erb
+++ b/src/rb/templates/db_impl.erb
@@ -28,19 +28,22 @@ import <%= root_package %>.iface.<%= model_defn.iface_name %>;
 <% end%>
 
 import <%= project_defn.databases_namespace %>.IDatabases;
+import com.rapleaf.jack.tracking.PostQueryAction;
 
 public class <%=db_name%>Impl implements I<%=db_name%> {
   
   private final BaseDatabaseConnection conn;
   private final IDatabases databases;
+  private final PostQueryAction postQueryAction;
 
 <% model_defns.each do |model_defn| %>
   private final LazyLoadPersistence<<%= model_defn.iface_name %>, IDatabases> <%= model_defn.table_name %>;
 <% end %>
 
-  public <%=db_name%>Impl(BaseDatabaseConnection conn, IDatabases databases) {
+  public <%=db_name%>Impl(BaseDatabaseConnection conn, IDatabases databases, PostQueryAction postQueryAction) {
     this.conn = conn;
     this.databases = databases;
+    this.postQueryAction = postQueryAction;
     
   <% model_defns.each do |model_defn| %>
     this.<%= model_defn.table_name %> = new LazyLoadPersistence<<%= model_defn.iface_name %>, IDatabases>(conn, databases) {
@@ -53,7 +56,9 @@ public class <%=db_name%>Impl implements I<%=db_name%> {
   }
 
   public GenericQuery.Builder createQuery() {
-    return GenericQuery.create(conn);
+    final GenericQuery.Builder builder = GenericQuery.create(conn);
+    builder.setPostQueryAction(postQueryAction);
+    return builder;
   }
 
   <% model_defns.each do |model_defn| %>

--- a/test/java/com/rapleaf/jack/test_project/DatabasesImpl.java
+++ b/test/java/com/rapleaf/jack/test_project/DatabasesImpl.java
@@ -10,6 +10,8 @@ import com.rapleaf.jack.BaseDatabaseConnection;
 import com.rapleaf.jack.DatabaseConnection;
 import com.rapleaf.jack.test_project.database_1.IDatabase1;
 import com.rapleaf.jack.test_project.database_1.impl.Database1Impl;
+import com.rapleaf.jack.tracking.PostQueryAction;
+import com.rapleaf.jack.tracking.NoOpAction;
 
 public class DatabasesImpl implements IDatabases {
   private IDatabase1 database1;
@@ -18,12 +20,16 @@ public class DatabasesImpl implements IDatabases {
   }
 
   public DatabasesImpl(BaseDatabaseConnection database1_connection) {
-    this.database1 = new Database1Impl(database1_connection, this);
+    this(new NoOpAction(), database1_connection);
+  }
+
+  public DatabasesImpl(PostQueryAction postQueryAction, BaseDatabaseConnection database1_connection) {
+    this.database1 = new Database1Impl(database1_connection, this, postQueryAction);
   }
 
   public IDatabase1 getDatabase1() {
     if (database1 == null) {
-      this.database1 = new Database1Impl(new DatabaseConnection("database1"), this);
+      this.database1 = new Database1Impl(new DatabaseConnection("database1"), this, new NoOpAction());
     }
     return database1;
   }

--- a/test/java/com/rapleaf/jack/test_project/database_1/impl/Database1Impl.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/impl/Database1Impl.java
@@ -19,20 +19,23 @@ import com.rapleaf.jack.test_project.database_1.iface.IPostPersistence;
 import com.rapleaf.jack.test_project.database_1.iface.IUserPersistence;
 
 import com.rapleaf.jack.test_project.IDatabases;
+import com.rapleaf.jack.tracking.PostQueryAction;
 
 public class Database1Impl implements IDatabase1 {
   
   private final BaseDatabaseConnection conn;
   private final IDatabases databases;
+  private final PostQueryAction postQueryAction;
   private final LazyLoadPersistence<ICommentPersistence, IDatabases> comments;
   private final LazyLoadPersistence<IImagePersistence, IDatabases> images;
   private final LazyLoadPersistence<ILockableModelPersistence, IDatabases> lockable_models;
   private final LazyLoadPersistence<IPostPersistence, IDatabases> posts;
   private final LazyLoadPersistence<IUserPersistence, IDatabases> users;
 
-  public Database1Impl(BaseDatabaseConnection conn, IDatabases databases) {
+  public Database1Impl(BaseDatabaseConnection conn, IDatabases databases, PostQueryAction postQueryAction) {
     this.conn = conn;
     this.databases = databases;
+    this.postQueryAction = postQueryAction;
     this.comments = new LazyLoadPersistence<ICommentPersistence, IDatabases>(conn, databases) {
       @Override
       protected ICommentPersistence build(BaseDatabaseConnection conn, IDatabases databases) {
@@ -66,7 +69,9 @@ public class Database1Impl implements IDatabase1 {
   }
 
   public GenericQuery.Builder createQuery() {
-    return GenericQuery.create(conn);
+    final GenericQuery.Builder builder = GenericQuery.create(conn);
+    builder.setPostQueryAction(postQueryAction);
+    return builder;
   }
 
   public ICommentPersistence comments(){


### PR DESCRIPTION
This will allow us to capture query execution time to report it elsewhere. It's simplistic so that we don't have pull in any JARs just to tell how long something took to execute.

This allows adding `PostQueryAction`s like 

```
public class MyStatsClient implements PostQueryAction {
  @Override
  public void perform(QueryStatistics statistics) {
    final StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
    final StackTraceElement containingClass = stackTrace[3];
    yFavouriteStatsClient.gauge(containingClass.getClassName(), statistics.executionTimeNanos);
  }
}
```