### PR TITLE
add getters for username and password

### DIFF
--- a/jack-core/src/com/rapleaf/jack/DatabaseConnection.java
+++ b/jack-core/src/com/rapleaf/jack/DatabaseConnection.java
@@ -60,6 +60,7 @@ public class DatabaseConnection extends BaseDatabaseConnection {
 
 
   private final String connectionString;
+  private final String dbName;
   private final Optional<String> username;
   private final Optional<String> password;
 
@@ -88,8 +89,8 @@ public class DatabaseConnection extends BaseDatabaseConnection {
     if (config.getPort().isPresent()) {
       connectionStringBuilder.append(":").append(config.getPort().get());
     }
-    connectionStringBuilder.append("/").append(getDbName(config.getDatabaseName(), config.enableParallelTests()));
-    connectionString = connectionStringBuilder.toString();
+    dbName = getDbName(config.getDatabaseName(), config.enableParallelTests());
+    connectionString = connectionStringBuilder.append("/").append(dbName).toString();
     username = config.getUsername();
     password = config.getPassword();
 
@@ -103,6 +104,10 @@ public class DatabaseConnection extends BaseDatabaseConnection {
 
   public Optional<String> getPassword() {
     return password;
+  }
+
+  public String getDbName() {
+    return dbName;
   }
 
   /**

--- a/jack-core/src/com/rapleaf/jack/DatabaseConnection.java
+++ b/jack-core/src/com/rapleaf/jack/DatabaseConnection.java
@@ -97,6 +97,14 @@ public class DatabaseConnection extends BaseDatabaseConnection {
     updateExpiration();
   }
 
+  public Optional<String> getUsername() {
+    return username;
+  }
+
+  public Optional<String> getPassword() {
+    return password;
+  }
+
   /**
    * Get a Connection to a database. If there is no connection, create a new one.
    * If the connection hasn't been used in a long time, close it and create a new one.


### PR DESCRIPTION
@tuliren on a scale of 1-10, how bad is this?  I'd like to hijack the DatabaseConnection class to get credentials from config/database.yml, but use them for some separate jetty initialization, and it would be a nuisance to try to get it to use the connection provided here.