### PR TITLE
Add SELECT DISTINCT support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source "http://rubygems.org"
 gem "activesupport", ">=3.0.0"
 gem "i18n", "0.5.0"
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,4 +12,4 @@ DEPENDENCIES
   i18n (= 0.5.0)
 
 BUNDLED WITH
-   1.12.5
+   1.15.1

--- a/jack-core/src/com/rapleaf/jack/queries/GenericQuery.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericQuery.java
@@ -165,14 +165,9 @@ public class GenericQuery extends AbstractExecution {
     return this;
   }
 
-  public GenericQuery selectDistinct(Collection<Column> columns) {
+  public GenericQuery distinct() {
     this.selectDistinct = true;
-    return select(columns);
-  }
-
-  public GenericQuery selectDistinct(Column column, Column... columns) {
-    this.selectDistinct = true;
-    return select(column, columns);
+    return this;
   }
 
   public Records fetch() throws IOException {

--- a/jack-core/src/com/rapleaf/jack/queries/GenericQuery.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericQuery.java
@@ -33,6 +33,7 @@ public class GenericQuery extends AbstractExecution {
   private final Set<Column> selectedColumns;
   private final Set<Column> groupByColumns;
   private Optional<LimitCriterion> limitCriteria;
+  private boolean selectDistinct;
 
   private GenericQuery(BaseDatabaseConnection dbConnection, TableReference tableReference, PostQueryAction postQueryAction) {
     super(dbConnection);
@@ -45,6 +46,7 @@ public class GenericQuery extends AbstractExecution {
     this.selectedColumns = Sets.newHashSet();
     this.groupByColumns = Sets.newHashSet();
     this.limitCriteria = Optional.empty();
+    this.selectDistinct = false;
   }
 
   public static Builder create(BaseDatabaseConnection dbConnection) {
@@ -163,6 +165,16 @@ public class GenericQuery extends AbstractExecution {
     return this;
   }
 
+  public GenericQuery selectDistinct(Collection<Column> columns) {
+    this.selectDistinct = true;
+    return select(columns);
+  }
+
+  public GenericQuery selectDistinct(Column column, Column... columns) {
+    this.selectDistinct = true;
+    return select(column, columns);
+  }
+
   public Records fetch() throws IOException {
     int retryCount = 0;
     final QueryStatistics.Measurer statTracker = new QueryStatistics.Measurer();
@@ -234,7 +246,8 @@ public class GenericQuery extends AbstractExecution {
         selectedColumns.addAll(tableReference.getTable().getAllColumns());
       }
     }
-    return getClauseFromColumns(selectedColumns, "SELECT ", ", ", " ");
+    String initialKeyword = selectDistinct ? "SELECT DISTINCT " : "SELECT ";
+    return getClauseFromColumns(selectedColumns, initialKeyword, ", ", " ");
   }
 
   private String getFromClause() {

--- a/jack-test/test/java/com/rapleaf/jack/queries/TestGenericQuery.java
+++ b/jack-test/test/java/com/rapleaf/jack/queries/TestGenericQuery.java
@@ -926,4 +926,21 @@ public class TestGenericQuery {
       // expected
     }
   }
+
+  @Test
+  public void testSelectDistinct() throws Exception {
+    String selectStatement = db.createQuery()
+        .from(User.TBL)
+        .select(User.TBL.getAllColumns())
+        .getQueryStatement();
+
+    String selectDistinctStatement = db.createQuery()
+        .from(User.TBL)
+        .selectDistinct(User.TBL.getAllColumns())
+        .getQueryStatement();
+
+    assertFalse(selectStatement.contains("SELECT DISTINCT"));
+    assertTrue(selectDistinctStatement.contains("SELECT DISTINCT"));
+  }
+
 }

--- a/jack-test/test/java/com/rapleaf/jack/queries/TestGenericQuery.java
+++ b/jack-test/test/java/com/rapleaf/jack/queries/TestGenericQuery.java
@@ -936,7 +936,7 @@ public class TestGenericQuery {
 
     String selectDistinctStatement = db.createQuery()
         .from(User.TBL)
-        .selectDistinct(User.TBL.getAllColumns())
+        .select(User.TBL.getAllColumns()).distinct()
         .getQueryStatement();
 
     assertFalse(selectStatement.contains("SELECT DISTINCT"));

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/models/TestStore.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/models/TestStore.java
@@ -33,7 +33,7 @@ import com.rapleaf.jack.util.JackUtility;
 
 public class TestStore extends ModelWithId<TestStore, IDatabases> implements Comparable<TestStore>{
   
-  public static final long serialVersionUID = -7579351792365343876L;
+  public static final long serialVersionUID = -7014741754758282419L;
 
   public static class Tbl extends AbstractTable<TestStore.Attributes, TestStore> {
     public final Column<Long> ID;
@@ -435,7 +435,7 @@ public class TestStore extends ModelWithId<TestStore, IDatabases> implements Com
   
   public static class Attributes extends AttributesWithId {
     
-    public static final long serialVersionUID = -7579351792365343876L;
+    public static final long serialVersionUID = -7014741754758282419L;
 
     // Fields
     private Integer __entry_type;


### PR DESCRIPTION
Adds a new generic query method, `selectDistinct`, which results in a `SELECT DISTINCT` query instead of `SELECT`. This is necessary for filtering out duplicate rows in queries with joins.