### PR TITLE
Add a SQL escape hatch that provides object hydration alone

### DIFF
--- a/src/java/com/rapleaf/jack/IDb.java
+++ b/src/java/com/rapleaf/jack/IDb.java
@@ -14,10 +14,14 @@
 // limitations under the License.
 package com.rapleaf.jack;
 
-import com.rapleaf.jack.queries.GenericQuery;
-
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.List;
+import java.util.Set;
+
+import com.rapleaf.jack.queries.Column;
+import com.rapleaf.jack.queries.GenericQuery;
+import com.rapleaf.jack.queries.Records;
 
 public interface IDb extends Serializable {
   
@@ -43,4 +47,6 @@ public interface IDb extends Serializable {
   public void resetConnection();
 
   GenericQuery.Builder createQuery();
+
+  Records findBySql(String statement, List<?> params, Set<Column> columns) throws IOException;
 }

--- a/src/java/com/rapleaf/jack/queries/GenericQuery.java
+++ b/src/java/com/rapleaf/jack/queries/GenericQuery.java
@@ -2,10 +2,8 @@ package com.rapleaf.jack.queries;
 
 import java.io.IOException;
 import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLRecoverableException;
-import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
@@ -201,86 +199,8 @@ public class GenericQuery {
       }
     }
   }
-
   private Records getQueryResults(PreparedStatement preparedStatement) throws SQLException {
-    ResultSet resultSet = null;
-
-    try {
-      resultSet = preparedStatement.executeQuery();
-      Records results = new Records();
-      while (resultSet.next()) {
-        Record record = parseResultSet(resultSet);
-        if (record != null) {
-          results.addRecord(record);
-        }
-      }
-      return results;
-    } catch (SQLRecoverableException e) {
-      dbConnection.resetConnection();
-      throw e;
-    } finally {
-      try {
-        if (resultSet != null) {
-          resultSet.close();
-        }
-        preparedStatement.close();
-      } catch (SQLRecoverableException e) {
-        LOG.error(e.toString());
-        dbConnection.resetConnection();
-      } catch (SQLException e) {
-        LOG.error(e.toString());
-      }
-    }
-  }
-
-  private Record parseResultSet(ResultSet resultSet) throws SQLException {
-    if (selectedColumns.isEmpty()) {
-      return null;
-    }
-
-    Record record = new Record(selectedColumns.size());
-    for (Column column : selectedColumns) {
-      String sqlKeyword = column.getSqlKeyword();
-      Class type = column.getType();
-      Object value;
-
-      if (type == Integer.class) {
-        value = resultSet.getInt(sqlKeyword);
-      } else if (type == Long.class) {
-        value = resultSet.getLong(sqlKeyword);
-      } else if (type == java.sql.Date.class) {
-        java.sql.Date date = resultSet.getDate(sqlKeyword);
-        if (date != null) {
-          value = date.getTime();
-        } else {
-          value = null;
-        }
-      } else if (type == Timestamp.class) {
-        Timestamp timestamp = resultSet.getTimestamp(sqlKeyword);
-        if (timestamp != null) {
-          value = timestamp.getTime();
-        } else {
-          value = null;
-        }
-      } else if (type == Double.class) {
-        value = resultSet.getDouble(sqlKeyword);
-      } else if (type == String.class) {
-        value = resultSet.getString(sqlKeyword);
-      } else if (type == Boolean.class) {
-        value = resultSet.getBoolean(sqlKeyword);
-      } else if (type == byte[].class) {
-        value = resultSet.getBytes(sqlKeyword);
-      } else {
-        value = resultSet.getObject(sqlKeyword);
-      }
-
-      if (resultSet.wasNull()) {
-        value = null;
-      }
-
-      record.addColumn(column, value);
-    }
-    return record;
+    return QueryFetcher.getQueryResults(preparedStatement, selectedColumns, dbConnection) ;
   }
 
   private String getQueryStatement() {

--- a/src/java/com/rapleaf/jack/queries/QueryFetcher.java
+++ b/src/java/com/rapleaf/jack/queries/QueryFetcher.java
@@ -1,0 +1,99 @@
+package com.rapleaf.jack.queries;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLRecoverableException;
+import java.sql.Timestamp;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.rapleaf.jack.BaseDatabaseConnection;
+
+public class QueryFetcher {
+
+  private static final Logger LOG = LoggerFactory.getLogger(QueryFetcher.class);
+
+  public static Records getQueryResults(PreparedStatement preparedStatement, Set<Column> selectedColumns, BaseDatabaseConnection dbConnection) throws SQLException {
+    ResultSet resultSet = null;
+
+    try {
+      resultSet = preparedStatement.executeQuery();
+      Records results = new Records();
+      while (resultSet.next()) {
+        Record record = parseResultSet(resultSet, selectedColumns);
+        if (record != null) {
+          results.addRecord(record);
+        }
+      }
+      return results;
+    } catch (SQLRecoverableException e) {
+      dbConnection.resetConnection();
+      throw e;
+    } finally {
+      try {
+        if (resultSet != null) {
+          resultSet.close();
+        }
+        preparedStatement.close();
+      } catch (SQLRecoverableException e) {
+        LOG.error(e.toString());
+        dbConnection.resetConnection();
+      } catch (SQLException e) {
+        LOG.error(e.toString());
+      }
+    }
+  }
+
+  private static Record parseResultSet(ResultSet resultSet, Set<Column> selectedColumns) throws SQLException {
+    if (selectedColumns.isEmpty()) {
+      return null;
+    }
+
+    Record record = new Record(selectedColumns.size());
+    for (Column column : selectedColumns) {
+      String sqlKeyword = column.getSqlKeyword();
+      Class type = column.getType();
+      Object value;
+
+      if (type == Integer.class) {
+        value = resultSet.getInt(sqlKeyword);
+      } else if (type == Long.class) {
+        value = resultSet.getLong(sqlKeyword);
+      } else if (type == java.sql.Date.class) {
+        java.sql.Date date = resultSet.getDate(sqlKeyword);
+        if (date != null) {
+          value = date.getTime();
+        } else {
+          value = null;
+        }
+      } else if (type == Timestamp.class) {
+        Timestamp timestamp = resultSet.getTimestamp(sqlKeyword);
+        if (timestamp != null) {
+          value = timestamp.getTime();
+        } else {
+          value = null;
+        }
+      } else if (type == Double.class) {
+        value = resultSet.getDouble(sqlKeyword);
+      } else if (type == String.class) {
+        value = resultSet.getString(sqlKeyword);
+      } else if (type == Boolean.class) {
+        value = resultSet.getBoolean(sqlKeyword);
+      } else if (type == byte[].class) {
+        value = resultSet.getBytes(sqlKeyword);
+      } else {
+        value = resultSet.getObject(sqlKeyword);
+      }
+
+      if (resultSet.wasNull()) {
+        value = null;
+      }
+
+      record.addColumn(column, value);
+    }
+    return record;
+  }
+}

--- a/src/rb/templates/db_impl.erb
+++ b/src/rb/templates/db_impl.erb
@@ -17,11 +17,18 @@
 package <%= root_package %>.impl;
 
 import java.io.IOException;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Set;
+import java.util.List;
 
 import <%= root_package %>.I<%= db_name%>;
 import <%= JACK_NAMESPACE %>.LazyLoadPersistence;
 import <%= JACK_NAMESPACE %>.queries.GenericQuery;
 import <%= JACK_NAMESPACE %>.BaseDatabaseConnection;
+import <%= JACK_NAMESPACE %>.queries.Records;
+import <%= JACK_NAMESPACE %>.queries.Column;
+import <%= JACK_NAMESPACE %>.queries.QueryFetcher;
 
 <% model_defns.each do |model_defn| %>
 import <%= root_package %>.iface.<%= model_defn.iface_name %>;
@@ -54,6 +61,21 @@ public class <%=db_name%>Impl implements I<%=db_name%> {
 
   public GenericQuery.Builder createQuery() {
     return GenericQuery.create(conn);
+  }
+
+  @Override
+  public Records findBySql(String statement, List<?> params, Set<Column> columns) throws IOException {
+    final PreparedStatement preparedStatement = conn.getPreparedStatement(statement);
+    try {
+      for (int i=0; i<params.size(); i++) {
+        final Object param = params.get(i);
+        final int paramIdx = i+1;
+        preparedStatement.setObject(paramIdx, param);
+      }
+      return QueryFetcher.getQueryResults(preparedStatement, columns, conn);
+    } catch (SQLException e) {
+      throw new IOException(e);
+    }
   }
 
   <% model_defns.each do |model_defn| %>

--- a/test/java/com/rapleaf/jack/TestDbImpl.java
+++ b/test/java/com/rapleaf/jack/TestDbImpl.java
@@ -1,0 +1,46 @@
+package com.rapleaf.jack;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.List;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+import com.rapleaf.jack.queries.Column;
+import com.rapleaf.jack.queries.Record;
+import com.rapleaf.jack.queries.Records;
+import com.rapleaf.jack.test_project.DatabasesImpl;
+import com.rapleaf.jack.test_project.IDatabases;
+import com.rapleaf.jack.test_project.database_1.IDatabase1;
+import com.rapleaf.jack.test_project.database_1.models.Post;
+import com.rapleaf.jack.test_project.database_1.models.User;
+
+public class TestDbImpl extends BaseDatabaseModelTestCase {
+  private static final DatabaseConnection DATABASE_CONNECTION1 = new DatabaseConnection("database1");
+
+  @Override
+  public IDatabases getDBS() {
+    return new DatabasesImpl(DATABASE_CONNECTION1);
+  }
+
+  public void testFindBySql() throws SQLException, IOException {
+    final IDatabase1 database1 = getDBS().getDatabase1();
+    final User user1 = database1.users().create("auser", 400);
+    final User user2 = database1.users().create("someuser", 300);
+    final Post post1 = database1.posts().create("atitle", 1L, user1.getIntId(), 300L);
+    final Post post2 = database1.posts().create("secondtitle", 2L, user1.getIntId(), 303L);
+    database1.posts().create("anothertitle", 1L, user2.getIntId(), 300L);
+    final Records records = database1.findBySql("SELECT * FROM posts WHERE posts.user_id IN (SELECT users.id FROM users WHERE users.num_posts > ?)", Lists.newArrayList(300), Sets.<Column>newHashSet(Post.ID, Post.TITLE));
+    List<String> titles = Lists.newArrayList();
+    List<Long> ids = Lists.newArrayList();
+    for (Record record : records) {
+      titles.add(record.getString(Post.TITLE));
+      ids.add(record.getLong(Post.ID));
+    }
+
+    assertEquals(Lists.newArrayList("atitle", "secondtitle"), titles);
+    assertEquals(Lists.newArrayList(post1.getId(), post2.getId()), ids);
+  }
+
+}

--- a/test/java/com/rapleaf/jack/test_project/database_1/impl/Database1Impl.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/impl/Database1Impl.java
@@ -7,11 +7,18 @@
 package com.rapleaf.jack.test_project.database_1.impl;
 
 import java.io.IOException;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Set;
+import java.util.List;
 
 import com.rapleaf.jack.test_project.database_1.IDatabase1;
 import com.rapleaf.jack.LazyLoadPersistence;
 import com.rapleaf.jack.queries.GenericQuery;
 import com.rapleaf.jack.BaseDatabaseConnection;
+import com.rapleaf.jack.queries.Records;
+import com.rapleaf.jack.queries.Column;
+import com.rapleaf.jack.queries.QueryFetcher;
 import com.rapleaf.jack.test_project.database_1.iface.ICommentPersistence;
 import com.rapleaf.jack.test_project.database_1.iface.IImagePersistence;
 import com.rapleaf.jack.test_project.database_1.iface.ILockableModelPersistence;
@@ -67,6 +74,21 @@ public class Database1Impl implements IDatabase1 {
 
   public GenericQuery.Builder createQuery() {
     return GenericQuery.create(conn);
+  }
+
+  @Override
+  public Records findBySql(String statement, List<?> params, Set<Column> columns) throws IOException {
+    final PreparedStatement preparedStatement = conn.getPreparedStatement(statement);
+    try {
+      for (int i=0; i<params.size(); i++) {
+        final Object param = params.get(i);
+        final int paramIdx = i+1;
+        preparedStatement.setObject(paramIdx, param);
+      }
+      return QueryFetcher.getQueryResults(preparedStatement, columns, conn);
+    } catch (SQLException e) {
+      throw new IOException(e);
+    }
   }
 
   public ICommentPersistence comments(){


### PR DESCRIPTION
  This is a means to allow queries that aren't possible in Jack's model
  while still retaining the ability to create the common `Records` objects
  that are used by Jack.

  The alternative, exposing the connection, is likely to cause confusion
  since the ORM's behaviour is directly coupled to connection state and
  managing autoCommit on both seemingly independently (but not really)
  is confusing.

  This is intended to be analogous to ActiveRecord's `find_by_sql`. [Example Usage](https://github.com/LiveRamp/jack/pull/166/files#diff-4d0daeb0c666e8482208be3cc784e44cR34).