### PR TITLE
added query method and deprecate execute(IQuery query)

### DIFF
--- a/src/java/com/rapleaf/jack/transaction/ITransactor.java
+++ b/src/java/com/rapleaf/jack/transaction/ITransactor.java
@@ -6,9 +6,15 @@ import com.rapleaf.jack.IDb;
 
 public interface ITransactor<DB extends IDb> extends Closeable {
 
+  @Deprecated
   <T> T execute(IQuery<DB, T> query);
 
+  <T> T query(IQuery<DB, T> query);
+
+  @Deprecated
   <T> T executeAsTransaction(IQuery<DB, T> query);
+
+  <T> T queryAsTransaction(IQuery<DB, T> query);
 
   void execute(IExecution<DB> execution);
 

--- a/src/java/com/rapleaf/jack/transaction/TransactorImpl.java
+++ b/src/java/com/rapleaf/jack/transaction/TransactorImpl.java
@@ -33,14 +33,26 @@ public class TransactorImpl<DB extends IDb> implements ITransactor<DB> {
     return new Builder<>(dbConstructor);
   }
 
+  @Deprecated
   @Override
   public <T> T execute(IQuery<DB, T> query) {
-    return execute(query, false);
+    return query(query);
   }
 
   @Override
+  public <T> T query(IQuery<DB, T> query) {
+    return query(query, false);
+  }
+
+  @Deprecated
+  @Override
   public <T> T executeAsTransaction(IQuery<DB, T> query) {
-    return execute(query, true);
+    return queryAsTransaction(query);
+  }
+
+  @Override
+  public <T> T queryAsTransaction(IQuery<DB, T> query) {
+    return query(query, true);
   }
 
   @Override
@@ -53,7 +65,7 @@ public class TransactorImpl<DB extends IDb> implements ITransactor<DB> {
     execute(execution, true);
   }
 
-  private <T> T execute(IQuery<DB, T> query, boolean asTransaction) {
+  private <T> T query(IQuery<DB, T> query, boolean asTransaction) {
     DB connection = dbManager.getConnection();
     connection.setAutoCommit(!asTransaction);
     try {

--- a/test/java/com/rapleaf/jack/transaction/TestDbTransactorImpl.java
+++ b/test/java/com/rapleaf/jack/transaction/TestDbTransactorImpl.java
@@ -28,7 +28,7 @@ public class TestDbTransactorImpl extends JackTestCase {
 
   @Before
   public void prepare() throws Exception {
-    transactorBuilder.get().execute(IDb::deleteAll);
+    transactorBuilder.get().query(IDb::deleteAll);
   }
 
   @After
@@ -41,7 +41,7 @@ public class TestDbTransactorImpl extends JackTestCase {
     TransactorImpl<IDatabase1> transactor = transactorBuilder.get();
 
     String expectedBio = "test";
-    String actualBio = transactor.execute(db -> {
+    String actualBio = transactor.query(db -> {
       User user = db.users().createDefaultInstance();
       user.setBio(expectedBio).save();
       return user.getBio();
@@ -55,7 +55,7 @@ public class TestDbTransactorImpl extends JackTestCase {
     TransactorImpl<IDatabase1> transactor = transactorBuilder.get();
 
     String expectedBio = "test";
-    String actualBio = transactor.executeAsTransaction(db -> {
+    String actualBio = transactor.queryAsTransaction(db -> {
       User user = db.users().createDefaultInstance();
       user.setBio(expectedBio).save();
       return user.getBio();
@@ -78,15 +78,13 @@ public class TestDbTransactorImpl extends JackTestCase {
     TransactorImpl<IDatabase1> transactor = transactorBuilder.get();
 
     String originalBio = "original";
-    User user = transactor.executeAsTransaction(db -> {
+    User user = transactor.queryAsTransaction(db -> {
       User u = db.users().createDefaultInstance();
       u.setBio(originalBio).save();
       return u;
     });
 
-    assertEquals(originalBio, transactor.execute(db -> {
-      return db.users().find(user.getId()).getBio();
-    }));
+    assertEquals(originalBio, transactor.query(db -> db.users().find(user.getId()).getBio()));
 
     try {
       transactor.executeAsTransaction((IExecution<IDatabase1>)db -> {
@@ -99,9 +97,7 @@ public class TestDbTransactorImpl extends JackTestCase {
       fail();
     } catch (SqlExecutionFailureException e) {
       // after rollback, there is no change
-      assertEquals(originalBio, transactor.execute(db -> {
-        return db.users().find(user.getId()).getBio();
-      }));
+      assertEquals(originalBio, transactor.query(db -> db.users().find(user.getId()).getBio()));
     }
   }
 
@@ -147,9 +143,7 @@ public class TestDbTransactorImpl extends JackTestCase {
     future4.get();
     executorService.shutdownNow();
 
-    int actualCount = transactor.execute(db -> {
-      return db.createQuery().from(User.TBL).fetch().size();
-    });
+    int actualCount = transactor.query(db -> db.createQuery().from(User.TBL).fetch().size());
     assertEquals(createCount1 + createCount2, actualCount);
   }
 
@@ -163,7 +157,7 @@ public class TestDbTransactorImpl extends JackTestCase {
     String handle2 = "handle 2";
     String handle3 = "handle 3";
 
-    User user = transactor.execute(db -> {
+    User user = transactor.query(db -> {
       User u = db.users().createDefaultInstance();
       u.setHandle(handle1).save();
       return u;
@@ -190,9 +184,7 @@ public class TestDbTransactorImpl extends JackTestCase {
     future2.get();
     executorService.shutdownNow();
 
-    assertEquals(handle3, transactor.execute(db -> {
-      return db.users().find(user.getId()).getHandle();
-    }));
+    assertEquals(handle3, transactor.query(db -> db.users().find(user.getId()).getHandle()));
   }
 
   @Test

--- a/test/java/com/rapleaf/jack/transaction/TestMockTransactorImpl.java
+++ b/test/java/com/rapleaf/jack/transaction/TestMockTransactorImpl.java
@@ -37,27 +37,27 @@ public class TestMockTransactorImpl extends JackTestCase {
 
   @Test
   public void testMockExecution() throws Exception {
-    transactor.execute(IDb::deleteAll);
+    transactor.query(IDb::deleteAll);
     verifyExecuteMethod(false, false);
   }
 
   @Test
   @SuppressWarnings("unchecked")
   public void testMockQuery() throws Exception {
-    boolean deleteAll = transactor.execute(IDb::deleteAll);
+    boolean deleteAll = transactor.query(IDb::deleteAll);
     assertTrue(deleteAll);
     verifyExecuteMethod(false, false);
   }
 
   @Test
   public void testMockExecutionAsTransaction() throws Exception {
-    transactor.executeAsTransaction(IDb::deleteAll);
+    transactor.queryAsTransaction(IDb::deleteAll);
     verifyExecuteMethod(true, false);
   }
 
   @Test
   public void testMockQueryAsTransaction() throws Exception {
-    boolean deleteAll = transactor.executeAsTransaction(IDb::deleteAll);
+    boolean deleteAll = transactor.queryAsTransaction(IDb::deleteAll);
     assertTrue(deleteAll);
     verifyExecuteMethod(true, false);
   }
@@ -78,7 +78,7 @@ public class TestMockTransactorImpl extends JackTestCase {
   @Test
   public void testMockQueryWithException() throws Exception {
     try {
-      boolean result = transactor.execute((IQuery<IDatabase1, Boolean>)db -> {
+      boolean result = transactor.query(db -> {
         db.deleteAll();
         throw new IOException();
       });
@@ -104,7 +104,7 @@ public class TestMockTransactorImpl extends JackTestCase {
   @Test
   public void testMockQueryAsTransactionWithException() throws Exception {
     try {
-      boolean result = transactor.executeAsTransaction((IQuery<IDatabase1, Boolean>)db -> {
+      boolean result = transactor.queryAsTransaction(db -> {
         db.deleteAll();
         throw new IOException();
       });


### PR DESCRIPTION
@tuliren, @roshan and @bpodgursky, what do you guys think about it?
It is backward compatible so we should be able to clean the usages of `execute(IQuery query)` before getting rid of it.

(Also, could I be (re?)added as a member of jack?)