### PR TITLE
allow overriding configs via environment

### DIFF
--- a/src/java/com/rapleaf/jack/BaseDatabaseConnection.java
+++ b/src/java/com/rapleaf/jack/BaseDatabaseConnection.java
@@ -1,5 +1,7 @@
 package com.rapleaf.jack;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.io.Serializable;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -9,7 +11,7 @@ import java.sql.Statement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class BaseDatabaseConnection implements Serializable {
+public abstract class BaseDatabaseConnection implements Serializable, Closeable {
 
   private static Logger LOG = LoggerFactory.getLogger(BaseDatabaseConnection.class);
 
@@ -148,6 +150,19 @@ public abstract class BaseDatabaseConnection implements Serializable {
       getConnection().rollback();
     } catch (SQLException e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Close the connection to the database.
+   */
+  @Override
+  public void close() throws IOException {
+    try {
+      getConnection().close();
+      conn = null;
+    } catch (SQLException e) {
+      throw new IOException(e);
     }
   }
 }

--- a/src/java/com/rapleaf/jack/DatabaseConnection.java
+++ b/src/java/com/rapleaf/jack/DatabaseConnection.java
@@ -18,6 +18,8 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 
+import com.google.common.base.Optional;
+
 /**
  * The DatabaseConnection class manages connections to your databases. The
  * database to be used is specified in config/environment.yml. This file
@@ -34,8 +36,8 @@ public class DatabaseConnection extends BaseDatabaseConnection {
   public static final String REDSHIFT_JDBC_DRIVER = "com.amazon.redshift.jdbc41.Driver";
 
   private final String connectionString;
-  private final String username;
-  private final String password;
+  private final Optional<String> username;
+  private final Optional<String> password;
   private final String driverClass;
   private long expiresAt;
   private long expiration;
@@ -89,7 +91,7 @@ public class DatabaseConnection extends BaseDatabaseConnection {
     try {
       if (conn == null) {
         Class.forName(driverClass);
-        conn = DriverManager.getConnection(connectionString, username, password);
+        conn = DriverManager.getConnection(connectionString, username.orNull(), password.orNull());
       } else if (isExpired() || conn.isClosed()) {
         resetConnection();
       }

--- a/src/java/com/rapleaf/jack/DatabaseConnectionConfiguration.java
+++ b/src/java/com/rapleaf/jack/DatabaseConnectionConfiguration.java
@@ -16,10 +16,10 @@ public class DatabaseConnectionConfiguration {
   private String dbName;
   private Optional<Integer> port;
   private Optional<Boolean> parrallelTest;
-  private String username;
-  private String password;
+  private Optional<String> username;
+  private Optional<String> password;
 
-  public DatabaseConnectionConfiguration(String adapter, String host, String dbName, Optional<Integer> port, Optional<Boolean> parrallelTest, String username, String password) {
+  public DatabaseConnectionConfiguration(String adapter, String host, String dbName, Optional<Integer> port, Optional<Boolean> parrallelTest, Optional<String> username, Optional<String> password) {
     this.adapter = adapter;
     this.host = host;
     this.dbName = dbName;
@@ -48,12 +48,12 @@ public class DatabaseConnectionConfiguration {
     String adapter = load("adapter", db_info, "adapter", "database", "JACK_DB_ADAPTER", "jack.db.adapter", new StringIdentity());
     String host = load("host", db_info, "host", "database", "JACK_DB_HOST", "jack.db.host", new StringIdentity());
     String dbName = load("database name", db_info, "database", "database", "JACK_DB_NAME", "jack.db.name", new StringIdentity());
-    Optional<Integer> port = loadOpt("port", db_info, "port", "database", "JACK_DB_PORT", "jack.db.port", new ToInteger());
-    Optional<Boolean> parallelTesting = loadOpt("parrallel testing", env_info, "enable_parallel_tests", "environment",
+    Optional<Integer> port = loadOpt(db_info, "port", "JACK_DB_PORT", "jack.db.port", new ToInteger());
+    Optional<Boolean> parallelTesting = loadOpt(env_info, "enable_parallel_tests",
         "JACK_DB_PARALLEL_TESTS", "jack.db.parallel.test", new ToBoolean());
 
-    String username = load("username", db_info, "username", "database", "JACK_DB_USERNAME", "jack.db.username", new StringIdentity());
-    String password = load("password", db_info, "password", "database", "JACK_DB_PASSWORD", "jack.db.password", new StringIdentity());
+    Optional<String> username = loadOpt(db_info, "username", "JACK_DB_USERNAME", "jack.db.username", new StringIdentity());
+    Optional<String> password = loadOpt(db_info, "password", "JACK_DB_PASSWORD", "jack.db.password", new StringIdentity());
 
     return new DatabaseConnectionConfiguration(adapter, host, dbName, port, parallelTesting, username, password);
   }
@@ -67,22 +67,20 @@ public class DatabaseConnectionConfiguration {
       String javaProp,
       Function<String, T> fromString) {
 
-    Optional<T> result = loadOpt(readableName, map, mapKey, mapYmlFile, envVar, javaProp, fromString);
+    Optional<T> result = loadOpt(map, mapKey, envVar, javaProp, fromString);
     if (result.isPresent()) {
       return result.get();
     } else {
       throw new RuntimeException("Unable to find required configuration " + readableName + ". Please set using one of:\n" +
           "Environment Variable: " + envVar + "\n" +
           "Java System Property: " + javaProp + "\n" +
-          "Entry in config/environment.yml or config/database.yml: " + mapKey);
+          "Entry in config/"+mapYmlFile+".yml: " + mapKey);
     }
   }
 
   private static <T> Optional<T> loadOpt(
-      String readableName,
       Map<String, Object> map,
       String mapKey,
-      String mapYmlFile,
       String envVar,
       String javaProp,
       Function<String, T> fromString) {
@@ -119,11 +117,11 @@ public class DatabaseConnectionConfiguration {
     return parrallelTest.isPresent() ? parrallelTest.get() : false;
   }
 
-  public String getUsername() {
+  public Optional<String> getUsername() {
     return username;
   }
 
-  public String getPassword() {
+  public Optional<String> getPassword() {
     return password;
   }
 

--- a/src/java/com/rapleaf/jack/DatabaseConnectionConfiguration.java
+++ b/src/java/com/rapleaf/jack/DatabaseConnectionConfiguration.java
@@ -45,17 +45,36 @@ public class DatabaseConnectionConfiguration {
       db_info = Maps.newHashMap();
     }
 
-    String adapter = load("adapter", db_info, "adapter", "database", "JACK_DB_ADAPTER", "jack.db.adapter", new StringIdentity());
-    String host = load("host", db_info, "host", "database", "JACK_DB_HOST", "jack.db.host", new StringIdentity());
-    String dbName = load("database name", db_info, "database", "database", "JACK_DB_NAME", "jack.db.name", new StringIdentity());
-    Optional<Integer> port = loadOpt(db_info, "port", "JACK_DB_PORT", "jack.db.port", new ToInteger());
-    Optional<Boolean> parallelTesting = loadOpt(env_info, "enable_parallel_tests",
-        "JACK_DB_PARALLEL_TESTS", "jack.db.parallel.test", new ToBoolean());
+    String adapter = load("adapter", db_info, "adapter", "database",
+        envVar("JACK_DB_ADAPTER", dbname_key), prop("jack.db.adapter", dbname_key), new StringIdentity());
 
-    Optional<String> username = loadOpt(db_info, "username", "JACK_DB_USERNAME", "jack.db.username", new StringIdentity());
-    Optional<String> password = loadOpt(db_info, "password", "JACK_DB_PASSWORD", "jack.db.password", new StringIdentity());
+    String host = load("host", db_info, "host", "database",
+        envVar("JACK_DB_HOST", dbname_key), prop("jack.db.host", dbname_key), new StringIdentity());
+
+    String dbName = load("database name", db_info, "database", "database",
+        envVar("JACK_DB_NAME", dbname_key), prop("jack.db.name", dbname_key), new StringIdentity());
+
+    Optional<Integer> port = loadOpt(db_info, "port",
+        envVar("JACK_DB_PORT", dbname_key), prop("jack.db.port", dbname_key), new ToInteger());
+
+    Optional<Boolean> parallelTesting = loadOpt(env_info, "enable_parallel_tests",
+        envVar("JACK_DB_PARALLEL_TESTS", dbname_key), prop("jack.db.parallel.test", dbname_key), new ToBoolean());
+
+    Optional<String> username = loadOpt(db_info, "username",
+        envVar("JACK_DB_USERNAME", dbname_key), prop("jack.db.username", dbname_key), new StringIdentity());
+
+    Optional<String> password = loadOpt(db_info, "password",
+        envVar("JACK_DB_PASSWORD", dbname_key), prop("jack.db.password", dbname_key), new StringIdentity());
 
     return new DatabaseConnectionConfiguration(adapter, host, dbName, port, parallelTesting, username, password);
+  }
+
+  private static String envVar(String baseEnvVar, String dbname_key) {
+    return baseEnvVar + "_" + dbname_key.toUpperCase();
+  }
+
+  private static String prop(String baseProp, String dbname_key) {
+    return baseProp + "." + dbname_key;
   }
 
   private static <T> T load(
@@ -74,7 +93,7 @@ public class DatabaseConnectionConfiguration {
       throw new RuntimeException("Unable to find required configuration " + readableName + ". Please set using one of:\n" +
           "Environment Variable: " + envVar + "\n" +
           "Java System Property: " + javaProp + "\n" +
-          "Entry in config/"+mapYmlFile+".yml: " + mapKey);
+          "Entry in config/" + mapYmlFile + ".yml: " + mapKey);
     }
   }
 

--- a/src/java/com/rapleaf/jack/DatabaseConnectionConfiguration.java
+++ b/src/java/com/rapleaf/jack/DatabaseConnectionConfiguration.java
@@ -15,56 +15,56 @@ public class DatabaseConnectionConfiguration {
   private String host;
   private String dbName;
   private Optional<Integer> port;
-  private Optional<Boolean> parrallelTest;
+  private Optional<Boolean> parallelTest;
   private Optional<String> username;
   private Optional<String> password;
 
-  public DatabaseConnectionConfiguration(String adapter, String host, String dbName, Optional<Integer> port, Optional<Boolean> parrallelTest, Optional<String> username, Optional<String> password) {
+  public DatabaseConnectionConfiguration(String adapter, String host, String dbName, Optional<Integer> port, Optional<Boolean> parallelTest, Optional<String> username, Optional<String> password) {
     this.adapter = adapter;
     this.host = host;
     this.dbName = dbName;
     this.port = port;
-    this.parrallelTest = parrallelTest;
+    this.parallelTest = parallelTest;
     this.username = username;
     this.password = password;
   }
 
-  public static DatabaseConnectionConfiguration loadFromEnvironment(String dbname_key) {
-    Map<String, Object> env_info;
-    Map<String, Object> db_info;
+  public static DatabaseConnectionConfiguration loadFromEnvironment(String dbNameKey) {
+    Map<String, Object> envInfo;
+    Map<String, Object> dbInfo;
     // load database info from config folder
     try {
-      env_info = (Map<String, Object>)YAML.load(new FileReader("config/environment.yml"));
+      envInfo = (Map<String, Object>)YAML.load(new FileReader("config/environment.yml"));
     } catch (FileNotFoundException e) {
-      env_info = Maps.newHashMap();
+      envInfo = Maps.newHashMap();
     }
-    String db_info_name = (String)env_info.get(dbname_key);
+    String db_info_name = (String)envInfo.get(dbNameKey);
     try {
-      db_info = (Map)((Map)YAML.load(new FileReader("config/database.yml"))).get(db_info_name);
+      dbInfo = (Map)((Map)YAML.load(new FileReader("config/database.yml"))).get(db_info_name);
     } catch (FileNotFoundException e) {
-      db_info = Maps.newHashMap();
+      dbInfo = Maps.newHashMap();
     }
 
-    String adapter = load("adapter", db_info, "adapter", "database",
-        envVar("JACK_DB_ADAPTER", dbname_key), prop("jack.db.adapter", dbname_key), new StringIdentity());
+    String adapter = load("adapter", dbInfo, "adapter", "database",
+        envVar("JACK_DB_ADAPTER", dbNameKey), prop("jack.db.adapter", dbNameKey), new StringIdentity());
 
-    String host = load("host", db_info, "host", "database",
-        envVar("JACK_DB_HOST", dbname_key), prop("jack.db.host", dbname_key), new StringIdentity());
+    String host = load("host", dbInfo, "host", "database",
+        envVar("JACK_DB_HOST", dbNameKey), prop("jack.db.host", dbNameKey), new StringIdentity());
 
-    String dbName = load("database name", db_info, "database", "database",
-        envVar("JACK_DB_NAME", dbname_key), prop("jack.db.name", dbname_key), new StringIdentity());
+    String dbName = load("database name", dbInfo, "database", "database",
+        envVar("JACK_DB_NAME", dbNameKey), prop("jack.db.name", dbNameKey), new StringIdentity());
 
-    Optional<Integer> port = loadOpt(db_info, "port",
-        envVar("JACK_DB_PORT", dbname_key), prop("jack.db.port", dbname_key), new ToInteger());
+    Optional<Integer> port = loadOpt(dbInfo, "port",
+        envVar("JACK_DB_PORT", dbNameKey), prop("jack.db.port", dbNameKey), new ToInteger());
 
-    Optional<Boolean> parallelTesting = loadOpt(env_info, "enable_parallel_tests",
-        envVar("JACK_DB_PARALLEL_TESTS", dbname_key), prop("jack.db.parallel.test", dbname_key), new ToBoolean());
+    Optional<Boolean> parallelTesting = loadOpt(envInfo, "enable_parallel_tests",
+        envVar("JACK_DB_PARALLEL_TESTS", dbNameKey), prop("jack.db.parallel.test", dbNameKey), new ToBoolean());
 
-    Optional<String> username = loadOpt(db_info, "username",
-        envVar("JACK_DB_USERNAME", dbname_key), prop("jack.db.username", dbname_key), new StringIdentity());
+    Optional<String> username = loadOpt(dbInfo, "username",
+        envVar("JACK_DB_USERNAME", dbNameKey), prop("jack.db.username", dbNameKey), new StringIdentity());
 
-    Optional<String> password = loadOpt(db_info, "password",
-        envVar("JACK_DB_PASSWORD", dbname_key), prop("jack.db.password", dbname_key), new StringIdentity());
+    Optional<String> password = loadOpt(dbInfo, "password",
+        envVar("JACK_DB_PASSWORD", dbNameKey), prop("jack.db.password", dbNameKey), new StringIdentity());
 
     return new DatabaseConnectionConfiguration(adapter, host, dbName, port, parallelTesting, username, password);
   }
@@ -133,7 +133,7 @@ public class DatabaseConnectionConfiguration {
   }
 
   public Boolean enableParallelTests() {
-    return parrallelTest.isPresent() ? parrallelTest.get() : false;
+    return parallelTest.isPresent() ? parallelTest.get() : false;
   }
 
   public Optional<String> getUsername() {

--- a/src/java/com/rapleaf/jack/DatabaseConnectionConfiguration.java
+++ b/src/java/com/rapleaf/jack/DatabaseConnectionConfiguration.java
@@ -1,0 +1,147 @@
+package com.rapleaf.jack;
+
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.util.Map;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.collect.Maps;
+import org.jvyaml.YAML;
+
+public class DatabaseConnectionConfiguration {
+
+  private String adapter;
+  private String host;
+  private String dbName;
+  private Optional<Integer> port;
+  private Optional<Boolean> parrallelTest;
+  private String username;
+  private String password;
+
+  public DatabaseConnectionConfiguration(String adapter, String host, String dbName, Optional<Integer> port, Optional<Boolean> parrallelTest, String username, String password) {
+    this.adapter = adapter;
+    this.host = host;
+    this.dbName = dbName;
+    this.port = port;
+    this.parrallelTest = parrallelTest;
+    this.username = username;
+    this.password = password;
+  }
+
+  public static DatabaseConnectionConfiguration loadFromEnvironment(String dbname_key) {
+    Map<String, Object> env_info;
+    Map<String, Object> db_info;
+    // load database info from config folder
+    try {
+      env_info = (Map<String, Object>)YAML.load(new FileReader("config/environment.yml"));
+    } catch (FileNotFoundException e) {
+      env_info = Maps.newHashMap();
+    }
+    String db_info_name = (String)env_info.get(dbname_key);
+    try {
+      db_info = (Map)((Map)YAML.load(new FileReader("config/database.yml"))).get(db_info_name);
+    } catch (FileNotFoundException e) {
+      db_info = Maps.newHashMap();
+    }
+
+    String adapter = load("adapter", db_info, "adapter", "database", "JACK_DB_ADAPTER", "jack.db.adapter", new StringIdentity());
+    String host = load("host", db_info, "host", "database", "JACK_DB_HOST", "jack.db.host", new StringIdentity());
+    String dbName = load("database name", db_info, "database", "database", "JACK_DB_NAME", "jack.db.name", new StringIdentity());
+    Optional<Integer> port = loadOpt("port", db_info, "port", "database", "JACK_DB_PORT", "jack.db.port", new ToInteger());
+    Optional<Boolean> parallelTesting = loadOpt("parrallel testing", env_info, "enable_parallel_tests", "environment",
+        "JACK_DB_PARALLEL_TESTS", "jack.db.parallel.test", new ToBoolean());
+
+    String username = load("username", db_info, "username", "database", "JACK_DB_USERNAME", "jack.db.username", new StringIdentity());
+    String password = load("password", db_info, "password", "database", "JACK_DB_PASSWORD", "jack.db.password", new StringIdentity());
+
+    return new DatabaseConnectionConfiguration(adapter, host, dbName, port, parallelTesting, username, password);
+  }
+
+  private static <T> T load(
+      String readableName,
+      Map<String, Object> map,
+      String mapKey,
+      String mapYmlFile,
+      String envVar,
+      String javaProp,
+      Function<String, T> fromString) {
+
+    Optional<T> result = loadOpt(readableName, map, mapKey, mapYmlFile, envVar, javaProp, fromString);
+    if (result.isPresent()) {
+      return result.get();
+    } else {
+      throw new RuntimeException("Unable to find required configuration " + readableName + ". Please set using one of:\n" +
+          "Environment Variable: " + envVar + "\n" +
+          "Java System Property: " + javaProp + "\n" +
+          "Entry in config/environment.yml or config/database.yml: " + mapKey);
+    }
+  }
+
+  private static <T> Optional<T> loadOpt(
+      String readableName,
+      Map<String, Object> map,
+      String mapKey,
+      String mapYmlFile,
+      String envVar,
+      String javaProp,
+      Function<String, T> fromString) {
+    if (System.getenv(envVar) != null) {
+      return Optional.fromNullable(fromString.apply(System.getenv(envVar)));
+    }
+    if (System.getProperty(javaProp) != null) {
+      return Optional.fromNullable(fromString.apply(System.getProperty(javaProp)));
+    }
+    if (map.containsKey(mapKey)) {
+      return Optional.fromNullable((T)map.get(mapKey));
+    }
+    return Optional.absent();
+  }
+
+
+  public String getAdapter() {
+    return adapter;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public Optional<Integer> getPort() {
+    return port;
+  }
+
+  public String getDatabaseName() {
+    return dbName;
+  }
+
+  public Boolean enableParallelTests() {
+    return parrallelTest.isPresent() ? parrallelTest.get() : false;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  private static class StringIdentity implements Function<String, String> {
+    public String apply(String s) {
+      return s;
+    }
+  }
+
+  private static class ToInteger implements Function<String, Integer> {
+    public Integer apply(String s) {
+      return Integer.parseInt(s);
+    }
+  }
+
+  private static class ToBoolean implements Function<String, Boolean> {
+    public Boolean apply(String s) {
+      return Boolean.parseBoolean(s);
+    }
+  }
+}


### PR DESCRIPTION
Allow the setting or overriding of all Jack connection configurations by
preferring data from environment variables and system properties. This
allows the use of Jack in situations where a config file is hard to
supply, and allows overriding specific properties for non-standard use
cases.

@roshan and @sidoh, as the most recent contributor and as a dev tools guy, if you're willing to quickly review I'd appreciate it.