### PR TITLE
Add close method on db interface

### DIFF
--- a/src/java/com/rapleaf/jack/IDb.java
+++ b/src/java/com/rapleaf/jack/IDb.java
@@ -14,6 +14,7 @@
 // limitations under the License.
 package com.rapleaf.jack;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
@@ -23,11 +24,11 @@ import com.rapleaf.jack.queries.Column;
 import com.rapleaf.jack.queries.GenericQuery;
 import com.rapleaf.jack.queries.Records;
 
-public interface IDb extends Serializable {
-  
+public interface IDb extends Serializable, Closeable {
+
   /**
    * Delete all records in every persistence within this database.
-   * 
+   *
    * @return true if and only if each persistence successfully
    *         deletes all its records.
    * @throws IOException
@@ -35,16 +36,19 @@ public interface IDb extends Serializable {
   public boolean deleteAll() throws IOException;
 
   public void disableCaching();
-  
+
   public void setAutoCommit(boolean autoCommit);
-  
+
   public boolean getAutoCommit();
-  
+
   public void commit();
-  
+
   public void rollback();
 
   public void resetConnection();
+
+  @Override
+  public void close() throws IOException;
 
   GenericQuery.Builder createQuery();
 

--- a/src/rb/templates/db_impl.erb
+++ b/src/rb/templates/db_impl.erb
@@ -132,6 +132,11 @@ public class <%=db_name%>Impl implements I<%=db_name%> {
     conn.resetConnection();
   }
 
+  @Override
+  public void close() throws IOException {
+    conn.close();
+  }
+
   public IDatabases getDatabases() {
     return databases;
   }

--- a/test/java/com/rapleaf/jack/TestDbImpl.java
+++ b/test/java/com/rapleaf/jack/TestDbImpl.java
@@ -18,6 +18,8 @@ import com.rapleaf.jack.test_project.database_1.models.Post;
 import com.rapleaf.jack.test_project.database_1.models.User;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class TestDbImpl extends BaseDatabaseModelTestCase {
   private static final DatabaseConnection DATABASE_CONNECTION1 = new DatabaseConnection("database1");
@@ -25,6 +27,15 @@ public class TestDbImpl extends BaseDatabaseModelTestCase {
   @Override
   public IDatabases getDBS() {
     return new DatabasesImpl(DATABASE_CONNECTION1);
+  }
+
+  @Test
+  public void testClose() throws Exception {
+    assertFalse(DATABASE_CONNECTION1.conn == null);
+    assertFalse(DATABASE_CONNECTION1.conn.isClosed());
+
+    getDBS().getDatabase1().close();
+    assertTrue(DATABASE_CONNECTION1.conn == null);
   }
 
   @Test

--- a/test/java/com/rapleaf/jack/test_project/database_1/impl/Database1Impl.java
+++ b/test/java/com/rapleaf/jack/test_project/database_1/impl/Database1Impl.java
@@ -158,6 +158,11 @@ public class Database1Impl implements IDatabase1 {
     conn.resetConnection();
   }
 
+  @Override
+  public void close() throws IOException {
+    conn.close();
+  }
+
   public IDatabases getDatabases() {
     return databases;
   }


### PR DESCRIPTION
@seancarr, I am working on adding a db connection pool, but I am not sure how soon it will be done. Meanwhile, can we use the `close` method to prevent a workflow from holding too many idle connections?
