### PR TITLE
Bug in transactor Metrics

### DIFF
--- a/jack-core/src/com/rapleaf/jack/transaction/DbMetrics.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/DbMetrics.java
@@ -5,7 +5,7 @@ public interface DbMetrics {
 
   long getCreatedConnectionsCount();
 
-  double getMaxConnectionsProportion();
+  double getMaxCapacityProportion();
 
   long getMaxConnectionWaitingTime();
 

--- a/jack-core/src/com/rapleaf/jack/transaction/DbMetricsImpl.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/DbMetricsImpl.java
@@ -118,7 +118,7 @@ public class DbMetricsImpl implements DbMetrics {
     summary += String.format("\nAverage number of Active connections : %,.2f", getAverageActiveConnections());
     summary += ("\nTotal number of queries/executions : " + getTotalQueries());
     summary += ("\nConnections created : " + getCreatedConnectionsCount());
-    summary += String.format("\n Max capacity time (%%) : %,.2f %%", 100 * getMaxConnectionsProportion());
+    summary += String.format("\n Max capacity time (%%) : %,.2f %%", 100 * getMaxConnectionsProportion());//TODO refactor the names
     summary += String.format("\nAverage connection waiting time : %,.2f ms", getAverageConnectionWaitingTime());
     summary += String.format("\nMaximum connection waiting time : %d ms", getMaxConnectionWaitingTime());
     summary += ("\nTransactor lifetime : " + getLifeTime() + " ms");

--- a/jack-core/src/com/rapleaf/jack/transaction/DbMetricsImpl.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/DbMetricsImpl.java
@@ -118,7 +118,7 @@ public class DbMetricsImpl implements DbMetrics {
     summary += String.format("\nAverage number of Active connections : %,.2f", getAverageActiveConnections());
     summary += ("\nTotal number of queries/executions : " + getTotalQueries());
     summary += ("\nConnections created : " + getCreatedConnectionsCount());
-    summary += String.format("\n Max capacity time (%%) : %,.2f %%", 100 * getMaxCapacityProportion());
+    summary += String.format("\nMax capacity time (%%) : %,.2f %%", 100 * getMaxCapacityProportion());
     summary += String.format("\nAverage connection waiting time : %,.2f ms", getAverageConnectionWaitingTime());
     summary += String.format("\nMaximum connection waiting time : %d ms", getMaxConnectionWaitingTime());
     summary += ("\nTransactor lifetime : " + getLifeTime() + " ms");

--- a/jack-core/src/com/rapleaf/jack/transaction/DbMetricsImpl.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/DbMetricsImpl.java
@@ -72,7 +72,7 @@ public class DbMetricsImpl implements DbMetrics {
   }
 
   @Override
-  public double getMaxConnectionsProportion() {
+  public double getMaxCapacityProportion() {
     return (double)maxActiveConnectionsTime / (double)getLifeTime();
   }
 
@@ -118,7 +118,7 @@ public class DbMetricsImpl implements DbMetrics {
     summary += String.format("\nAverage number of Active connections : %,.2f", getAverageActiveConnections());
     summary += ("\nTotal number of queries/executions : " + getTotalQueries());
     summary += ("\nConnections created : " + getCreatedConnectionsCount());
-    summary += String.format("\n Max capacity time (%%) : %,.2f %%", 100 * getMaxConnectionsProportion());//TODO refactor the names
+    summary += String.format("\n Max capacity time (%%) : %,.2f %%", 100 * getMaxCapacityProportion());
     summary += String.format("\nAverage connection waiting time : %,.2f ms", getAverageConnectionWaitingTime());
     summary += String.format("\nMaximum connection waiting time : %d ms", getMaxConnectionWaitingTime());
     summary += ("\nTransactor lifetime : " + getLifeTime() + " ms");

--- a/jack-core/src/com/rapleaf/jack/transaction/DbPoolManager.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/DbPoolManager.java
@@ -133,7 +133,6 @@ class DbPoolManager<DB extends IDb> implements IDbManager<DB> {
       metrics.update(false, connectionPool);
       return metrics;
     }
-
   }
 
   @VisibleForTesting

--- a/jack-core/src/com/rapleaf/jack/transaction/DbPoolManager.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/DbPoolManager.java
@@ -133,6 +133,7 @@ class DbPoolManager<DB extends IDb> implements IDbManager<DB> {
       metrics.update(false, connectionPool);
       return metrics;
     }
+
   }
 
   @VisibleForTesting

--- a/jack-core/src/com/rapleaf/jack/transaction/MockDbMetrics.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/MockDbMetrics.java
@@ -12,7 +12,7 @@ public class MockDbMetrics implements DbMetrics {
   }
 
   @Override
-  public double getMaxConnectionsProportion() {
+  public double getMaxCapacityProportion() {
     return 0;
   }
 

--- a/jack-core/src/com/rapleaf/jack/transaction/TransactorMetricsImpl.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/TransactorMetricsImpl.java
@@ -84,7 +84,7 @@ public class TransactorMetricsImpl implements TransactorMetrics {
   public String getSummary() {
     LinkedList<TransactorMetricElement> longestQueriesList = getLongestQueries();
     String summary = ("\n-----------------------QUERY METRICS-----------------------\n");
-    summary += String.format("\n Average Query execution time :  %,.2f ms", getAverageQueryExecutionTime());
+    summary += String.format("\nAverage Query execution time :  %,.2f ms", getAverageQueryExecutionTime());
     summary += "\n\n------" + longestQueriesSize + " QUERIES WITH LONGEST AVERAGE EXECUTION TIME------\n";
     for (TransactorMetricElement query : longestQueriesList) {
       summary += "\nClass name : " + query.getQueryTrace().getClassName();

--- a/jack-test/test/java/com/rapleaf/jack/transaction/TestDbMetrics.java
+++ b/jack-test/test/java/com/rapleaf/jack/transaction/TestDbMetrics.java
@@ -70,7 +70,7 @@ public class TestDbMetrics extends JackTestCase {
     sleepMillis(100);
     long totalTime = stopwatch.elapsedMillis();
     DbMetrics dbMetrics = transactor.getDbMetrics();
-    double maxConnectionsProportion = dbMetrics.getMaxConnectionsProportion();
+    double maxConnectionsProportion = dbMetrics.getMaxCapacityProportion();
     transactor.close();
     double expectedMaxConnectionsProportion = (double)timeActive / (double)totalTime;
 

--- a/jack-test/test/java/com/rapleaf/jack/transaction/TestDbMetrics.java
+++ b/jack-test/test/java/com/rapleaf/jack/transaction/TestDbMetrics.java
@@ -78,7 +78,7 @@ public class TestDbMetrics extends JackTestCase {
   }
 
 
-  @Test
+  //@Test
   public void testMaxConnectionWaitingTime() throws Exception {
     TransactorImpl<IDatabase1> transactor = transactorBuilder.setMetricsTracking(true).setMaxTotalConnections(1).get();
     Future<Long> future1 = executorService.submit(

--- a/jack-test/test/java/com/rapleaf/jack/transaction/TestDbMetrics.java
+++ b/jack-test/test/java/com/rapleaf/jack/transaction/TestDbMetrics.java
@@ -109,8 +109,7 @@ public class TestDbMetrics extends JackTestCase {
     double expectedMaxConnectionsWaitingTime = Math.max(measuredMaxWaitingTime, firstMaxConnectionWaitingTime);
 
     assertRoughEqual(maxConnectionsWaitingTime, expectedMaxConnectionsWaitingTime, 20);
-    //The first run is a bit different because of the setAutoCommit method,
-    // /we treat it separately and then measure the waiting time for the other runs
+    //The first setAutoCommit method call is slower than later calls. So the first call is treated differently in the test
 
   }
 
@@ -147,8 +146,7 @@ public class TestDbMetrics extends JackTestCase {
     double expectedAverageConnectionsWaitingTime = ((startingTimeSum - schedulingTimeSum) + firstAverageConnectionWaitingTime) / (connectionCount + 1);
 
     assertRoughEqual(averageConnectionsWaitingTime, expectedAverageConnectionsWaitingTime, .2 * expectedAverageConnectionsWaitingTime);
-    //The first run is a bit different because of the setAutoCommit method,
-    // /we treat it separately and then measure the waiting time for the other runs
+    //The first setAutoCommit method call is slower than later calls. So the first call is treated differently in the test
 
   }
 

--- a/jack-test/test/java/com/rapleaf/jack/transaction/TestDbMetrics.java
+++ b/jack-test/test/java/com/rapleaf/jack/transaction/TestDbMetrics.java
@@ -78,55 +78,78 @@ public class TestDbMetrics extends JackTestCase {
   }
 
 
-  //@Test
+  @Test
   public void testMaxConnectionWaitingTime() throws Exception {
     TransactorImpl<IDatabase1> transactor = transactorBuilder.setMetricsTracking(true).setMaxTotalConnections(1).get();
-    Future<Long> future1 = executorService.submit(
-        () -> transactor.query(a -> {
+    transactor.execute(a -> {});
+    double firstMaxConnectionWaitingTime = transactor.getDbMetrics().getMaxConnectionWaitingTime();
+    int connectionCount = 5;
+    final Long[] startingTimes = new Long[connectionCount];
+    final Long[] schedulingTimes = new Long[connectionCount];
+    Future[] futures = new Future[connectionCount];
+    for (int i = 0; i < connectionCount; i++) {
+      int finalI = i;
+      futures[i] = executorService.submit(() ->
+      {
+        schedulingTimes[finalI] = stopwatch.elapsedMillis();
+        transactor.execute(a -> {
+          startingTimes[finalI] = stopwatch.elapsedMillis();
           sleepMillis(100);
-          return stopwatch.elapsedMillis();
-        }));
-    final Long[] startingTime2 = new Long[1];
-    Future future2 = executorService.submit(
-        () -> {
-          startingTime2[0] = stopwatch.elapsedMillis();
-          transactor.execute(a -> {sleepMillis(100);});
         });
-    long finishingTime1 = future1.get();
-    future2.get();
+      });
+    }
+    long measuredMaxWaitingTime = 0;
+    for (int i = 0; i < connectionCount; i++) {
+      futures[i].get();
+      measuredMaxWaitingTime = Math.max(measuredMaxWaitingTime, startingTimes[i] - schedulingTimes[i]);
+    }
     DbMetrics dbMetrics = transactor.getDbMetrics();
     double maxConnectionsWaitingTime = dbMetrics.getMaxConnectionWaitingTime();
     transactor.close();
-    double expectedMaxConnectionsWaitingTime = finishingTime1 - startingTime2[0];
-    LOG.info("maxConnectionsWaitingTime : {} ms", maxConnectionsWaitingTime);
-    LOG.info("expected maxConnectionsWaitingTime {} ms", expectedMaxConnectionsWaitingTime);
-    expectedMaxConnectionsWaitingTime = (expectedMaxConnectionsWaitingTime > 0) ? expectedMaxConnectionsWaitingTime : 0;
+    double expectedMaxConnectionsWaitingTime = Math.max(measuredMaxWaitingTime, firstMaxConnectionWaitingTime);
 
     assertRoughEqual(maxConnectionsWaitingTime, expectedMaxConnectionsWaitingTime, 20);
+    //The first run is a bit different because of the setAutoCommit method,
+    // /we treat it separately and then measure the waiting time for the other runs
+
   }
 
-  // @Test
+  @Test
   public void testAverageConnectionWaitingTime() throws Exception {
     TransactorImpl<IDatabase1> transactor = transactorBuilder.setMetricsTracking(true).setMaxTotalConnections(1).get();
-    Future<Long> future1 = executorService.submit(() -> transactor.query(a -> {
-      sleepMillis(100);
-      return stopwatch.elapsedMillis();
-    }));
-    final Long[] startingTime2 = new Long[1];
-    Future future2 = executorService.submit(
-        () -> {
-          startingTime2[0] = stopwatch.elapsedMillis();
-          transactor.execute(a -> {sleepMillis(100);});
+    transactor.execute(a -> {});
+    double firstAverageConnectionWaitingTime = transactor.getDbMetrics().getAverageConnectionWaitingTime();
+    int connectionCount = 5;
+    final Long[] startingTimes = new Long[connectionCount];
+    final Long[] schedulingTimes = new Long[connectionCount];
+    Future[] futures = new Future[connectionCount];
+    for (int i = 0; i < connectionCount; i++) {
+      int finalI = i;
+      futures[i] = executorService.submit(() ->
+      {
+        schedulingTimes[finalI] = stopwatch.elapsedMillis();
+        transactor.execute(a -> {
+          startingTimes[finalI] = stopwatch.elapsedMillis();
+          sleepMillis(100);
         });
-    long finishingTime1 = future1.get();
-    future2.get();
+      });
+    }
+    long startingTimeSum = 0;
+    long schedulingTimeSum = 0;
+    for (int i = 0; i < connectionCount; i++) {
+      futures[i].get();
+      startingTimeSum += startingTimes[i];
+      schedulingTimeSum += schedulingTimes[i];
+    }
     DbMetrics dbMetrics = transactor.getDbMetrics();
     double averageConnectionsWaitingTime = dbMetrics.getAverageConnectionWaitingTime();
     transactor.close();
-    double expectedAverageConnectionsWaitingTime = (finishingTime1 - startingTime2[0]) / 2;
-    expectedAverageConnectionsWaitingTime = (expectedAverageConnectionsWaitingTime > 0) ? expectedAverageConnectionsWaitingTime : 0;
+    double expectedAverageConnectionsWaitingTime = ((startingTimeSum - schedulingTimeSum) + firstAverageConnectionWaitingTime) / (connectionCount + 1);
 
-    assertRoughEqual(averageConnectionsWaitingTime, expectedAverageConnectionsWaitingTime, 15);
+    assertRoughEqual(averageConnectionsWaitingTime, expectedAverageConnectionsWaitingTime, .2 * expectedAverageConnectionsWaitingTime);
+    //The first run is a bit different because of the setAutoCommit method,
+    // /we treat it separately and then measure the waiting time for the other runs
+
   }
 
   @Test

--- a/jack-test/test/java/com/rapleaf/jack/transaction/TestTransactorMetrics.java
+++ b/jack-test/test/java/com/rapleaf/jack/transaction/TestTransactorMetrics.java
@@ -98,7 +98,7 @@ public class TestTransactorMetrics extends JackTestCase {
   public void testQueryOverhead() throws Exception {
     TransactorImpl<IDatabase1> transactor1 = transactorBuilder.setMetricsTracking(false).get();
     long startTime1 = stopwatch.elapsedMillis();
-    int totalRuns = 10;
+    int totalRuns = 50;
     for (int i = 0; i < totalRuns; i++) {
       transactor1.execute(db -> {
         Thread.sleep(20);


### PR DESCRIPTION
There was a null pointer exception in the transactor metrics priority queue.
I assume this was due to a synchronization issue, I handled it and handled the null exception separately.
