### PR TITLE
Get rid of double curly brace initialization in persistence impls

### DIFF
--- a/src/rb/templates/persistence_impl.erb
+++ b/src/rb/templates/persistence_impl.erb
@@ -220,7 +220,9 @@ public class <%= model_defn.impl_name %> extends AbstractDatabaseModel<<%= model
   <% model_defn.fields.each do |field_defn| %>
 
   public List<<%= model_defn.model_name %>> findBy<%= field_defn.name.camelcase %>(final <%= field_defn.java_type %> value) throws IOException {
-    return find(new HashMap<Enum, Object>(){{put(<%= model_defn.model_name %>._Fields.<%= field_defn.name %>, value);}});
+    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
+    searchKey.put(<%= model_defn.model_name %>._Fields.<%= field_defn.name %>, value);
+    return find(searchKey);
   }
   <% end %>
 

--- a/src/rb/templates/persistence_impl.erb
+++ b/src/rb/templates/persistence_impl.erb
@@ -85,7 +85,7 @@ public class <%= model_defn.impl_name %> extends AbstractDatabaseModel<<%= model
 
   public List<<%= model_defn.model_name %>> find(Set<Long> ids, Map<Enum, Object> fieldsMap) throws IOException {
     List<<%= model_defn.model_name %>> foundList = new ArrayList<<%= model_defn.model_name %>>();
-    
+
     if (fieldsMap == null || fieldsMap.isEmpty()) {
       return foundList;
     }
@@ -100,7 +100,7 @@ public class <%= model_defn.impl_name %> extends AbstractDatabaseModel<<%= model
       Map.Entry<Enum, Object> entry = iter.next();
       Enum field = entry.getKey();
       Object value = entry.getValue();
-      
+
       String queryValue = value != null ? " = ? " : " IS NULL";
       if (value != null) {
         nonNullValueFields.add((<%= model_defn.model_name %>._Fields) field);
@@ -220,9 +220,7 @@ public class <%= model_defn.impl_name %> extends AbstractDatabaseModel<<%= model
   <% model_defn.fields.each do |field_defn| %>
 
   public List<<%= model_defn.model_name %>> findBy<%= field_defn.name.camelcase %>(final <%= field_defn.java_type %> value) throws IOException {
-    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
-    searchKey.put(<%= model_defn.model_name %>._Fields.<%= field_defn.name %>, value);
-    return find(searchKey);
+    return find(Collections.<Enum, Object>singletonMap(<%= model_defn.model_name %>._Fields.<%= field_defn.name %>, value));
   }
   <% end %>
 

--- a/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseCommentPersistenceImpl.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseCommentPersistenceImpl.java
@@ -245,19 +245,27 @@ public class BaseCommentPersistenceImpl extends AbstractDatabaseModel<Comment> i
   }
 
   public List<Comment> findByContent(final String value) throws IOException {
-    return find(new HashMap<Enum, Object>(){{put(Comment._Fields.content, value);}});
+    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
+    searchKey.put(Comment._Fields.content, value);
+    return find(searchKey);
   }
 
   public List<Comment> findByCommenterId(final int value) throws IOException {
-    return find(new HashMap<Enum, Object>(){{put(Comment._Fields.commenter_id, value);}});
+    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
+    searchKey.put(Comment._Fields.commenter_id, value);
+    return find(searchKey);
   }
 
   public List<Comment> findByCommentedOnId(final long value) throws IOException {
-    return find(new HashMap<Enum, Object>(){{put(Comment._Fields.commented_on_id, value);}});
+    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
+    searchKey.put(Comment._Fields.commented_on_id, value);
+    return find(searchKey);
   }
 
   public List<Comment> findByCreatedAt(final long value) throws IOException {
-    return find(new HashMap<Enum, Object>(){{put(Comment._Fields.created_at, value);}});
+    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
+    searchKey.put(Comment._Fields.created_at, value);
+    return find(searchKey);
   }
 
   public CommentQueryBuilder query() {

--- a/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseCommentPersistenceImpl.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseCommentPersistenceImpl.java
@@ -107,7 +107,7 @@ public class BaseCommentPersistenceImpl extends AbstractDatabaseModel<Comment> i
 
   public List<Comment> find(Set<Long> ids, Map<Enum, Object> fieldsMap) throws IOException {
     List<Comment> foundList = new ArrayList<Comment>();
-    
+
     if (fieldsMap == null || fieldsMap.isEmpty()) {
       return foundList;
     }
@@ -122,7 +122,7 @@ public class BaseCommentPersistenceImpl extends AbstractDatabaseModel<Comment> i
       Map.Entry<Enum, Object> entry = iter.next();
       Enum field = entry.getKey();
       Object value = entry.getValue();
-      
+
       String queryValue = value != null ? " = ? " : " IS NULL";
       if (value != null) {
         nonNullValueFields.add((Comment._Fields) field);
@@ -245,27 +245,19 @@ public class BaseCommentPersistenceImpl extends AbstractDatabaseModel<Comment> i
   }
 
   public List<Comment> findByContent(final String value) throws IOException {
-    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
-    searchKey.put(Comment._Fields.content, value);
-    return find(searchKey);
+    return find(Collections.<Enum, Object>singletonMap(Comment._Fields.content, value));
   }
 
   public List<Comment> findByCommenterId(final int value) throws IOException {
-    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
-    searchKey.put(Comment._Fields.commenter_id, value);
-    return find(searchKey);
+    return find(Collections.<Enum, Object>singletonMap(Comment._Fields.commenter_id, value));
   }
 
   public List<Comment> findByCommentedOnId(final long value) throws IOException {
-    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
-    searchKey.put(Comment._Fields.commented_on_id, value);
-    return find(searchKey);
+    return find(Collections.<Enum, Object>singletonMap(Comment._Fields.commented_on_id, value));
   }
 
   public List<Comment> findByCreatedAt(final long value) throws IOException {
-    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
-    searchKey.put(Comment._Fields.created_at, value);
-    return find(searchKey);
+    return find(Collections.<Enum, Object>singletonMap(Comment._Fields.created_at, value));
   }
 
   public CommentQueryBuilder query() {

--- a/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseImagePersistenceImpl.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseImagePersistenceImpl.java
@@ -94,7 +94,7 @@ public class BaseImagePersistenceImpl extends AbstractDatabaseModel<Image> imple
 
   public List<Image> find(Set<Long> ids, Map<Enum, Object> fieldsMap) throws IOException {
     List<Image> foundList = new ArrayList<Image>();
-    
+
     if (fieldsMap == null || fieldsMap.isEmpty()) {
       return foundList;
     }
@@ -109,7 +109,7 @@ public class BaseImagePersistenceImpl extends AbstractDatabaseModel<Image> imple
       Map.Entry<Enum, Object> entry = iter.next();
       Enum field = entry.getKey();
       Object value = entry.getValue();
-      
+
       String queryValue = value != null ? " = ? " : " IS NULL";
       if (value != null) {
         nonNullValueFields.add((Image._Fields) field);
@@ -202,9 +202,7 @@ public class BaseImagePersistenceImpl extends AbstractDatabaseModel<Image> imple
   }
 
   public List<Image> findByUserId(final Integer value) throws IOException {
-    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
-    searchKey.put(Image._Fields.user_id, value);
-    return find(searchKey);
+    return find(Collections.<Enum, Object>singletonMap(Image._Fields.user_id, value));
   }
 
   public ImageQueryBuilder query() {

--- a/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseImagePersistenceImpl.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseImagePersistenceImpl.java
@@ -202,7 +202,9 @@ public class BaseImagePersistenceImpl extends AbstractDatabaseModel<Image> imple
   }
 
   public List<Image> findByUserId(final Integer value) throws IOException {
-    return find(new HashMap<Enum, Object>(){{put(Image._Fields.user_id, value);}});
+    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
+    searchKey.put(Image._Fields.user_id, value);
+    return find(searchKey);
   }
 
   public ImageQueryBuilder query() {

--- a/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseLockableModelPersistenceImpl.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseLockableModelPersistenceImpl.java
@@ -245,19 +245,27 @@ public class BaseLockableModelPersistenceImpl extends AbstractDatabaseModel<Lock
   }
 
   public List<LockableModel> findByLockVersion(final int value) throws IOException {
-    return find(new HashMap<Enum, Object>(){{put(LockableModel._Fields.lock_version, value);}});
+    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
+    searchKey.put(LockableModel._Fields.lock_version, value);
+    return find(searchKey);
   }
 
   public List<LockableModel> findByMessage(final String value) throws IOException {
-    return find(new HashMap<Enum, Object>(){{put(LockableModel._Fields.message, value);}});
+    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
+    searchKey.put(LockableModel._Fields.message, value);
+    return find(searchKey);
   }
 
   public List<LockableModel> findByCreatedAt(final long value) throws IOException {
-    return find(new HashMap<Enum, Object>(){{put(LockableModel._Fields.created_at, value);}});
+    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
+    searchKey.put(LockableModel._Fields.created_at, value);
+    return find(searchKey);
   }
 
   public List<LockableModel> findByUpdatedAt(final long value) throws IOException {
-    return find(new HashMap<Enum, Object>(){{put(LockableModel._Fields.updated_at, value);}});
+    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
+    searchKey.put(LockableModel._Fields.updated_at, value);
+    return find(searchKey);
   }
 
   public LockableModelQueryBuilder query() {

--- a/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseLockableModelPersistenceImpl.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseLockableModelPersistenceImpl.java
@@ -107,7 +107,7 @@ public class BaseLockableModelPersistenceImpl extends AbstractDatabaseModel<Lock
 
   public List<LockableModel> find(Set<Long> ids, Map<Enum, Object> fieldsMap) throws IOException {
     List<LockableModel> foundList = new ArrayList<LockableModel>();
-    
+
     if (fieldsMap == null || fieldsMap.isEmpty()) {
       return foundList;
     }
@@ -122,7 +122,7 @@ public class BaseLockableModelPersistenceImpl extends AbstractDatabaseModel<Lock
       Map.Entry<Enum, Object> entry = iter.next();
       Enum field = entry.getKey();
       Object value = entry.getValue();
-      
+
       String queryValue = value != null ? " = ? " : " IS NULL";
       if (value != null) {
         nonNullValueFields.add((LockableModel._Fields) field);
@@ -245,27 +245,19 @@ public class BaseLockableModelPersistenceImpl extends AbstractDatabaseModel<Lock
   }
 
   public List<LockableModel> findByLockVersion(final int value) throws IOException {
-    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
-    searchKey.put(LockableModel._Fields.lock_version, value);
-    return find(searchKey);
+    return find(Collections.<Enum, Object>singletonMap(LockableModel._Fields.lock_version, value));
   }
 
   public List<LockableModel> findByMessage(final String value) throws IOException {
-    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
-    searchKey.put(LockableModel._Fields.message, value);
-    return find(searchKey);
+    return find(Collections.<Enum, Object>singletonMap(LockableModel._Fields.message, value));
   }
 
   public List<LockableModel> findByCreatedAt(final long value) throws IOException {
-    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
-    searchKey.put(LockableModel._Fields.created_at, value);
-    return find(searchKey);
+    return find(Collections.<Enum, Object>singletonMap(LockableModel._Fields.created_at, value));
   }
 
   public List<LockableModel> findByUpdatedAt(final long value) throws IOException {
-    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
-    searchKey.put(LockableModel._Fields.updated_at, value);
-    return find(searchKey);
+    return find(Collections.<Enum, Object>singletonMap(LockableModel._Fields.updated_at, value));
   }
 
   public LockableModelQueryBuilder query() {

--- a/test/java/com/rapleaf/jack/test_project/database_1/impl/BasePostPersistenceImpl.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/impl/BasePostPersistenceImpl.java
@@ -256,19 +256,27 @@ public class BasePostPersistenceImpl extends AbstractDatabaseModel<Post> impleme
   }
 
   public List<Post> findByTitle(final String value) throws IOException {
-    return find(new HashMap<Enum, Object>(){{put(Post._Fields.title, value);}});
+    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
+    searchKey.put(Post._Fields.title, value);
+    return find(searchKey);
   }
 
   public List<Post> findByPostedAtMillis(final Long value) throws IOException {
-    return find(new HashMap<Enum, Object>(){{put(Post._Fields.posted_at_millis, value);}});
+    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
+    searchKey.put(Post._Fields.posted_at_millis, value);
+    return find(searchKey);
   }
 
   public List<Post> findByUserId(final Integer value) throws IOException {
-    return find(new HashMap<Enum, Object>(){{put(Post._Fields.user_id, value);}});
+    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
+    searchKey.put(Post._Fields.user_id, value);
+    return find(searchKey);
   }
 
   public List<Post> findByUpdatedAt(final Long value) throws IOException {
-    return find(new HashMap<Enum, Object>(){{put(Post._Fields.updated_at, value);}});
+    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
+    searchKey.put(Post._Fields.updated_at, value);
+    return find(searchKey);
   }
 
   public PostQueryBuilder query() {

--- a/test/java/com/rapleaf/jack/test_project/database_1/impl/BasePostPersistenceImpl.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/impl/BasePostPersistenceImpl.java
@@ -112,7 +112,7 @@ public class BasePostPersistenceImpl extends AbstractDatabaseModel<Post> impleme
 
   public List<Post> find(Set<Long> ids, Map<Enum, Object> fieldsMap) throws IOException {
     List<Post> foundList = new ArrayList<Post>();
-    
+
     if (fieldsMap == null || fieldsMap.isEmpty()) {
       return foundList;
     }
@@ -127,7 +127,7 @@ public class BasePostPersistenceImpl extends AbstractDatabaseModel<Post> impleme
       Map.Entry<Enum, Object> entry = iter.next();
       Enum field = entry.getKey();
       Object value = entry.getValue();
-      
+
       String queryValue = value != null ? " = ? " : " IS NULL";
       if (value != null) {
         nonNullValueFields.add((Post._Fields) field);
@@ -256,27 +256,19 @@ public class BasePostPersistenceImpl extends AbstractDatabaseModel<Post> impleme
   }
 
   public List<Post> findByTitle(final String value) throws IOException {
-    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
-    searchKey.put(Post._Fields.title, value);
-    return find(searchKey);
+    return find(Collections.<Enum, Object>singletonMap(Post._Fields.title, value));
   }
 
   public List<Post> findByPostedAtMillis(final Long value) throws IOException {
-    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
-    searchKey.put(Post._Fields.posted_at_millis, value);
-    return find(searchKey);
+    return find(Collections.<Enum, Object>singletonMap(Post._Fields.posted_at_millis, value));
   }
 
   public List<Post> findByUserId(final Integer value) throws IOException {
-    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
-    searchKey.put(Post._Fields.user_id, value);
-    return find(searchKey);
+    return find(Collections.<Enum, Object>singletonMap(Post._Fields.user_id, value));
   }
 
   public List<Post> findByUpdatedAt(final Long value) throws IOException {
-    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
-    searchKey.put(Post._Fields.updated_at, value);
-    return find(searchKey);
+    return find(Collections.<Enum, Object>singletonMap(Post._Fields.updated_at, value));
   }
 
   public PostQueryBuilder query() {

--- a/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseUserPersistenceImpl.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseUserPersistenceImpl.java
@@ -354,43 +354,63 @@ public class BaseUserPersistenceImpl extends AbstractDatabaseModel<User> impleme
   }
 
   public List<User> findByHandle(final String value) throws IOException {
-    return find(new HashMap<Enum, Object>(){{put(User._Fields.handle, value);}});
+    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
+    searchKey.put(User._Fields.handle, value);
+    return find(searchKey);
   }
 
   public List<User> findByCreatedAtMillis(final Long value) throws IOException {
-    return find(new HashMap<Enum, Object>(){{put(User._Fields.created_at_millis, value);}});
+    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
+    searchKey.put(User._Fields.created_at_millis, value);
+    return find(searchKey);
   }
 
   public List<User> findByNumPosts(final int value) throws IOException {
-    return find(new HashMap<Enum, Object>(){{put(User._Fields.num_posts, value);}});
+    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
+    searchKey.put(User._Fields.num_posts, value);
+    return find(searchKey);
   }
 
   public List<User> findBySomeDate(final Long value) throws IOException {
-    return find(new HashMap<Enum, Object>(){{put(User._Fields.some_date, value);}});
+    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
+    searchKey.put(User._Fields.some_date, value);
+    return find(searchKey);
   }
 
   public List<User> findBySomeDatetime(final Long value) throws IOException {
-    return find(new HashMap<Enum, Object>(){{put(User._Fields.some_datetime, value);}});
+    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
+    searchKey.put(User._Fields.some_datetime, value);
+    return find(searchKey);
   }
 
   public List<User> findByBio(final String value) throws IOException {
-    return find(new HashMap<Enum, Object>(){{put(User._Fields.bio, value);}});
+    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
+    searchKey.put(User._Fields.bio, value);
+    return find(searchKey);
   }
 
   public List<User> findBySomeBinary(final byte[] value) throws IOException {
-    return find(new HashMap<Enum, Object>(){{put(User._Fields.some_binary, value);}});
+    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
+    searchKey.put(User._Fields.some_binary, value);
+    return find(searchKey);
   }
 
   public List<User> findBySomeFloat(final Double value) throws IOException {
-    return find(new HashMap<Enum, Object>(){{put(User._Fields.some_float, value);}});
+    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
+    searchKey.put(User._Fields.some_float, value);
+    return find(searchKey);
   }
 
   public List<User> findBySomeDecimal(final Double value) throws IOException {
-    return find(new HashMap<Enum, Object>(){{put(User._Fields.some_decimal, value);}});
+    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
+    searchKey.put(User._Fields.some_decimal, value);
+    return find(searchKey);
   }
 
   public List<User> findBySomeBoolean(final Boolean value) throws IOException {
-    return find(new HashMap<Enum, Object>(){{put(User._Fields.some_boolean, value);}});
+    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
+    searchKey.put(User._Fields.some_boolean, value);
+    return find(searchKey);
   }
 
   public UserQueryBuilder query() {

--- a/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseUserPersistenceImpl.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseUserPersistenceImpl.java
@@ -142,7 +142,7 @@ public class BaseUserPersistenceImpl extends AbstractDatabaseModel<User> impleme
 
   public List<User> find(Set<Long> ids, Map<Enum, Object> fieldsMap) throws IOException {
     List<User> foundList = new ArrayList<User>();
-    
+
     if (fieldsMap == null || fieldsMap.isEmpty()) {
       return foundList;
     }
@@ -157,7 +157,7 @@ public class BaseUserPersistenceImpl extends AbstractDatabaseModel<User> impleme
       Map.Entry<Enum, Object> entry = iter.next();
       Enum field = entry.getKey();
       Object value = entry.getValue();
-      
+
       String queryValue = value != null ? " = ? " : " IS NULL";
       if (value != null) {
         nonNullValueFields.add((User._Fields) field);
@@ -354,63 +354,43 @@ public class BaseUserPersistenceImpl extends AbstractDatabaseModel<User> impleme
   }
 
   public List<User> findByHandle(final String value) throws IOException {
-    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
-    searchKey.put(User._Fields.handle, value);
-    return find(searchKey);
+    return find(Collections.<Enum, Object>singletonMap(User._Fields.handle, value));
   }
 
   public List<User> findByCreatedAtMillis(final Long value) throws IOException {
-    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
-    searchKey.put(User._Fields.created_at_millis, value);
-    return find(searchKey);
+    return find(Collections.<Enum, Object>singletonMap(User._Fields.created_at_millis, value));
   }
 
   public List<User> findByNumPosts(final int value) throws IOException {
-    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
-    searchKey.put(User._Fields.num_posts, value);
-    return find(searchKey);
+    return find(Collections.<Enum, Object>singletonMap(User._Fields.num_posts, value));
   }
 
   public List<User> findBySomeDate(final Long value) throws IOException {
-    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
-    searchKey.put(User._Fields.some_date, value);
-    return find(searchKey);
+    return find(Collections.<Enum, Object>singletonMap(User._Fields.some_date, value));
   }
 
   public List<User> findBySomeDatetime(final Long value) throws IOException {
-    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
-    searchKey.put(User._Fields.some_datetime, value);
-    return find(searchKey);
+    return find(Collections.<Enum, Object>singletonMap(User._Fields.some_datetime, value));
   }
 
   public List<User> findByBio(final String value) throws IOException {
-    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
-    searchKey.put(User._Fields.bio, value);
-    return find(searchKey);
+    return find(Collections.<Enum, Object>singletonMap(User._Fields.bio, value));
   }
 
   public List<User> findBySomeBinary(final byte[] value) throws IOException {
-    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
-    searchKey.put(User._Fields.some_binary, value);
-    return find(searchKey);
+    return find(Collections.<Enum, Object>singletonMap(User._Fields.some_binary, value));
   }
 
   public List<User> findBySomeFloat(final Double value) throws IOException {
-    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
-    searchKey.put(User._Fields.some_float, value);
-    return find(searchKey);
+    return find(Collections.<Enum, Object>singletonMap(User._Fields.some_float, value));
   }
 
   public List<User> findBySomeDecimal(final Double value) throws IOException {
-    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
-    searchKey.put(User._Fields.some_decimal, value);
-    return find(searchKey);
+    return find(Collections.<Enum, Object>singletonMap(User._Fields.some_decimal, value));
   }
 
   public List<User> findBySomeBoolean(final Boolean value) throws IOException {
-    Map<Enum, Object> searchKey = new HashMap<>(1, 1.0f);
-    searchKey.put(User._Fields.some_boolean, value);
-    return find(searchKey);
+    return find(Collections.<Enum, Object>singletonMap(User._Fields.some_boolean, value));
   }
 
   public UserQueryBuilder query() {


### PR DESCRIPTION
Using double curly braces to initialize map and list objects is an anti-pattern
that we should never use. See https://blog.jooq.org/2014/12/08/dont-be-clever-the-double-curly-braces-anti-pattern/
for a detailed discussion. Essentially the problems are:
 * It's not very readable.
 * It creates a separate class for each instance, which adds overhead in the
   ClassLoader.
 * It can create memory leaks, since the new objects retain a reference to
   their enclosing class, which leaves a high potential for circular
   references.

This removes this anti-pattern from our jack-generated code.
@bpodgursky 