### PR TITLE
Delete all lazy

### DIFF
--- a/src/java/com/rapleaf/jack/AbstractDatabaseModel.java
+++ b/src/java/com/rapleaf/jack/AbstractDatabaseModel.java
@@ -83,6 +83,7 @@ public abstract class AbstractDatabaseModel<T extends ModelWithId<T, ? extends G
     lockFieldName = DEFAULT_LOCK_FIELD_NAME;
   }
 
+
   protected String getInsertStatement(List<String> fieldNames) {
     return String.format("INSERT INTO %s (%s) VALUES(%s);", tableName,
         escapedFieldNames(fieldNames), qmarks(fieldNames.size()));
@@ -237,6 +238,19 @@ public abstract class AbstractDatabaseModel<T extends ModelWithId<T, ? extends G
       executeQuery(foundList, "SELECT * FROM " + tableName + " WHERE " + getIdSetCondition(notCachedIds));
     }
     return foundList;
+  }
+
+  @Override
+  public boolean isEmpty() throws IOException {
+
+    try {
+      PreparedStatement statement = conn.getPreparedStatement("SELECT 1 FROM " + tableName + " LIMIT 1");
+      ResultSet rs = statement.executeQuery();
+      return !rs.isBeforeFirst();
+    } catch (SQLException e) {
+      throw new IOException(e);
+    }
+
   }
 
   public List<T> findWithOrder(Set<Long> ids, ModelQuery query) throws IOException {

--- a/src/java/com/rapleaf/jack/AbstractDatabaseModel.java
+++ b/src/java/com/rapleaf/jack/AbstractDatabaseModel.java
@@ -243,12 +243,17 @@ public abstract class AbstractDatabaseModel<T extends ModelWithId<T, ? extends G
   @Override
   public boolean isEmpty() throws IOException {
 
+    PreparedStatement statement = null;
+    ResultSet rs = null;
+    
     try {
-      PreparedStatement statement = conn.getPreparedStatement("SELECT 1 FROM " + tableName + " LIMIT 1");
-      ResultSet rs = statement.executeQuery();
+      statement = conn.getPreparedStatement("SELECT 1 FROM " + tableName + " LIMIT 1");
+      rs = statement.executeQuery();
       return !rs.isBeforeFirst();
     } catch (SQLException e) {
       throw new IOException(e);
+    }finally {
+      closeQuery(rs, statement);
     }
 
   }

--- a/src/java/com/rapleaf/jack/IModelPersistence.java
+++ b/src/java/com/rapleaf/jack/IModelPersistence.java
@@ -126,4 +126,6 @@ public interface IModelPersistence<T extends ModelWithId> extends Serializable {
   public void enableCaching();
 
   public void disableCaching();
+
+  public boolean isEmpty() throws IOException;
 }

--- a/src/rb/templates/db_impl.erb
+++ b/src/rb/templates/db_impl.erb
@@ -106,6 +106,22 @@ public class <%=db_name%>Impl implements I<%=db_name%> {
     return success;
   }
 
+  public boolean deleteAllLazy() throws IOException {
+    boolean success = true;
+  <% if model_defns.any? %>
+    try {
+  <% end %>
+  <% model_defns.each do |model_defn| %>
+    success &= <%= model_defn.persistence_getter %>.isEmpty() || <%= model_defn.persistence_getter %>.deleteAll();
+  <% end %>
+  <% if model_defns.any? %>
+    } catch (IOException e) {
+      throw e;
+    }
+  <% end %>
+    return success;
+  }
+
   public void disableCaching() {
   <% model_defns.each do |model_defn| %>
     <%= model_defn.table_name %>.disableCaching();

--- a/test/java/com/rapleaf/jack/TestAbstractDatabaseModel.java
+++ b/test/java/com/rapleaf/jack/TestAbstractDatabaseModel.java
@@ -32,6 +32,19 @@ public class TestAbstractDatabaseModel extends BaseDatabaseModelTestCase {
   }
 
   @Test
+  public void testIsEmpty() throws IOException {
+
+    ICommentPersistence comments = dbs.getDatabase1().comments();
+    assertTrue(comments.isEmpty());
+
+    comments.create("comment", 1, 1, 1);
+
+    assertFalse(comments.isEmpty());
+
+  }
+
+
+  @Test
   public void testFindAllByForeignKeyCache() throws Exception {
     ICommentPersistence comments = dbs.getDatabase1().comments();
     int userId = 1;

--- a/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseCommentPersistenceImpl.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseCommentPersistenceImpl.java
@@ -6,29 +6,39 @@
  */
 package com.rapleaf.jack.test_project.database_1.impl;
 
-import java.io.IOException;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.sql.SQLRecoverableException;
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.io.IOException;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Date;
+import java.sql.Timestamp;
 
 import com.rapleaf.jack.AbstractDatabaseModel;
 import com.rapleaf.jack.BaseDatabaseConnection;
-import com.rapleaf.jack.queries.WhereClause;
+import com.rapleaf.jack.queries.where_operators.IWhereOperator;
 import com.rapleaf.jack.queries.WhereConstraint;
-import com.rapleaf.jack.test_project.IDatabases;
+import com.rapleaf.jack.queries.WhereClause;
+import com.rapleaf.jack.queries.ModelQuery;
+import com.rapleaf.jack.ModelWithId;
+import com.rapleaf.jack.util.JackUtility;
 import com.rapleaf.jack.test_project.database_1.iface.ICommentPersistence;
 import com.rapleaf.jack.test_project.database_1.models.Comment;
-import com.rapleaf.jack.test_project.database_1.query.CommentDeleteBuilder;
 import com.rapleaf.jack.test_project.database_1.query.CommentQueryBuilder;
+import com.rapleaf.jack.test_project.database_1.query.CommentDeleteBuilder;
+
+
+import com.rapleaf.jack.test_project.IDatabases;
 
 public class BaseCommentPersistenceImpl extends AbstractDatabaseModel<Comment> implements ICommentPersistence {
   private final IDatabases databases;

--- a/test/java/com/rapleaf/jack/test_project/database_1/impl/Database1Impl.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/impl/Database1Impl.java
@@ -130,6 +130,20 @@ public class Database1Impl implements IDatabase1 {
     return success;
   }
 
+  public boolean deleteAllLazy() throws IOException {
+    boolean success = true;
+    try {
+    success &= comments().isEmpty() || comments().deleteAll();
+    success &= images().isEmpty() || images().deleteAll();
+    success &= lockableModels().isEmpty() || lockableModels().deleteAll();
+    success &= posts().isEmpty() || posts().deleteAll();
+    success &= users().isEmpty() || users().deleteAll();
+    } catch (IOException e) {
+      throw e;
+    }
+    return success;
+  }
+
   public void disableCaching() {
     comments.disableCaching();
     images.disableCaching();


### PR DESCRIPTION
@tuliren 

Since we're seeing major slowdowns in truncate speed when upgrading to 5.6/5.7, I want to see if it's faster to check if the table is empty before truncating.  Since most tests only populate 2-3 couple tables out of 550+, it will avoid the vast majority of truncates, albeit at the cost of extra queries.  

If this is significantly better, I'd probably want to replace deleteAll entirely with this implementation, but I want to test out performance first. 