### PR TITLE
Travis CI with Ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ services:
 
 install: true
 
-script:
+before_script:
+  - export RAILS_ENV=development
   - unset BUNDLE_GEMFILE
+
+script:
   - mvn test -B -Pmysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language:
   - ruby
+
 rvm:
   - 2.3.0
+
 jdk:
   - oraclejdk7
 
@@ -15,6 +17,8 @@ install: true
 
 before_script:
   - export RAILS_ENV=development
+  # This variable needs to be unset because after rvm installs ruby 2.3, BUNDLE_GEMFILE is set to the
+  # Gemfile under the root path, which fails the dependency installation in the two test projects.
   - unset BUNDLE_GEMFILE
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,8 @@ notifications:
 services:
   - mysql
 
+install: true
+
 script:
+  - unset BUNDLE_GEMFILE
   - mvn test -B -Pmysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language:
-  - java
-
+  - ruby
+rvm:
+  - 2.3.0
 jdk:
   - oraclejdk7
 
@@ -10,9 +11,5 @@ notifications:
 services:
   - mysql
 
-install:
-  - rvm mount -r http://rubies.travis-ci.org/ubuntu/12.04/x86_64/ree-1.8.7-2011.12.tar.bz2 --verify-downloads 1
-
-before_script:
-  - export RAILS_ENV=development
-  - test/select-dbms.sh mysql
+script:
+  - mvn test -B -Pmysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
 
 jdk:
   - oraclejdk7
+  - oraclejdk8
 
 notifications:
   email: false

--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
                   <goal>exec</goal>
                 </goals>
                 <configuration>
-                  <executable>/bin/sh</executable>
+                  <executable>/bin/bash</executable>
                   <arguments>
                     <argument>test/select-dbms.sh</argument>
                     <argument>mysql</argument>
@@ -325,7 +325,7 @@
                   <goal>exec</goal>
                 </goals>
                 <configuration>
-                  <executable>/bin/sh</executable>
+                  <executable>/bin/bash</executable>
                   <arguments>
                     <argument>test/select-dbms.sh</argument>
                     <argument>postgres</argument>


### PR DESCRIPTION
- Replaced java environment with ruby so that we can specify ruby version by the built-in rvm.
- Added test environment for jdk8. Each build now includes two jobs, one for jdk7, and one for 8.
