### PR TITLE
Idempotent Close Method

### DIFF
--- a/src/java/com/rapleaf/jack/BaseDatabaseConnection.java
+++ b/src/java/com/rapleaf/jack/BaseDatabaseConnection.java
@@ -174,8 +174,10 @@ public abstract class BaseDatabaseConnection implements Serializable, Closeable 
   @Override
   public void close() throws IOException {
     try {
-      getConnection().close();
-      conn = null;
+      if (conn != null) {
+        getConnection().close();
+        conn = null;
+      }
     } catch (SQLException e) {
       throw new IOException(e);
     }


### PR DESCRIPTION
@seancarr, the current `close` method is not idempotent. If this method is called twice on a connection, the second call will create a new connection and close it immediately.
