### PR TITLE
changes for matching columns

### DIFF
--- a/src/java/com/rapleaf/jack/queries/Column.java
+++ b/src/java/com/rapleaf/jack/queries/Column.java
@@ -278,8 +278,16 @@ public class Column<T> {
     return new GenericConstraint<String>(this.as(String.class), new Match(pattern));
   }
 
+  public GenericConstraint matches(Column<String> col, String prefix, String suffix) {
+    return new GenericConstraint<String>(this.as(String.class), new Match(col, prefix, suffix));
+  }
+
   public GenericConstraint contains(String string) {
-    return new GenericConstraint<String>(this.as(String.class), new Match("%" + string + "%"));
+    return matches("%" + string + "%");
+  }
+
+  public GenericConstraint contains(Column<String> col) {
+    return matches(col, "%", "%");
   }
 
   public GenericConstraint startsWith(String start) {

--- a/src/java/com/rapleaf/jack/queries/where_operators/Match.java
+++ b/src/java/com/rapleaf/jack/queries/where_operators/Match.java
@@ -1,8 +1,16 @@
 package com.rapleaf.jack.queries.where_operators;
 
+import com.google.common.base.Preconditions;
+import com.rapleaf.jack.queries.Column;
+
 public class Match extends WhereOperator<String> {
 
   public Match(String pattern) {
     super("LIKE ?", pattern);
+  }
+
+  public Match(Column<String> column, String prefix, String suffix) {
+    super(String.format("LIKE CONCAT('%s', %s, '%s')", prefix, column.getSqlKeyword(), suffix));
+    Preconditions.checkNotNull(column);
   }
 }

--- a/src/java/com/rapleaf/jack/queries/where_operators/Match.java
+++ b/src/java/com/rapleaf/jack/queries/where_operators/Match.java
@@ -10,6 +10,6 @@ public class Match extends WhereOperator<String> {
   }
 
   public Match(Column<String> column, String prefix, String suffix) {
-    super(String.format("LIKE CONCAT('%s', %s, '%s')", prefix, Preconditions.checkNotNull(column).getSqlKeyword(), suffix));
+    super(String.format("LIKE CONCAT(CONCAT('%s', %s), '%s')", prefix, Preconditions.checkNotNull(column).getSqlKeyword(), suffix));
   }
 }

--- a/src/java/com/rapleaf/jack/queries/where_operators/Match.java
+++ b/src/java/com/rapleaf/jack/queries/where_operators/Match.java
@@ -10,7 +10,6 @@ public class Match extends WhereOperator<String> {
   }
 
   public Match(Column<String> column, String prefix, String suffix) {
-    super(String.format("LIKE CONCAT('%s', %s, '%s')", prefix, column.getSqlKeyword(), suffix));
-    Preconditions.checkNotNull(column);
+    super(String.format("LIKE CONCAT('%s', %s, '%s')", prefix, Preconditions.checkNotNull(column).getSqlKeyword(), suffix));
   }
 }

--- a/test/java/com/rapleaf/jack/TestGenericQuery.java
+++ b/test/java/com/rapleaf/jack/TestGenericQuery.java
@@ -708,6 +708,34 @@ public class TestGenericQuery {
     assertEquals(commentD.getContent(), recordForCommentD.get(Comment.CONTENT));
     assertEquals(userC.getHandle(), recordForCommentD.get(User.HANDLE));
     assertEquals(postC.getTitle(), recordForCommentD.get(Post.TITLE));
+
+    results2 = db.createQuery()
+            .from(Post.TBL)
+            .leftJoin(User.TBL).on(User.ID.equalTo(Post.USER_ID.as(Long.class)))
+            .leftJoin(Comment.TBL).on(Comment.CONTENT.contains(Post.TITLE))
+            .orderBy(User.HANDLE)
+            .orderBy(Post.TITLE, QueryOrder.DESC)
+            .select(User.HANDLE, Comment.CONTENT, Post.TITLE)
+            .fetch();
+
+    assertEquals(3, results2.size());
+    assertEquals(3, results2.get(0).columnCount());
+
+    // the result is: post B, A, C
+    Record recordForPostB = results2.get(0);
+    assertEquals(commentC.getContent(), recordForPostB.get(Comment.CONTENT));
+    assertEquals(userB.getHandle(), recordForPostB.get(User.HANDLE));
+    assertEquals(postB.getTitle(), recordForPostB.get(Post.TITLE));
+
+    Record recordForPostA = results2.get(1);
+    assertEquals(commentB.getContent(), recordForPostA.get(Comment.CONTENT));
+    assertEquals(userB.getHandle(), recordForPostA.get(User.HANDLE));
+    assertEquals(postA.getTitle(), recordForPostA.get(Post.TITLE));
+
+    Record recordForPostC = results2.get(2);
+    assertEquals(commentD.getContent(), recordForPostC.get(Comment.CONTENT));
+    assertEquals(userC.getHandle(), recordForPostC.get(User.HANDLE));
+    assertEquals(postC.getTitle(), recordForPostC.get(Post.TITLE));
   }
 
   @Test


### PR DESCRIPTION
@rfaugeroux @tuliren 

I'm doing this because I would like to use a join that involves using a 'contains' condition against a column name instead of a string literal for another task.