### PR TITLE
Remove deprecated transactor methods

### DIFF
--- a/jack-core/src/com/rapleaf/jack/transaction/ITransactor.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/ITransactor.java
@@ -6,13 +6,7 @@ import com.rapleaf.jack.IDb;
 
 public interface ITransactor<DB extends IDb> extends Closeable {
 
-  @Deprecated
-  <T> T execute(IQuery<DB, T> query);
-
   <T> T query(IQuery<DB, T> query);
-
-  @Deprecated
-  <T> T executeAsTransaction(IQuery<DB, T> query);
 
   <T> T queryAsTransaction(IQuery<DB, T> query);
 

--- a/jack-core/src/com/rapleaf/jack/transaction/TransactorImpl.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/TransactorImpl.java
@@ -33,21 +33,9 @@ public class TransactorImpl<DB extends IDb> implements ITransactor<DB> {
     return new Builder<>(dbConstructor);
   }
 
-  @Deprecated
-  @Override
-  public <T> T execute(IQuery<DB, T> query) {
-    return query(query);
-  }
-
   @Override
   public <T> T query(IQuery<DB, T> query) {
     return query(query, false);
-  }
-
-  @Deprecated
-  @Override
-  public <T> T executeAsTransaction(IQuery<DB, T> query) {
-    return queryAsTransaction(query);
   }
 
   @Override


### PR DESCRIPTION
@npoulallion, I think it's time to remove these methods. I will merge it after cleaning up existing use cases in the production.
