### PR TITLE
IExecution and IQuery Exception

### DIFF
--- a/src/java/com/rapleaf/jack/transaction/IExecution.java
+++ b/src/java/com/rapleaf/jack/transaction/IExecution.java
@@ -1,12 +1,10 @@
 package com.rapleaf.jack.transaction;
 
-import java.io.IOException;
-
 import com.rapleaf.jack.IDb;
 
 @FunctionalInterface
 public interface IExecution<DB extends IDb> {
 
-  void execute(DB db) throws IOException;
+  void execute(DB db) throws Exception;
 
 }

--- a/src/java/com/rapleaf/jack/transaction/IQuery.java
+++ b/src/java/com/rapleaf/jack/transaction/IQuery.java
@@ -1,12 +1,10 @@
 package com.rapleaf.jack.transaction;
 
-import java.io.IOException;
-
 import com.rapleaf.jack.IDb;
 
 @FunctionalInterface
 public interface IQuery<DB extends IDb, T> {
 
-  T query(DB db) throws IOException;
+  T query(DB db) throws Exception;
 
 }


### PR DESCRIPTION
The purpose of this change is to allow the transactor catch any type of exception. Previously, IExecution and IQuery only throw IOException, and all the other exceptions still need to be manually handled by the user.

@vpatel
