### PR TITLE
Ignore Null When Inserting New Row

### DIFF
--- a/jack-core/src/com/rapleaf/jack/AbstractDatabaseModel.java
+++ b/jack-core/src/com/rapleaf/jack/AbstractDatabaseModel.java
@@ -56,7 +56,7 @@ public abstract class AbstractDatabaseModel<T extends ModelWithId<T, ? extends G
   private final String setFieldsPrepStatementSection;
   private final String lockFieldName;
 
-  protected interface InsertStatementCreator {
+  protected interface StatementCreator {
     String getStatement();
 
     void setStatement(PreparedStatement statement) throws SQLException;
@@ -156,7 +156,7 @@ public abstract class AbstractDatabaseModel<T extends ModelWithId<T, ? extends G
 
   protected abstract T instanceFromResultSet(ResultSet rs, Set<Enum> selectedFields) throws SQLException;
 
-  protected long realCreate(InsertStatementCreator statementCreator) throws IOException {
+  protected long realCreate(StatementCreator statementCreator) throws IOException {
     int retryCount = 0;
 
     PreparedStatement stmt = null;

--- a/jack-core/src/com/rapleaf/jack/AbstractDatabaseModel.java
+++ b/jack-core/src/com/rapleaf/jack/AbstractDatabaseModel.java
@@ -30,7 +30,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Optional;

--- a/jack-core/src/com/rapleaf/jack/AbstractDatabaseModel.java
+++ b/jack-core/src/com/rapleaf/jack/AbstractDatabaseModel.java
@@ -252,7 +252,7 @@ public abstract class AbstractDatabaseModel<T extends ModelWithId<T, ? extends G
       return !rs.isBeforeFirst();
     } catch (SQLException e) {
       throw new IOException(e);
-    }finally {
+    } finally {
       closeQuery(rs, statement);
     }
 
@@ -626,7 +626,7 @@ public abstract class AbstractDatabaseModel<T extends ModelWithId<T, ? extends G
     return foundList;
   }
 
-  protected abstract void setAttrs(T model, PreparedStatement stmt)
+  protected abstract void setAttrs(T model, PreparedStatement stmt, boolean setNull)
       throws SQLException;
 
   // ActiveRecord documentation says it supports optimistic locking using integer fields
@@ -670,7 +670,7 @@ public abstract class AbstractDatabaseModel<T extends ModelWithId<T, ? extends G
   private boolean insertStrict(T model, Long oldUpdatedAt) throws JackException, IOException {
     PreparedStatement insertStmt = conn.getPreparedStatement(getInsertWithIdStatement(fieldNames));
     try {
-      setAttrs(model, insertStmt);
+      setAttrs(model, insertStmt, false);
       insertStmt.setLong(fieldNames.size() + 1, model.getId());
       insertStmt.execute();
       final int updateCount = insertStmt.getUpdateCount();
@@ -929,7 +929,7 @@ public abstract class AbstractDatabaseModel<T extends ModelWithId<T, ? extends G
 
       @Override
       public PreparedStatement setParams(AbstractDatabaseModel<A> baseModel, A modelInstance, PreparedStatement statement) throws SQLException {
-        baseModel.setAttrs(modelInstance, statement);
+        baseModel.setAttrs(modelInstance, statement, true);
         return statement;
       }
     }
@@ -947,7 +947,7 @@ public abstract class AbstractDatabaseModel<T extends ModelWithId<T, ? extends G
 
       @Override
       public PreparedStatement setParams(AbstractDatabaseModel<A> baseModel, A modelInstance, PreparedStatement statement) throws SQLException {
-        baseModel.setAttrs(modelInstance, statement);
+        baseModel.setAttrs(modelInstance, statement, true);
         // the lock_version is after all the field params and the id param
         statement.setLong(numFieldNames + 2, lockVersion);
         return statement;

--- a/jack-core/src/rb/templates/create_method.erb
+++ b/jack-core/src/rb/templates/create_method.erb
@@ -21,25 +21,44 @@
 
 <% end %>
   public <%= model_defn.model_name %> create(<%= signature %>) throws IOException {
-    long __id = realCreate(new AttrSetter() {
-      public void set(PreparedStatement stmt) throws SQLException {
-<% x = 1 %>
+    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+      private final List<String> nonNullFields = new ArrayList<>();
+      private final List<AttrSetter> statementSetters = new ArrayList<>();
+
+      {
+        int index = 1;
+
 <% model_defn.fields.each do |field_defn| %>
   <% if !field_defn.nullable? || !only_not_null %>
     <% if field_defn.nullable? %>
-        if (<%= field_defn.name %> == null) {
-          stmt.setNull(<%=x%>, java.sql.Types.<%= field_defn.sql_type%>);
-        } else {
-    <% end %>
-          stmt.set<%=field_defn.prep_stmt_type%>(<%=x%>, <%=field_defn.prep_stmt_modifier(field_defn.name)%>);
-    <% if field_defn.nullable? %>
+        if (<%=field_defn.name%> != null) {
+          nonNullFields.add("<%=field_defn.name%>");
+          int fieldIndex<%= field_defn.ordinal %> = index++;
+          statementSetters.add(stmt -> stmt.set<%=field_defn.prep_stmt_type%>(fieldIndex<%= field_defn.ordinal %>, <%=field_defn.prep_stmt_modifier(field_defn.name)%>));
         }
+    <% else %>
+        nonNullFields.add("<%=field_defn.name%>");
+        int fieldIndex<%= field_defn.ordinal %> = index++;
+        statementSetters.add(stmt -> stmt.set<%=field_defn.prep_stmt_type%>(fieldIndex<%= field_defn.ordinal %>, <%=field_defn.prep_stmt_modifier(field_defn.name)%>));
     <% end %>
-    <% x+= 1 %>
   <% end %>
 <% end %>
       }
-    }, getInsertStatement(<%= "Arrays.<String>asList(" + model_defn.field_names_list(only_not_null) + ")"  %>));
+
+      @Override
+      public String getStatement() {
+        return getInsertStatement(nonNullFields);
+      }
+
+      @Override
+      public void setStatement(PreparedStatement statement) throws SQLException {
+        for (AttrSetter setter : statementSetters) {
+          setter.set(statement);
+        }
+      }
+    };
+
+    long __id = realCreate(statementCreator);
 <% names_only = model_defn.fields.map{|field_defn| !field_defn.nullable? || !only_not_null ? field_defn.name : "null"}.join(", ") %>
     <%= model_defn.model_name %> newInst = new <%= model_defn.model_name %>(__id<%= names_only.empty? ? "" : ", "%><%= names_only %>, databases);
     newInst.setCreated(true);
@@ -47,4 +66,3 @@
     clearForeignKeyCache();
     return newInst;
   }
-

--- a/jack-core/src/rb/templates/create_method.erb
+++ b/jack-core/src/rb/templates/create_method.erb
@@ -27,16 +27,17 @@
 
       {
         int index = 1;
-
 <% model_defn.fields.each do |field_defn| %>
   <% if !field_defn.nullable? || !only_not_null %>
     <% if field_defn.nullable? %>
+
         if (<%=field_defn.name%> != null) {
           nonNullFields.add("<%=field_defn.name%>");
           int fieldIndex<%= field_defn.ordinal %> = index++;
           statementSetters.add(stmt -> stmt.set<%=field_defn.prep_stmt_type%>(fieldIndex<%= field_defn.ordinal %>, <%=field_defn.prep_stmt_modifier(field_defn.name)%>));
         }
     <% else %>
+
         nonNullFields.add("<%=field_defn.name%>");
         int fieldIndex<%= field_defn.ordinal %> = index++;
         statementSetters.add(stmt -> stmt.set<%=field_defn.prep_stmt_type%>(fieldIndex<%= field_defn.ordinal %>, <%=field_defn.prep_stmt_modifier(field_defn.name)%>));

--- a/jack-core/src/rb/templates/create_method.erb
+++ b/jack-core/src/rb/templates/create_method.erb
@@ -24,27 +24,29 @@
     StatementCreator statementCreator = new StatementCreator() {
       private final List<String> nonNullFields = new ArrayList<>();
       private final List<AttrSetter> statementSetters = new ArrayList<>();
+<% if !only_not_null || model_defn.fields.select{|f| !f.nullable?}.any? %>
 
       {
         int index = 1;
-<% model_defn.fields.each do |field_defn| %>
-  <% if !field_defn.nullable? || !only_not_null %>
-    <% if field_defn.nullable? %>
+  <% model_defn.fields.each do |field_defn| %>
+    <% if !field_defn.nullable? || !only_not_null %>
+      <% if field_defn.nullable? %>
 
         if (<%=field_defn.name%> != null) {
           nonNullFields.add("<%=field_defn.name%>");
           int fieldIndex<%= field_defn.ordinal %> = index++;
           statementSetters.add(stmt -> stmt.set<%=field_defn.prep_stmt_type%>(fieldIndex<%= field_defn.ordinal %>, <%=field_defn.prep_stmt_modifier(field_defn.name)%>));
         }
-    <% else %>
+      <% else %>
 
         nonNullFields.add("<%=field_defn.name%>");
         int fieldIndex<%= field_defn.ordinal %> = index++;
         statementSetters.add(stmt -> stmt.set<%=field_defn.prep_stmt_type%>(fieldIndex<%= field_defn.ordinal %>, <%=field_defn.prep_stmt_modifier(field_defn.name)%>));
+      <% end %>
     <% end %>
   <% end %>
-<% end %>
       }
+<% end %>
 
       @Override
       public String getStatement() {

--- a/jack-core/src/rb/templates/create_method.erb
+++ b/jack-core/src/rb/templates/create_method.erb
@@ -21,7 +21,7 @@
 
 <% end %>
   public <%= model_defn.model_name %> create(<%= signature %>) throws IOException {
-    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+    StatementCreator statementCreator = new StatementCreator() {
       private final List<String> nonNullFields = new ArrayList<>();
       private final List<AttrSetter> statementSetters = new ArrayList<>();
 

--- a/jack-core/src/rb/templates/persistence_impl.erb
+++ b/jack-core/src/rb/templates/persistence_impl.erb
@@ -33,6 +33,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.util.function.Supplier;
 
 import <%= JACK_NAMESPACE %>.AbstractDatabaseModel;
 import <%= JACK_NAMESPACE %>.BaseDatabaseConnection;

--- a/jack-core/src/rb/templates/persistence_impl.erb
+++ b/jack-core/src/rb/templates/persistence_impl.erb
@@ -186,11 +186,11 @@ public class <%= model_defn.impl_name %> extends AbstractDatabaseModel<<%= model
   }
 
   @Override
-  protected void setAttrs(<%= model_defn.model_name %> model, PreparedStatement stmt) throws SQLException {
+  protected void setAttrs(<%= model_defn.model_name %> model, PreparedStatement stmt, boolean setNull) throws SQLException {
     <% x = 1 %>
     <% model_defn.fields.each do |field_defn| %>
     <% if field_defn.nullable? %>
-    if (model.<%= field_defn.getter %> == null) {
+    if (setNull && model.<%= field_defn.getter %> == null) {
       stmt.setNull(<%= x %>, java.sql.Types.<%= field_defn.sql_type %>);
     } else {
     <% else %>

--- a/jack-core/src/rb/templates/persistence_impl.erb
+++ b/jack-core/src/rb/templates/persistence_impl.erb
@@ -187,24 +187,26 @@ public class <%= model_defn.impl_name %> extends AbstractDatabaseModel<<%= model
 
   @Override
   protected void setAttrs(<%= model_defn.model_name %> model, PreparedStatement stmt, boolean setNull) throws SQLException {
-    <% x = 1 %>
+    int index = 1;
     <% model_defn.fields.each do |field_defn| %>
     <% if field_defn.nullable? %>
     if (setNull && model.<%= field_defn.getter %> == null) {
-      stmt.setNull(<%= x %>, java.sql.Types.<%= field_defn.sql_type %>);
+      stmt.setNull(index, java.sql.Types.<%= field_defn.sql_type %>);
+      ++index;
     } else if (model.<%= field_defn.getter %> != null) {
     <% else %>
     {
     <% end %>
     <% if field_defn.name == "lock_version" and field_defn.data_type == :integer  %>
-      stmt.set<%= field_defn.prep_stmt_type %>(<%= x %>, <%= field_defn.prep_stmt_modifier("model.#{field_defn.getter} + 1") %>);
+      stmt.set<%= field_defn.prep_stmt_type %>(index, <%= field_defn.prep_stmt_modifier("model.#{field_defn.getter} + 1") %>);
+      ++index;
     <% else %>
-      stmt.set<%= field_defn.prep_stmt_type %>(<%= x %>, <%= field_defn.prep_stmt_modifier("model.#{field_defn.getter}") %>);
+      stmt.set<%= field_defn.prep_stmt_type %>(index, <%= field_defn.prep_stmt_modifier("model.#{field_defn.getter}") %>);
+      ++index;
     <% end %>
     }
-      <% x+= 1 %>
     <% end %>
-    stmt.setLong(<%= x %>, model.getId());
+    stmt.setLong(index, model.getId());
   }
 
   @Override

--- a/jack-core/src/rb/templates/persistence_impl.erb
+++ b/jack-core/src/rb/templates/persistence_impl.erb
@@ -20,9 +20,6 @@ import java.sql.SQLRecoverableException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -33,21 +30,15 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Date;
 import java.sql.Timestamp;
-import java.util.function.Supplier;
 
 import <%= JACK_NAMESPACE %>.AbstractDatabaseModel;
 import <%= JACK_NAMESPACE %>.BaseDatabaseConnection;
-import <%= JACK_NAMESPACE %>.queries.where_operators.IWhereOperator;
 import <%= JACK_NAMESPACE %>.queries.WhereConstraint;
 import <%= JACK_NAMESPACE %>.queries.WhereClause;
-import <%= JACK_NAMESPACE %>.queries.ModelQuery;
-import <%= JACK_NAMESPACE %>.ModelWithId;
-import <%= JACK_NAMESPACE %>.util.JackUtility;
 import <%= root_package %>.iface.<%= model_defn.iface_name %>;
 import <%= root_package %>.models.<%= model_defn.model_name %>;
 import <%= root_package %>.query.<%= model_defn.query_builder_name %>;
 import <%= root_package %>.query.<%= model_defn.delete_builder_name %>;
-
 
 import <%= project_defn.databases_namespace %>.IDatabases;
 

--- a/jack-core/src/rb/templates/persistence_impl.erb
+++ b/jack-core/src/rb/templates/persistence_impl.erb
@@ -191,18 +191,15 @@ public class <%= model_defn.impl_name %> extends AbstractDatabaseModel<<%= model
     <% model_defn.fields.each do |field_defn| %>
     <% if field_defn.nullable? %>
     if (setNull && model.<%= field_defn.getter %> == null) {
-      stmt.setNull(index, java.sql.Types.<%= field_defn.sql_type %>);
-      ++index;
+      stmt.setNull(index++, java.sql.Types.<%= field_defn.sql_type %>);
     } else if (model.<%= field_defn.getter %> != null) {
     <% else %>
     {
     <% end %>
     <% if field_defn.name == "lock_version" and field_defn.data_type == :integer  %>
-      stmt.set<%= field_defn.prep_stmt_type %>(index, <%= field_defn.prep_stmt_modifier("model.#{field_defn.getter} + 1") %>);
-      ++index;
+      stmt.set<%= field_defn.prep_stmt_type %>(index++, <%= field_defn.prep_stmt_modifier("model.#{field_defn.getter} + 1") %>);
     <% else %>
-      stmt.set<%= field_defn.prep_stmt_type %>(index, <%= field_defn.prep_stmt_modifier("model.#{field_defn.getter}") %>);
-      ++index;
+      stmt.set<%= field_defn.prep_stmt_type %>(index++, <%= field_defn.prep_stmt_modifier("model.#{field_defn.getter}") %>);
     <% end %>
     }
     <% end %>

--- a/jack-core/src/rb/templates/persistence_impl.erb
+++ b/jack-core/src/rb/templates/persistence_impl.erb
@@ -192,7 +192,7 @@ public class <%= model_defn.impl_name %> extends AbstractDatabaseModel<<%= model
     <% if field_defn.nullable? %>
     if (setNull && model.<%= field_defn.getter %> == null) {
       stmt.setNull(<%= x %>, java.sql.Types.<%= field_defn.sql_type %>);
-    } else {
+    } else if (model.<%= field_defn.getter %> != null) {
     <% else %>
     {
     <% end %>

--- a/jack-test/test/java/com/rapleaf/jack/LoggingMysqlConnection.java
+++ b/jack-test/test/java/com/rapleaf/jack/LoggingMysqlConnection.java
@@ -1,0 +1,34 @@
+package com.rapleaf.jack;
+
+import java.sql.PreparedStatement;
+import java.util.List;
+
+import com.google.common.collect.Lists;
+
+public class LoggingMysqlConnection extends MysqlDatabaseConnection {
+
+  private final List<String> preparedStatements = Lists.newArrayList();
+
+  public LoggingMysqlConnection(String dbNameKey) {
+    super(dbNameKey);
+  }
+
+  public PreparedStatement getPreparedStatement(String statement) {
+    preparedStatements.add(statement);
+    return super.getPreparedStatement(statement);
+  }
+
+  public PreparedStatement getPreparedStatement(String statement, int options) {
+    preparedStatements.add(statement);
+    return super.getPreparedStatement(statement, options);
+  }
+
+  public List<String> getPreparedStatements() {
+    return preparedStatements;
+  }
+
+  public void clearPreparedStatements() {
+    preparedStatements.clear();
+  }
+
+}

--- a/jack-test/test/java/com/rapleaf/jack/TestAbstractDatabaseModel.java
+++ b/jack-test/test/java/com/rapleaf/jack/TestAbstractDatabaseModel.java
@@ -33,16 +33,12 @@ public class TestAbstractDatabaseModel extends BaseDatabaseModelTestCase {
 
   @Test
   public void testIsEmpty() throws IOException {
-
     ICommentPersistence comments = dbs.getDatabase1().comments();
     assertTrue(comments.isEmpty());
 
     comments.create("comment", 1, 1, 1);
-
     assertFalse(comments.isEmpty());
-
   }
-
 
   @Test
   public void testFindAllByForeignKeyCache() throws Exception {
@@ -91,7 +87,7 @@ public class TestAbstractDatabaseModel extends BaseDatabaseModelTestCase {
   public void testOptimisticLockingHasNoEffectWhileCaching() throws IOException {
     final IUserPersistence users = dbs.getDatabase1().users();
     final User user = users.create("handle1", 1);
-    user.setCreatedAtMillis(1l);
+    user.setCreatedAtMillis(1L);
     if (!user.save()) {
       fail("Failed to setup test properly");
     }
@@ -99,15 +95,15 @@ public class TestAbstractDatabaseModel extends BaseDatabaseModelTestCase {
     final User user1 = users.find(user.getId());
     final User user2 = users.find(user.getId());
 
-    user1.setCreatedAtMillis(2l);
+    user1.setCreatedAtMillis(2L);
     user1.save();
 
-    user2.setCreatedAtMillis(3l);
+    user2.setCreatedAtMillis(3L);
     user2.save();
 
     final User finalUser = users.find(user.getId());
 
-    assertEquals(3l, finalUser.getCreatedAtMillis().longValue());
+    assertEquals(3L, finalUser.getCreatedAtMillis().longValue());
 
     final ILockableModelPersistence lockableModels = dbs.getDatabase1().lockableModels();
     final LockableModel lockableModel = lockableModels.createDefaultInstance();
@@ -137,7 +133,7 @@ public class TestAbstractDatabaseModel extends BaseDatabaseModelTestCase {
     dbs.getDatabase1().disableCaching();
     final IUserPersistence users = dbs.getDatabase1().users();
     final User user = users.create("handle1", 1);
-    user.setCreatedAtMillis(1l);
+    user.setCreatedAtMillis(1L);
     if (!user.save()) {
       fail("Failed to setup test properly");
     }
@@ -145,15 +141,15 @@ public class TestAbstractDatabaseModel extends BaseDatabaseModelTestCase {
     final User user1 = users.find(user.getId());
     final User user2 = users.find(user.getId());
 
-    user1.setCreatedAtMillis(2l);
+    user1.setCreatedAtMillis(2L);
     user1.save();
 
-    user2.setCreatedAtMillis(3l);
+    user2.setCreatedAtMillis(3L);
     user2.save();
 
     final User finalUser = users.find(user.getId());
 
-    assertEquals(3l, finalUser.getCreatedAtMillis().longValue());
+    assertEquals(3L, finalUser.getCreatedAtMillis().longValue());
   }
 
   @Test

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseCommentPersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseCommentPersistenceImpl.java
@@ -215,8 +215,8 @@ public class BaseCommentPersistenceImpl extends AbstractDatabaseModel<Comment> i
   }
 
   @Override
-  protected void setAttrs(Comment model, PreparedStatement stmt) throws SQLException {
-    if (model.getContent() == null) {
+  protected void setAttrs(Comment model, PreparedStatement stmt, boolean setNull) throws SQLException {
+    if (setNull && model.getContent() == null) {
       stmt.setNull(1, java.sql.Types.CHAR);
     } else {
       stmt.setString(1, model.getContent());

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseCommentPersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseCommentPersistenceImpl.java
@@ -23,6 +23,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.util.function.Supplier;
 
 import com.rapleaf.jack.AbstractDatabaseModel;
 import com.rapleaf.jack.BaseDatabaseConnection;
@@ -62,18 +63,42 @@ public class BaseCommentPersistenceImpl extends AbstractDatabaseModel<Comment> i
     return this.create(content, commenter_id, commented_on_id, System.currentTimeMillis());
   }
   public Comment create(final String content, final int commenter_id, final long commented_on_id, final long created_at) throws IOException {
-    long __id = realCreate(new AttrSetter() {
-      public void set(PreparedStatement stmt) throws SQLException {
-        if (content == null) {
-          stmt.setNull(1, java.sql.Types.CHAR);
-        } else {
-          stmt.setString(1, content);
+    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+      private final List<String> nonNullFields = new ArrayList<>();
+      private final List<AttrSetter> statementSetters = new ArrayList<>();
+
+      {
+        int index = 1;
+        if (content != null) {
+          nonNullFields.add("content");
+          int fieldIndex0 = index++;
+          statementSetters.add(stmt -> stmt.setString(fieldIndex0, content));
         }
-          stmt.setInt(2, commenter_id);
-          stmt.setLong(3, commented_on_id);
-          stmt.setTimestamp(4, new Timestamp(created_at));
+        nonNullFields.add("commenter_id");
+        int fieldIndex1 = index++;
+        statementSetters.add(stmt -> stmt.setInt(fieldIndex1, commenter_id));
+        nonNullFields.add("commented_on_id");
+        int fieldIndex2 = index++;
+        statementSetters.add(stmt -> stmt.setLong(fieldIndex2, commented_on_id));
+        nonNullFields.add("created_at");
+        int fieldIndex3 = index++;
+        statementSetters.add(stmt -> stmt.setTimestamp(fieldIndex3, new Timestamp(created_at)));
       }
-    }, getInsertStatement(Arrays.<String>asList("content", "commenter_id", "commented_on_id", "created_at")));
+
+      @Override
+      public String getStatement() {
+        return getInsertStatement(nonNullFields);
+      }
+
+      @Override
+      public void setStatement(PreparedStatement statement) throws SQLException {
+        for (AttrSetter setter : statementSetters) {
+          setter.set(statement);
+        }
+      }
+    };
+
+    long __id = realCreate(statementCreator);
     Comment newInst = new Comment(__id, content, commenter_id, commented_on_id, created_at, databases);
     newInst.setCreated(true);
     cachedById.put(__id, newInst);
@@ -81,22 +106,44 @@ public class BaseCommentPersistenceImpl extends AbstractDatabaseModel<Comment> i
     return newInst;
   }
 
-
   public Comment create(final int commenter_id, final long commented_on_id, final long created_at) throws IOException {
-    long __id = realCreate(new AttrSetter() {
-      public void set(PreparedStatement stmt) throws SQLException {
-          stmt.setInt(1, commenter_id);
-          stmt.setLong(2, commented_on_id);
-          stmt.setTimestamp(3, new Timestamp(created_at));
+    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+      private final List<String> nonNullFields = new ArrayList<>();
+      private final List<AttrSetter> statementSetters = new ArrayList<>();
+
+      {
+        int index = 1;
+        nonNullFields.add("commenter_id");
+        int fieldIndex1 = index++;
+        statementSetters.add(stmt -> stmt.setInt(fieldIndex1, commenter_id));
+        nonNullFields.add("commented_on_id");
+        int fieldIndex2 = index++;
+        statementSetters.add(stmt -> stmt.setLong(fieldIndex2, commented_on_id));
+        nonNullFields.add("created_at");
+        int fieldIndex3 = index++;
+        statementSetters.add(stmt -> stmt.setTimestamp(fieldIndex3, new Timestamp(created_at)));
       }
-    }, getInsertStatement(Arrays.<String>asList("commenter_id", "commented_on_id", "created_at")));
+
+      @Override
+      public String getStatement() {
+        return getInsertStatement(nonNullFields);
+      }
+
+      @Override
+      public void setStatement(PreparedStatement statement) throws SQLException {
+        for (AttrSetter setter : statementSetters) {
+          setter.set(statement);
+        }
+      }
+    };
+
+    long __id = realCreate(statementCreator);
     Comment newInst = new Comment(__id, null, commenter_id, commented_on_id, created_at, databases);
     newInst.setCreated(true);
     cachedById.put(__id, newInst);
     clearForeignKeyCache();
     return newInst;
   }
-
 
   public Comment createDefaultInstance() throws IOException {
     return create(0, 0L, 0L);

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseCommentPersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseCommentPersistenceImpl.java
@@ -216,21 +216,27 @@ public class BaseCommentPersistenceImpl extends AbstractDatabaseModel<Comment> i
 
   @Override
   protected void setAttrs(Comment model, PreparedStatement stmt, boolean setNull) throws SQLException {
+    int index = 1;
     if (setNull && model.getContent() == null) {
-      stmt.setNull(1, java.sql.Types.CHAR);
-    } else {
-      stmt.setString(1, model.getContent());
+      stmt.setNull(index, java.sql.Types.CHAR);
+      ++index;
+    } else if (model.getContent() != null) {
+      stmt.setString(index, model.getContent());
+      ++index;
     }
     {
-      stmt.setInt(2, model.getCommenterId());
+      stmt.setInt(index, model.getCommenterId());
+      ++index;
     }
     {
-      stmt.setLong(3, model.getCommentedOnId());
+      stmt.setLong(index, model.getCommentedOnId());
+      ++index;
     }
     {
-      stmt.setTimestamp(4, new Timestamp(model.getCreatedAt()));
+      stmt.setTimestamp(index, new Timestamp(model.getCreatedAt()));
+      ++index;
     }
-    stmt.setLong(5, model.getId());
+    stmt.setLong(index, model.getId());
   }
 
   @Override

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseCommentPersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseCommentPersistenceImpl.java
@@ -54,7 +54,7 @@ public class BaseCommentPersistenceImpl extends AbstractDatabaseModel<Comment> i
     return this.create(content, commenter_id, commented_on_id, System.currentTimeMillis());
   }
   public Comment create(final String content, final int commenter_id, final long commented_on_id, final long created_at) throws IOException {
-    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+    StatementCreator statementCreator = new StatementCreator() {
       private final List<String> nonNullFields = new ArrayList<>();
       private final List<AttrSetter> statementSetters = new ArrayList<>();
 
@@ -102,7 +102,7 @@ public class BaseCommentPersistenceImpl extends AbstractDatabaseModel<Comment> i
   }
 
   public Comment create(final int commenter_id, final long commented_on_id, final long created_at) throws IOException {
-    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+    StatementCreator statementCreator = new StatementCreator() {
       private final List<String> nonNullFields = new ArrayList<>();
       private final List<AttrSetter> statementSetters = new ArrayList<>();
 

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseCommentPersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseCommentPersistenceImpl.java
@@ -218,23 +218,18 @@ public class BaseCommentPersistenceImpl extends AbstractDatabaseModel<Comment> i
   protected void setAttrs(Comment model, PreparedStatement stmt, boolean setNull) throws SQLException {
     int index = 1;
     if (setNull && model.getContent() == null) {
-      stmt.setNull(index, java.sql.Types.CHAR);
-      ++index;
+      stmt.setNull(index++, java.sql.Types.CHAR);
     } else if (model.getContent() != null) {
-      stmt.setString(index, model.getContent());
-      ++index;
+      stmt.setString(index++, model.getContent());
     }
     {
-      stmt.setInt(index, model.getCommenterId());
-      ++index;
+      stmt.setInt(index++, model.getCommenterId());
     }
     {
-      stmt.setLong(index, model.getCommentedOnId());
-      ++index;
+      stmt.setLong(index++, model.getCommentedOnId());
     }
     {
-      stmt.setTimestamp(index, new Timestamp(model.getCreatedAt()));
-      ++index;
+      stmt.setTimestamp(index++, new Timestamp(model.getCreatedAt()));
     }
     stmt.setLong(index, model.getId());
   }

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseCommentPersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseCommentPersistenceImpl.java
@@ -10,9 +10,6 @@ import java.sql.SQLRecoverableException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -23,21 +20,15 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Date;
 import java.sql.Timestamp;
-import java.util.function.Supplier;
 
 import com.rapleaf.jack.AbstractDatabaseModel;
 import com.rapleaf.jack.BaseDatabaseConnection;
-import com.rapleaf.jack.queries.where_operators.IWhereOperator;
 import com.rapleaf.jack.queries.WhereConstraint;
 import com.rapleaf.jack.queries.WhereClause;
-import com.rapleaf.jack.queries.ModelQuery;
-import com.rapleaf.jack.ModelWithId;
-import com.rapleaf.jack.util.JackUtility;
 import com.rapleaf.jack.test_project.database_1.iface.ICommentPersistence;
 import com.rapleaf.jack.test_project.database_1.models.Comment;
 import com.rapleaf.jack.test_project.database_1.query.CommentQueryBuilder;
 import com.rapleaf.jack.test_project.database_1.query.CommentDeleteBuilder;
-
 
 import com.rapleaf.jack.test_project.IDatabases;
 
@@ -69,17 +60,21 @@ public class BaseCommentPersistenceImpl extends AbstractDatabaseModel<Comment> i
 
       {
         int index = 1;
+
         if (content != null) {
           nonNullFields.add("content");
           int fieldIndex0 = index++;
           statementSetters.add(stmt -> stmt.setString(fieldIndex0, content));
         }
+
         nonNullFields.add("commenter_id");
         int fieldIndex1 = index++;
         statementSetters.add(stmt -> stmt.setInt(fieldIndex1, commenter_id));
+
         nonNullFields.add("commented_on_id");
         int fieldIndex2 = index++;
         statementSetters.add(stmt -> stmt.setLong(fieldIndex2, commented_on_id));
+
         nonNullFields.add("created_at");
         int fieldIndex3 = index++;
         statementSetters.add(stmt -> stmt.setTimestamp(fieldIndex3, new Timestamp(created_at)));
@@ -113,12 +108,15 @@ public class BaseCommentPersistenceImpl extends AbstractDatabaseModel<Comment> i
 
       {
         int index = 1;
+
         nonNullFields.add("commenter_id");
         int fieldIndex1 = index++;
         statementSetters.add(stmt -> stmt.setInt(fieldIndex1, commenter_id));
+
         nonNullFields.add("commented_on_id");
         int fieldIndex2 = index++;
         statementSetters.add(stmt -> stmt.setLong(fieldIndex2, commented_on_id));
+
         nonNullFields.add("created_at");
         int fieldIndex3 = index++;
         statementSetters.add(stmt -> stmt.setTimestamp(fieldIndex3, new Timestamp(created_at)));

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseImagePersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseImagePersistenceImpl.java
@@ -87,10 +87,6 @@ public class BaseImagePersistenceImpl extends AbstractDatabaseModel<Image> imple
       private final List<String> nonNullFields = new ArrayList<>();
       private final List<AttrSetter> statementSetters = new ArrayList<>();
 
-      {
-        int index = 1;
-      }
-
       @Override
       public String getStatement() {
         return getInsertStatement(nonNullFields);

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseImagePersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseImagePersistenceImpl.java
@@ -47,7 +47,7 @@ public class BaseImagePersistenceImpl extends AbstractDatabaseModel<Image> imple
   }
 
   public Image create(final Integer user_id) throws IOException {
-    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+    StatementCreator statementCreator = new StatementCreator() {
       private final List<String> nonNullFields = new ArrayList<>();
       private final List<AttrSetter> statementSetters = new ArrayList<>();
 
@@ -83,7 +83,7 @@ public class BaseImagePersistenceImpl extends AbstractDatabaseModel<Image> imple
   }
 
   public Image create() throws IOException {
-    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+    StatementCreator statementCreator = new StatementCreator() {
       private final List<String> nonNullFields = new ArrayList<>();
       private final List<AttrSetter> statementSetters = new ArrayList<>();
 

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseImagePersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseImagePersistenceImpl.java
@@ -23,6 +23,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.util.function.Supplier;
 
 import com.rapleaf.jack.AbstractDatabaseModel;
 import com.rapleaf.jack.BaseDatabaseConnection;
@@ -55,15 +56,33 @@ public class BaseImagePersistenceImpl extends AbstractDatabaseModel<Image> imple
   }
 
   public Image create(final Integer user_id) throws IOException {
-    long __id = realCreate(new AttrSetter() {
-      public void set(PreparedStatement stmt) throws SQLException {
-        if (user_id == null) {
-          stmt.setNull(1, java.sql.Types.INTEGER);
-        } else {
-          stmt.setInt(1, user_id);
+    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+      private final List<String> nonNullFields = new ArrayList<>();
+      private final List<AttrSetter> statementSetters = new ArrayList<>();
+
+      {
+        int index = 1;
+        if (user_id != null) {
+          nonNullFields.add("user_id");
+          int fieldIndex0 = index++;
+          statementSetters.add(stmt -> stmt.setInt(fieldIndex0, user_id));
         }
       }
-    }, getInsertStatement(Arrays.<String>asList("user_id")));
+
+      @Override
+      public String getStatement() {
+        return getInsertStatement(nonNullFields);
+      }
+
+      @Override
+      public void setStatement(PreparedStatement statement) throws SQLException {
+        for (AttrSetter setter : statementSetters) {
+          setter.set(statement);
+        }
+      }
+    };
+
+    long __id = realCreate(statementCreator);
     Image newInst = new Image(__id, user_id, databases);
     newInst.setCreated(true);
     cachedById.put(__id, newInst);
@@ -71,19 +90,35 @@ public class BaseImagePersistenceImpl extends AbstractDatabaseModel<Image> imple
     return newInst;
   }
 
-
   public Image create() throws IOException {
-    long __id = realCreate(new AttrSetter() {
-      public void set(PreparedStatement stmt) throws SQLException {
+    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+      private final List<String> nonNullFields = new ArrayList<>();
+      private final List<AttrSetter> statementSetters = new ArrayList<>();
+
+      {
+        int index = 1;
       }
-    }, getInsertStatement(Arrays.<String>asList()));
+
+      @Override
+      public String getStatement() {
+        return getInsertStatement(nonNullFields);
+      }
+
+      @Override
+      public void setStatement(PreparedStatement statement) throws SQLException {
+        for (AttrSetter setter : statementSetters) {
+          setter.set(statement);
+        }
+      }
+    };
+
+    long __id = realCreate(statementCreator);
     Image newInst = new Image(__id, null, databases);
     newInst.setCreated(true);
     cachedById.put(__id, newInst);
     clearForeignKeyCache();
     return newInst;
   }
-
 
   public Image createDefaultInstance() throws IOException {
     return create();

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseImagePersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseImagePersistenceImpl.java
@@ -187,11 +187,9 @@ public class BaseImagePersistenceImpl extends AbstractDatabaseModel<Image> imple
   protected void setAttrs(Image model, PreparedStatement stmt, boolean setNull) throws SQLException {
     int index = 1;
     if (setNull && model.getUserId() == null) {
-      stmt.setNull(index, java.sql.Types.INTEGER);
-      ++index;
+      stmt.setNull(index++, java.sql.Types.INTEGER);
     } else if (model.getUserId() != null) {
-      stmt.setInt(index, model.getUserId());
-      ++index;
+      stmt.setInt(index++, model.getUserId());
     }
     stmt.setLong(index, model.getId());
   }

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseImagePersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseImagePersistenceImpl.java
@@ -184,8 +184,8 @@ public class BaseImagePersistenceImpl extends AbstractDatabaseModel<Image> imple
   }
 
   @Override
-  protected void setAttrs(Image model, PreparedStatement stmt) throws SQLException {
-    if (model.getUserId() == null) {
+  protected void setAttrs(Image model, PreparedStatement stmt, boolean setNull) throws SQLException {
+    if (setNull && model.getUserId() == null) {
       stmt.setNull(1, java.sql.Types.INTEGER);
     } else {
       stmt.setInt(1, model.getUserId());

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseImagePersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseImagePersistenceImpl.java
@@ -10,9 +10,6 @@ import java.sql.SQLRecoverableException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -23,21 +20,15 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Date;
 import java.sql.Timestamp;
-import java.util.function.Supplier;
 
 import com.rapleaf.jack.AbstractDatabaseModel;
 import com.rapleaf.jack.BaseDatabaseConnection;
-import com.rapleaf.jack.queries.where_operators.IWhereOperator;
 import com.rapleaf.jack.queries.WhereConstraint;
 import com.rapleaf.jack.queries.WhereClause;
-import com.rapleaf.jack.queries.ModelQuery;
-import com.rapleaf.jack.ModelWithId;
-import com.rapleaf.jack.util.JackUtility;
 import com.rapleaf.jack.test_project.database_1.iface.IImagePersistence;
 import com.rapleaf.jack.test_project.database_1.models.Image;
 import com.rapleaf.jack.test_project.database_1.query.ImageQueryBuilder;
 import com.rapleaf.jack.test_project.database_1.query.ImageDeleteBuilder;
-
 
 import com.rapleaf.jack.test_project.IDatabases;
 
@@ -62,6 +53,7 @@ public class BaseImagePersistenceImpl extends AbstractDatabaseModel<Image> imple
 
       {
         int index = 1;
+
         if (user_id != null) {
           nonNullFields.add("user_id");
           int fieldIndex0 = index++;

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseImagePersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseImagePersistenceImpl.java
@@ -185,12 +185,15 @@ public class BaseImagePersistenceImpl extends AbstractDatabaseModel<Image> imple
 
   @Override
   protected void setAttrs(Image model, PreparedStatement stmt, boolean setNull) throws SQLException {
+    int index = 1;
     if (setNull && model.getUserId() == null) {
-      stmt.setNull(1, java.sql.Types.INTEGER);
-    } else {
-      stmt.setInt(1, model.getUserId());
+      stmt.setNull(index, java.sql.Types.INTEGER);
+      ++index;
+    } else if (model.getUserId() != null) {
+      stmt.setInt(index, model.getUserId());
+      ++index;
     }
-    stmt.setLong(2, model.getId());
+    stmt.setLong(index, model.getId());
   }
 
   @Override

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseLockableModelPersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseLockableModelPersistenceImpl.java
@@ -219,25 +219,33 @@ public class BaseLockableModelPersistenceImpl extends AbstractDatabaseModel<Lock
 
   @Override
   protected void setAttrs(LockableModel model, PreparedStatement stmt, boolean setNull) throws SQLException {
+    int index = 1;
     {
-      stmt.setInt(1, model.getLockVersion() + 1);
+      stmt.setInt(index, model.getLockVersion() + 1);
+      ++index;
     }
     if (setNull && model.getMessage() == null) {
-      stmt.setNull(2, java.sql.Types.CHAR);
-    } else {
-      stmt.setString(2, model.getMessage());
+      stmt.setNull(index, java.sql.Types.CHAR);
+      ++index;
+    } else if (model.getMessage() != null) {
+      stmt.setString(index, model.getMessage());
+      ++index;
     }
     if (setNull && model.getCreatedAt() == null) {
-      stmt.setNull(3, java.sql.Types.DATE);
-    } else {
-      stmt.setTimestamp(3, new Timestamp(model.getCreatedAt()));
+      stmt.setNull(index, java.sql.Types.DATE);
+      ++index;
+    } else if (model.getCreatedAt() != null) {
+      stmt.setTimestamp(index, new Timestamp(model.getCreatedAt()));
+      ++index;
     }
     if (setNull && model.getUpdatedAt() == null) {
-      stmt.setNull(4, java.sql.Types.DATE);
-    } else {
-      stmt.setTimestamp(4, new Timestamp(model.getUpdatedAt()));
+      stmt.setNull(index, java.sql.Types.DATE);
+      ++index;
+    } else if (model.getUpdatedAt() != null) {
+      stmt.setTimestamp(index, new Timestamp(model.getUpdatedAt()));
+      ++index;
     }
-    stmt.setLong(5, model.getId());
+    stmt.setLong(index, model.getId());
   }
 
   @Override

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseLockableModelPersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseLockableModelPersistenceImpl.java
@@ -23,6 +23,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.util.function.Supplier;
 
 import com.rapleaf.jack.AbstractDatabaseModel;
 import com.rapleaf.jack.BaseDatabaseConnection;
@@ -59,26 +60,46 @@ public class BaseLockableModelPersistenceImpl extends AbstractDatabaseModel<Lock
   }
 
   public LockableModel create(final int lock_version, final String message, final Long created_at, final Long updated_at) throws IOException {
-    long __id = realCreate(new AttrSetter() {
-      public void set(PreparedStatement stmt) throws SQLException {
-          stmt.setInt(1, lock_version);
-        if (message == null) {
-          stmt.setNull(2, java.sql.Types.CHAR);
-        } else {
-          stmt.setString(2, message);
+    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+      private final List<String> nonNullFields = new ArrayList<>();
+      private final List<AttrSetter> statementSetters = new ArrayList<>();
+
+      {
+        int index = 1;
+        nonNullFields.add("lock_version");
+        int fieldIndex0 = index++;
+        statementSetters.add(stmt -> stmt.setInt(fieldIndex0, lock_version));
+        if (message != null) {
+          nonNullFields.add("message");
+          int fieldIndex1 = index++;
+          statementSetters.add(stmt -> stmt.setString(fieldIndex1, message));
         }
-        if (created_at == null) {
-          stmt.setNull(3, java.sql.Types.DATE);
-        } else {
-          stmt.setTimestamp(3, new Timestamp(created_at));
+        if (created_at != null) {
+          nonNullFields.add("created_at");
+          int fieldIndex2 = index++;
+          statementSetters.add(stmt -> stmt.setTimestamp(fieldIndex2, new Timestamp(created_at)));
         }
-        if (updated_at == null) {
-          stmt.setNull(4, java.sql.Types.DATE);
-        } else {
-          stmt.setTimestamp(4, new Timestamp(updated_at));
+        if (updated_at != null) {
+          nonNullFields.add("updated_at");
+          int fieldIndex3 = index++;
+          statementSetters.add(stmt -> stmt.setTimestamp(fieldIndex3, new Timestamp(updated_at)));
         }
       }
-    }, getInsertStatement(Arrays.<String>asList("lock_version", "message", "created_at", "updated_at")));
+
+      @Override
+      public String getStatement() {
+        return getInsertStatement(nonNullFields);
+      }
+
+      @Override
+      public void setStatement(PreparedStatement statement) throws SQLException {
+        for (AttrSetter setter : statementSetters) {
+          setter.set(statement);
+        }
+      }
+    };
+
+    long __id = realCreate(statementCreator);
     LockableModel newInst = new LockableModel(__id, lock_version, message, created_at, updated_at, databases);
     newInst.setCreated(true);
     cachedById.put(__id, newInst);
@@ -86,20 +107,38 @@ public class BaseLockableModelPersistenceImpl extends AbstractDatabaseModel<Lock
     return newInst;
   }
 
-
   public LockableModel create(final int lock_version) throws IOException {
-    long __id = realCreate(new AttrSetter() {
-      public void set(PreparedStatement stmt) throws SQLException {
-          stmt.setInt(1, lock_version);
+    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+      private final List<String> nonNullFields = new ArrayList<>();
+      private final List<AttrSetter> statementSetters = new ArrayList<>();
+
+      {
+        int index = 1;
+        nonNullFields.add("lock_version");
+        int fieldIndex0 = index++;
+        statementSetters.add(stmt -> stmt.setInt(fieldIndex0, lock_version));
       }
-    }, getInsertStatement(Arrays.<String>asList("lock_version")));
+
+      @Override
+      public String getStatement() {
+        return getInsertStatement(nonNullFields);
+      }
+
+      @Override
+      public void setStatement(PreparedStatement statement) throws SQLException {
+        for (AttrSetter setter : statementSetters) {
+          setter.set(statement);
+        }
+      }
+    };
+
+    long __id = realCreate(statementCreator);
     LockableModel newInst = new LockableModel(__id, lock_version, null, null, null, databases);
     newInst.setCreated(true);
     cachedById.put(__id, newInst);
     clearForeignKeyCache();
     return newInst;
   }
-
 
   public LockableModel createDefaultInstance() throws IOException {
     return create(0);

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseLockableModelPersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseLockableModelPersistenceImpl.java
@@ -10,9 +10,6 @@ import java.sql.SQLRecoverableException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -23,21 +20,15 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Date;
 import java.sql.Timestamp;
-import java.util.function.Supplier;
 
 import com.rapleaf.jack.AbstractDatabaseModel;
 import com.rapleaf.jack.BaseDatabaseConnection;
-import com.rapleaf.jack.queries.where_operators.IWhereOperator;
 import com.rapleaf.jack.queries.WhereConstraint;
 import com.rapleaf.jack.queries.WhereClause;
-import com.rapleaf.jack.queries.ModelQuery;
-import com.rapleaf.jack.ModelWithId;
-import com.rapleaf.jack.util.JackUtility;
 import com.rapleaf.jack.test_project.database_1.iface.ILockableModelPersistence;
 import com.rapleaf.jack.test_project.database_1.models.LockableModel;
 import com.rapleaf.jack.test_project.database_1.query.LockableModelQueryBuilder;
 import com.rapleaf.jack.test_project.database_1.query.LockableModelDeleteBuilder;
-
 
 import com.rapleaf.jack.test_project.IDatabases;
 
@@ -66,19 +57,23 @@ public class BaseLockableModelPersistenceImpl extends AbstractDatabaseModel<Lock
 
       {
         int index = 1;
+
         nonNullFields.add("lock_version");
         int fieldIndex0 = index++;
         statementSetters.add(stmt -> stmt.setInt(fieldIndex0, lock_version));
+
         if (message != null) {
           nonNullFields.add("message");
           int fieldIndex1 = index++;
           statementSetters.add(stmt -> stmt.setString(fieldIndex1, message));
         }
+
         if (created_at != null) {
           nonNullFields.add("created_at");
           int fieldIndex2 = index++;
           statementSetters.add(stmt -> stmt.setTimestamp(fieldIndex2, new Timestamp(created_at)));
         }
+
         if (updated_at != null) {
           nonNullFields.add("updated_at");
           int fieldIndex3 = index++;
@@ -114,6 +109,7 @@ public class BaseLockableModelPersistenceImpl extends AbstractDatabaseModel<Lock
 
       {
         int index = 1;
+
         nonNullFields.add("lock_version");
         int fieldIndex0 = index++;
         statementSetters.add(stmt -> stmt.setInt(fieldIndex0, lock_version));

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseLockableModelPersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseLockableModelPersistenceImpl.java
@@ -51,7 +51,7 @@ public class BaseLockableModelPersistenceImpl extends AbstractDatabaseModel<Lock
   }
 
   public LockableModel create(final int lock_version, final String message, final Long created_at, final Long updated_at) throws IOException {
-    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+    StatementCreator statementCreator = new StatementCreator() {
       private final List<String> nonNullFields = new ArrayList<>();
       private final List<AttrSetter> statementSetters = new ArrayList<>();
 
@@ -103,7 +103,7 @@ public class BaseLockableModelPersistenceImpl extends AbstractDatabaseModel<Lock
   }
 
   public LockableModel create(final int lock_version) throws IOException {
-    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+    StatementCreator statementCreator = new StatementCreator() {
       private final List<String> nonNullFields = new ArrayList<>();
       private final List<AttrSetter> statementSetters = new ArrayList<>();
 

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseLockableModelPersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseLockableModelPersistenceImpl.java
@@ -218,21 +218,21 @@ public class BaseLockableModelPersistenceImpl extends AbstractDatabaseModel<Lock
   }
 
   @Override
-  protected void setAttrs(LockableModel model, PreparedStatement stmt) throws SQLException {
+  protected void setAttrs(LockableModel model, PreparedStatement stmt, boolean setNull) throws SQLException {
     {
       stmt.setInt(1, model.getLockVersion() + 1);
     }
-    if (model.getMessage() == null) {
+    if (setNull && model.getMessage() == null) {
       stmt.setNull(2, java.sql.Types.CHAR);
     } else {
       stmt.setString(2, model.getMessage());
     }
-    if (model.getCreatedAt() == null) {
+    if (setNull && model.getCreatedAt() == null) {
       stmt.setNull(3, java.sql.Types.DATE);
     } else {
       stmt.setTimestamp(3, new Timestamp(model.getCreatedAt()));
     }
-    if (model.getUpdatedAt() == null) {
+    if (setNull && model.getUpdatedAt() == null) {
       stmt.setNull(4, java.sql.Types.DATE);
     } else {
       stmt.setTimestamp(4, new Timestamp(model.getUpdatedAt()));

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseLockableModelPersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseLockableModelPersistenceImpl.java
@@ -221,29 +221,22 @@ public class BaseLockableModelPersistenceImpl extends AbstractDatabaseModel<Lock
   protected void setAttrs(LockableModel model, PreparedStatement stmt, boolean setNull) throws SQLException {
     int index = 1;
     {
-      stmt.setInt(index, model.getLockVersion() + 1);
-      ++index;
+      stmt.setInt(index++, model.getLockVersion() + 1);
     }
     if (setNull && model.getMessage() == null) {
-      stmt.setNull(index, java.sql.Types.CHAR);
-      ++index;
+      stmt.setNull(index++, java.sql.Types.CHAR);
     } else if (model.getMessage() != null) {
-      stmt.setString(index, model.getMessage());
-      ++index;
+      stmt.setString(index++, model.getMessage());
     }
     if (setNull && model.getCreatedAt() == null) {
-      stmt.setNull(index, java.sql.Types.DATE);
-      ++index;
+      stmt.setNull(index++, java.sql.Types.DATE);
     } else if (model.getCreatedAt() != null) {
-      stmt.setTimestamp(index, new Timestamp(model.getCreatedAt()));
-      ++index;
+      stmt.setTimestamp(index++, new Timestamp(model.getCreatedAt()));
     }
     if (setNull && model.getUpdatedAt() == null) {
-      stmt.setNull(index, java.sql.Types.DATE);
-      ++index;
+      stmt.setNull(index++, java.sql.Types.DATE);
     } else if (model.getUpdatedAt() != null) {
-      stmt.setTimestamp(index, new Timestamp(model.getUpdatedAt()));
-      ++index;
+      stmt.setTimestamp(index++, new Timestamp(model.getUpdatedAt()));
     }
     stmt.setLong(index, model.getId());
   }

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BasePostPersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BasePostPersistenceImpl.java
@@ -108,10 +108,6 @@ public class BasePostPersistenceImpl extends AbstractDatabaseModel<Post> impleme
       private final List<String> nonNullFields = new ArrayList<>();
       private final List<AttrSetter> statementSetters = new ArrayList<>();
 
-      {
-        int index = 1;
-      }
-
       @Override
       public String getStatement() {
         return getInsertStatement(nonNullFields);

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BasePostPersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BasePostPersistenceImpl.java
@@ -223,32 +223,24 @@ public class BasePostPersistenceImpl extends AbstractDatabaseModel<Post> impleme
   protected void setAttrs(Post model, PreparedStatement stmt, boolean setNull) throws SQLException {
     int index = 1;
     if (setNull && model.getTitle() == null) {
-      stmt.setNull(index, java.sql.Types.CHAR);
-      ++index;
+      stmt.setNull(index++, java.sql.Types.CHAR);
     } else if (model.getTitle() != null) {
-      stmt.setString(index, model.getTitle());
-      ++index;
+      stmt.setString(index++, model.getTitle());
     }
     if (setNull && model.getPostedAtMillis() == null) {
-      stmt.setNull(index, java.sql.Types.DATE);
-      ++index;
+      stmt.setNull(index++, java.sql.Types.DATE);
     } else if (model.getPostedAtMillis() != null) {
-      stmt.setDate(index, new Date(model.getPostedAtMillis()));
-      ++index;
+      stmt.setDate(index++, new Date(model.getPostedAtMillis()));
     }
     if (setNull && model.getUserId() == null) {
-      stmt.setNull(index, java.sql.Types.INTEGER);
-      ++index;
+      stmt.setNull(index++, java.sql.Types.INTEGER);
     } else if (model.getUserId() != null) {
-      stmt.setInt(index, model.getUserId());
-      ++index;
+      stmt.setInt(index++, model.getUserId());
     }
     if (setNull && model.getUpdatedAt() == null) {
-      stmt.setNull(index, java.sql.Types.DATE);
-      ++index;
+      stmt.setNull(index++, java.sql.Types.DATE);
     } else if (model.getUpdatedAt() != null) {
-      stmt.setTimestamp(index, new Timestamp(model.getUpdatedAt()));
-      ++index;
+      stmt.setTimestamp(index++, new Timestamp(model.getUpdatedAt()));
     }
     stmt.setLong(index, model.getId());
   }

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BasePostPersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BasePostPersistenceImpl.java
@@ -23,6 +23,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.util.function.Supplier;
 
 import com.rapleaf.jack.AbstractDatabaseModel;
 import com.rapleaf.jack.BaseDatabaseConnection;
@@ -58,30 +59,48 @@ public class BasePostPersistenceImpl extends AbstractDatabaseModel<Post> impleme
   }
 
   public Post create(final String title, final Long posted_at_millis, final Integer user_id, final Long updated_at) throws IOException {
-    long __id = realCreate(new AttrSetter() {
-      public void set(PreparedStatement stmt) throws SQLException {
-        if (title == null) {
-          stmt.setNull(1, java.sql.Types.CHAR);
-        } else {
-          stmt.setString(1, title);
+    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+      private final List<String> nonNullFields = new ArrayList<>();
+      private final List<AttrSetter> statementSetters = new ArrayList<>();
+
+      {
+        int index = 1;
+        if (title != null) {
+          nonNullFields.add("title");
+          int fieldIndex0 = index++;
+          statementSetters.add(stmt -> stmt.setString(fieldIndex0, title));
         }
-        if (posted_at_millis == null) {
-          stmt.setNull(2, java.sql.Types.DATE);
-        } else {
-          stmt.setDate(2, new Date(posted_at_millis));
+        if (posted_at_millis != null) {
+          nonNullFields.add("posted_at_millis");
+          int fieldIndex1 = index++;
+          statementSetters.add(stmt -> stmt.setDate(fieldIndex1, new Date(posted_at_millis)));
         }
-        if (user_id == null) {
-          stmt.setNull(3, java.sql.Types.INTEGER);
-        } else {
-          stmt.setInt(3, user_id);
+        if (user_id != null) {
+          nonNullFields.add("user_id");
+          int fieldIndex2 = index++;
+          statementSetters.add(stmt -> stmt.setInt(fieldIndex2, user_id));
         }
-        if (updated_at == null) {
-          stmt.setNull(4, java.sql.Types.DATE);
-        } else {
-          stmt.setTimestamp(4, new Timestamp(updated_at));
+        if (updated_at != null) {
+          nonNullFields.add("updated_at");
+          int fieldIndex3 = index++;
+          statementSetters.add(stmt -> stmt.setTimestamp(fieldIndex3, new Timestamp(updated_at)));
         }
       }
-    }, getInsertStatement(Arrays.<String>asList("title", "posted_at_millis", "user_id", "updated_at")));
+
+      @Override
+      public String getStatement() {
+        return getInsertStatement(nonNullFields);
+      }
+
+      @Override
+      public void setStatement(PreparedStatement statement) throws SQLException {
+        for (AttrSetter setter : statementSetters) {
+          setter.set(statement);
+        }
+      }
+    };
+
+    long __id = realCreate(statementCreator);
     Post newInst = new Post(__id, title, posted_at_millis, user_id, updated_at, databases);
     newInst.setCreated(true);
     cachedById.put(__id, newInst);
@@ -89,19 +108,35 @@ public class BasePostPersistenceImpl extends AbstractDatabaseModel<Post> impleme
     return newInst;
   }
 
-
   public Post create() throws IOException {
-    long __id = realCreate(new AttrSetter() {
-      public void set(PreparedStatement stmt) throws SQLException {
+    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+      private final List<String> nonNullFields = new ArrayList<>();
+      private final List<AttrSetter> statementSetters = new ArrayList<>();
+
+      {
+        int index = 1;
       }
-    }, getInsertStatement(Arrays.<String>asList()));
+
+      @Override
+      public String getStatement() {
+        return getInsertStatement(nonNullFields);
+      }
+
+      @Override
+      public void setStatement(PreparedStatement statement) throws SQLException {
+        for (AttrSetter setter : statementSetters) {
+          setter.set(statement);
+        }
+      }
+    };
+
+    long __id = realCreate(statementCreator);
     Post newInst = new Post(__id, null, null, null, null, databases);
     newInst.setCreated(true);
     cachedById.put(__id, newInst);
     clearForeignKeyCache();
     return newInst;
   }
-
 
   public Post createDefaultInstance() throws IOException {
     return create();

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BasePostPersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BasePostPersistenceImpl.java
@@ -221,27 +221,36 @@ public class BasePostPersistenceImpl extends AbstractDatabaseModel<Post> impleme
 
   @Override
   protected void setAttrs(Post model, PreparedStatement stmt, boolean setNull) throws SQLException {
+    int index = 1;
     if (setNull && model.getTitle() == null) {
-      stmt.setNull(1, java.sql.Types.CHAR);
-    } else {
-      stmt.setString(1, model.getTitle());
+      stmt.setNull(index, java.sql.Types.CHAR);
+      ++index;
+    } else if (model.getTitle() != null) {
+      stmt.setString(index, model.getTitle());
+      ++index;
     }
     if (setNull && model.getPostedAtMillis() == null) {
-      stmt.setNull(2, java.sql.Types.DATE);
-    } else {
-      stmt.setDate(2, new Date(model.getPostedAtMillis()));
+      stmt.setNull(index, java.sql.Types.DATE);
+      ++index;
+    } else if (model.getPostedAtMillis() != null) {
+      stmt.setDate(index, new Date(model.getPostedAtMillis()));
+      ++index;
     }
     if (setNull && model.getUserId() == null) {
-      stmt.setNull(3, java.sql.Types.INTEGER);
-    } else {
-      stmt.setInt(3, model.getUserId());
+      stmt.setNull(index, java.sql.Types.INTEGER);
+      ++index;
+    } else if (model.getUserId() != null) {
+      stmt.setInt(index, model.getUserId());
+      ++index;
     }
     if (setNull && model.getUpdatedAt() == null) {
-      stmt.setNull(4, java.sql.Types.DATE);
-    } else {
-      stmt.setTimestamp(4, new Timestamp(model.getUpdatedAt()));
+      stmt.setNull(index, java.sql.Types.DATE);
+      ++index;
+    } else if (model.getUpdatedAt() != null) {
+      stmt.setTimestamp(index, new Timestamp(model.getUpdatedAt()));
+      ++index;
     }
-    stmt.setLong(5, model.getId());
+    stmt.setLong(index, model.getId());
   }
 
   @Override

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BasePostPersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BasePostPersistenceImpl.java
@@ -220,23 +220,23 @@ public class BasePostPersistenceImpl extends AbstractDatabaseModel<Post> impleme
   }
 
   @Override
-  protected void setAttrs(Post model, PreparedStatement stmt) throws SQLException {
-    if (model.getTitle() == null) {
+  protected void setAttrs(Post model, PreparedStatement stmt, boolean setNull) throws SQLException {
+    if (setNull && model.getTitle() == null) {
       stmt.setNull(1, java.sql.Types.CHAR);
     } else {
       stmt.setString(1, model.getTitle());
     }
-    if (model.getPostedAtMillis() == null) {
+    if (setNull && model.getPostedAtMillis() == null) {
       stmt.setNull(2, java.sql.Types.DATE);
     } else {
       stmt.setDate(2, new Date(model.getPostedAtMillis()));
     }
-    if (model.getUserId() == null) {
+    if (setNull && model.getUserId() == null) {
       stmt.setNull(3, java.sql.Types.INTEGER);
     } else {
       stmt.setInt(3, model.getUserId());
     }
-    if (model.getUpdatedAt() == null) {
+    if (setNull && model.getUpdatedAt() == null) {
       stmt.setNull(4, java.sql.Types.DATE);
     } else {
       stmt.setTimestamp(4, new Timestamp(model.getUpdatedAt()));

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BasePostPersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BasePostPersistenceImpl.java
@@ -10,9 +10,6 @@ import java.sql.SQLRecoverableException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -23,21 +20,15 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Date;
 import java.sql.Timestamp;
-import java.util.function.Supplier;
 
 import com.rapleaf.jack.AbstractDatabaseModel;
 import com.rapleaf.jack.BaseDatabaseConnection;
-import com.rapleaf.jack.queries.where_operators.IWhereOperator;
 import com.rapleaf.jack.queries.WhereConstraint;
 import com.rapleaf.jack.queries.WhereClause;
-import com.rapleaf.jack.queries.ModelQuery;
-import com.rapleaf.jack.ModelWithId;
-import com.rapleaf.jack.util.JackUtility;
 import com.rapleaf.jack.test_project.database_1.iface.IPostPersistence;
 import com.rapleaf.jack.test_project.database_1.models.Post;
 import com.rapleaf.jack.test_project.database_1.query.PostQueryBuilder;
 import com.rapleaf.jack.test_project.database_1.query.PostDeleteBuilder;
-
 
 import com.rapleaf.jack.test_project.IDatabases;
 
@@ -65,21 +56,25 @@ public class BasePostPersistenceImpl extends AbstractDatabaseModel<Post> impleme
 
       {
         int index = 1;
+
         if (title != null) {
           nonNullFields.add("title");
           int fieldIndex0 = index++;
           statementSetters.add(stmt -> stmt.setString(fieldIndex0, title));
         }
+
         if (posted_at_millis != null) {
           nonNullFields.add("posted_at_millis");
           int fieldIndex1 = index++;
           statementSetters.add(stmt -> stmt.setDate(fieldIndex1, new Date(posted_at_millis)));
         }
+
         if (user_id != null) {
           nonNullFields.add("user_id");
           int fieldIndex2 = index++;
           statementSetters.add(stmt -> stmt.setInt(fieldIndex2, user_id));
         }
+
         if (updated_at != null) {
           nonNullFields.add("updated_at");
           int fieldIndex3 = index++;

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BasePostPersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BasePostPersistenceImpl.java
@@ -50,7 +50,7 @@ public class BasePostPersistenceImpl extends AbstractDatabaseModel<Post> impleme
   }
 
   public Post create(final String title, final Long posted_at_millis, final Integer user_id, final Long updated_at) throws IOException {
-    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+    StatementCreator statementCreator = new StatementCreator() {
       private final List<String> nonNullFields = new ArrayList<>();
       private final List<AttrSetter> statementSetters = new ArrayList<>();
 
@@ -104,7 +104,7 @@ public class BasePostPersistenceImpl extends AbstractDatabaseModel<Post> impleme
   }
 
   public Post create() throws IOException {
-    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+    StatementCreator statementCreator = new StatementCreator() {
       private final List<String> nonNullFields = new ArrayList<>();
       private final List<AttrSetter> statementSetters = new ArrayList<>();
 

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseTestStorePersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseTestStorePersistenceImpl.java
@@ -247,46 +247,34 @@ public class BaseTestStorePersistenceImpl extends AbstractDatabaseModel<TestStor
   protected void setAttrs(TestStore model, PreparedStatement stmt, boolean setNull) throws SQLException {
     int index = 1;
     if (setNull && model.getEntryType() == null) {
-      stmt.setNull(index, java.sql.Types.INTEGER);
-      ++index;
+      stmt.setNull(index++, java.sql.Types.INTEGER);
     } else if (model.getEntryType() != null) {
-      stmt.setInt(index, model.getEntryType());
-      ++index;
+      stmt.setInt(index++, model.getEntryType());
     }
     if (setNull && model.getEntryScope() == null) {
-      stmt.setNull(index, java.sql.Types.INTEGER);
-      ++index;
+      stmt.setNull(index++, java.sql.Types.INTEGER);
     } else if (model.getEntryScope() != null) {
-      stmt.setLong(index, model.getEntryScope());
-      ++index;
+      stmt.setLong(index++, model.getEntryScope());
     }
     if (setNull && model.getEntryKey() == null) {
-      stmt.setNull(index, java.sql.Types.CHAR);
-      ++index;
+      stmt.setNull(index++, java.sql.Types.CHAR);
     } else if (model.getEntryKey() != null) {
-      stmt.setString(index, model.getEntryKey());
-      ++index;
+      stmt.setString(index++, model.getEntryKey());
     }
     if (setNull && model.getEntryValue() == null) {
-      stmt.setNull(index, java.sql.Types.CHAR);
-      ++index;
+      stmt.setNull(index++, java.sql.Types.CHAR);
     } else if (model.getEntryValue() != null) {
-      stmt.setString(index, model.getEntryValue());
-      ++index;
+      stmt.setString(index++, model.getEntryValue());
     }
     if (setNull && model.getCreatedAt() == null) {
-      stmt.setNull(index, java.sql.Types.DATE);
-      ++index;
+      stmt.setNull(index++, java.sql.Types.DATE);
     } else if (model.getCreatedAt() != null) {
-      stmt.setTimestamp(index, new Timestamp(model.getCreatedAt()));
-      ++index;
+      stmt.setTimestamp(index++, new Timestamp(model.getCreatedAt()));
     }
     if (setNull && model.getUpdatedAt() == null) {
-      stmt.setNull(index, java.sql.Types.DATE);
-      ++index;
+      stmt.setNull(index++, java.sql.Types.DATE);
     } else if (model.getUpdatedAt() != null) {
-      stmt.setTimestamp(index, new Timestamp(model.getUpdatedAt()));
-      ++index;
+      stmt.setTimestamp(index++, new Timestamp(model.getUpdatedAt()));
     }
     stmt.setLong(index, model.getId());
   }

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseTestStorePersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseTestStorePersistenceImpl.java
@@ -244,33 +244,33 @@ public class BaseTestStorePersistenceImpl extends AbstractDatabaseModel<TestStor
   }
 
   @Override
-  protected void setAttrs(TestStore model, PreparedStatement stmt) throws SQLException {
-    if (model.getEntryType() == null) {
+  protected void setAttrs(TestStore model, PreparedStatement stmt, boolean setNull) throws SQLException {
+    if (setNull && model.getEntryType() == null) {
       stmt.setNull(1, java.sql.Types.INTEGER);
     } else {
       stmt.setInt(1, model.getEntryType());
     }
-    if (model.getEntryScope() == null) {
+    if (setNull && model.getEntryScope() == null) {
       stmt.setNull(2, java.sql.Types.INTEGER);
     } else {
       stmt.setLong(2, model.getEntryScope());
     }
-    if (model.getEntryKey() == null) {
+    if (setNull && model.getEntryKey() == null) {
       stmt.setNull(3, java.sql.Types.CHAR);
     } else {
       stmt.setString(3, model.getEntryKey());
     }
-    if (model.getEntryValue() == null) {
+    if (setNull && model.getEntryValue() == null) {
       stmt.setNull(4, java.sql.Types.CHAR);
     } else {
       stmt.setString(4, model.getEntryValue());
     }
-    if (model.getCreatedAt() == null) {
+    if (setNull && model.getCreatedAt() == null) {
       stmt.setNull(5, java.sql.Types.DATE);
     } else {
       stmt.setTimestamp(5, new Timestamp(model.getCreatedAt()));
     }
-    if (model.getUpdatedAt() == null) {
+    if (setNull && model.getUpdatedAt() == null) {
       stmt.setNull(6, java.sql.Types.DATE);
     } else {
       stmt.setTimestamp(6, new Timestamp(model.getUpdatedAt()));

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseTestStorePersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseTestStorePersistenceImpl.java
@@ -10,9 +10,6 @@ import java.sql.SQLRecoverableException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -23,21 +20,15 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Date;
 import java.sql.Timestamp;
-import java.util.function.Supplier;
 
 import com.rapleaf.jack.AbstractDatabaseModel;
 import com.rapleaf.jack.BaseDatabaseConnection;
-import com.rapleaf.jack.queries.where_operators.IWhereOperator;
 import com.rapleaf.jack.queries.WhereConstraint;
 import com.rapleaf.jack.queries.WhereClause;
-import com.rapleaf.jack.queries.ModelQuery;
-import com.rapleaf.jack.ModelWithId;
-import com.rapleaf.jack.util.JackUtility;
 import com.rapleaf.jack.test_project.database_1.iface.ITestStorePersistence;
 import com.rapleaf.jack.test_project.database_1.models.TestStore;
 import com.rapleaf.jack.test_project.database_1.query.TestStoreQueryBuilder;
 import com.rapleaf.jack.test_project.database_1.query.TestStoreDeleteBuilder;
-
 
 import com.rapleaf.jack.test_project.IDatabases;
 
@@ -67,31 +58,37 @@ public class BaseTestStorePersistenceImpl extends AbstractDatabaseModel<TestStor
 
       {
         int index = 1;
+
         if (entry_type != null) {
           nonNullFields.add("entry_type");
           int fieldIndex0 = index++;
           statementSetters.add(stmt -> stmt.setInt(fieldIndex0, entry_type));
         }
+
         if (entry_scope != null) {
           nonNullFields.add("entry_scope");
           int fieldIndex1 = index++;
           statementSetters.add(stmt -> stmt.setLong(fieldIndex1, entry_scope));
         }
+
         if (entry_key != null) {
           nonNullFields.add("entry_key");
           int fieldIndex2 = index++;
           statementSetters.add(stmt -> stmt.setString(fieldIndex2, entry_key));
         }
+
         if (entry_value != null) {
           nonNullFields.add("entry_value");
           int fieldIndex3 = index++;
           statementSetters.add(stmt -> stmt.setString(fieldIndex3, entry_value));
         }
+
         if (created_at != null) {
           nonNullFields.add("created_at");
           int fieldIndex4 = index++;
           statementSetters.add(stmt -> stmt.setTimestamp(fieldIndex4, new Timestamp(created_at)));
         }
+
         if (updated_at != null) {
           nonNullFields.add("updated_at");
           int fieldIndex5 = index++;

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseTestStorePersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseTestStorePersistenceImpl.java
@@ -122,10 +122,6 @@ public class BaseTestStorePersistenceImpl extends AbstractDatabaseModel<TestStor
       private final List<String> nonNullFields = new ArrayList<>();
       private final List<AttrSetter> statementSetters = new ArrayList<>();
 
-      {
-        int index = 1;
-      }
-
       @Override
       public String getStatement() {
         return getInsertStatement(nonNullFields);

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseTestStorePersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseTestStorePersistenceImpl.java
@@ -245,37 +245,50 @@ public class BaseTestStorePersistenceImpl extends AbstractDatabaseModel<TestStor
 
   @Override
   protected void setAttrs(TestStore model, PreparedStatement stmt, boolean setNull) throws SQLException {
+    int index = 1;
     if (setNull && model.getEntryType() == null) {
-      stmt.setNull(1, java.sql.Types.INTEGER);
-    } else {
-      stmt.setInt(1, model.getEntryType());
+      stmt.setNull(index, java.sql.Types.INTEGER);
+      ++index;
+    } else if (model.getEntryType() != null) {
+      stmt.setInt(index, model.getEntryType());
+      ++index;
     }
     if (setNull && model.getEntryScope() == null) {
-      stmt.setNull(2, java.sql.Types.INTEGER);
-    } else {
-      stmt.setLong(2, model.getEntryScope());
+      stmt.setNull(index, java.sql.Types.INTEGER);
+      ++index;
+    } else if (model.getEntryScope() != null) {
+      stmt.setLong(index, model.getEntryScope());
+      ++index;
     }
     if (setNull && model.getEntryKey() == null) {
-      stmt.setNull(3, java.sql.Types.CHAR);
-    } else {
-      stmt.setString(3, model.getEntryKey());
+      stmt.setNull(index, java.sql.Types.CHAR);
+      ++index;
+    } else if (model.getEntryKey() != null) {
+      stmt.setString(index, model.getEntryKey());
+      ++index;
     }
     if (setNull && model.getEntryValue() == null) {
-      stmt.setNull(4, java.sql.Types.CHAR);
-    } else {
-      stmt.setString(4, model.getEntryValue());
+      stmt.setNull(index, java.sql.Types.CHAR);
+      ++index;
+    } else if (model.getEntryValue() != null) {
+      stmt.setString(index, model.getEntryValue());
+      ++index;
     }
     if (setNull && model.getCreatedAt() == null) {
-      stmt.setNull(5, java.sql.Types.DATE);
-    } else {
-      stmt.setTimestamp(5, new Timestamp(model.getCreatedAt()));
+      stmt.setNull(index, java.sql.Types.DATE);
+      ++index;
+    } else if (model.getCreatedAt() != null) {
+      stmt.setTimestamp(index, new Timestamp(model.getCreatedAt()));
+      ++index;
     }
     if (setNull && model.getUpdatedAt() == null) {
-      stmt.setNull(6, java.sql.Types.DATE);
-    } else {
-      stmt.setTimestamp(6, new Timestamp(model.getUpdatedAt()));
+      stmt.setNull(index, java.sql.Types.DATE);
+      ++index;
+    } else if (model.getUpdatedAt() != null) {
+      stmt.setTimestamp(index, new Timestamp(model.getUpdatedAt()));
+      ++index;
     }
-    stmt.setLong(7, model.getId());
+    stmt.setLong(index, model.getId());
   }
 
   @Override

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseTestStorePersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseTestStorePersistenceImpl.java
@@ -52,7 +52,7 @@ public class BaseTestStorePersistenceImpl extends AbstractDatabaseModel<TestStor
   }
 
   public TestStore create(final Integer entry_type, final Long entry_scope, final String entry_key, final String entry_value, final Long created_at, final Long updated_at) throws IOException {
-    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+    StatementCreator statementCreator = new StatementCreator() {
       private final List<String> nonNullFields = new ArrayList<>();
       private final List<AttrSetter> statementSetters = new ArrayList<>();
 
@@ -118,7 +118,7 @@ public class BaseTestStorePersistenceImpl extends AbstractDatabaseModel<TestStor
   }
 
   public TestStore create() throws IOException {
-    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+    StatementCreator statementCreator = new StatementCreator() {
       private final List<String> nonNullFields = new ArrayList<>();
       private final List<AttrSetter> statementSetters = new ArrayList<>();
 

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseTestStorePersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseTestStorePersistenceImpl.java
@@ -23,6 +23,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.util.function.Supplier;
 
 import com.rapleaf.jack.AbstractDatabaseModel;
 import com.rapleaf.jack.BaseDatabaseConnection;
@@ -60,40 +61,58 @@ public class BaseTestStorePersistenceImpl extends AbstractDatabaseModel<TestStor
   }
 
   public TestStore create(final Integer entry_type, final Long entry_scope, final String entry_key, final String entry_value, final Long created_at, final Long updated_at) throws IOException {
-    long __id = realCreate(new AttrSetter() {
-      public void set(PreparedStatement stmt) throws SQLException {
-        if (entry_type == null) {
-          stmt.setNull(1, java.sql.Types.INTEGER);
-        } else {
-          stmt.setInt(1, entry_type);
+    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+      private final List<String> nonNullFields = new ArrayList<>();
+      private final List<AttrSetter> statementSetters = new ArrayList<>();
+
+      {
+        int index = 1;
+        if (entry_type != null) {
+          nonNullFields.add("entry_type");
+          int fieldIndex0 = index++;
+          statementSetters.add(stmt -> stmt.setInt(fieldIndex0, entry_type));
         }
-        if (entry_scope == null) {
-          stmt.setNull(2, java.sql.Types.INTEGER);
-        } else {
-          stmt.setLong(2, entry_scope);
+        if (entry_scope != null) {
+          nonNullFields.add("entry_scope");
+          int fieldIndex1 = index++;
+          statementSetters.add(stmt -> stmt.setLong(fieldIndex1, entry_scope));
         }
-        if (entry_key == null) {
-          stmt.setNull(3, java.sql.Types.CHAR);
-        } else {
-          stmt.setString(3, entry_key);
+        if (entry_key != null) {
+          nonNullFields.add("entry_key");
+          int fieldIndex2 = index++;
+          statementSetters.add(stmt -> stmt.setString(fieldIndex2, entry_key));
         }
-        if (entry_value == null) {
-          stmt.setNull(4, java.sql.Types.CHAR);
-        } else {
-          stmt.setString(4, entry_value);
+        if (entry_value != null) {
+          nonNullFields.add("entry_value");
+          int fieldIndex3 = index++;
+          statementSetters.add(stmt -> stmt.setString(fieldIndex3, entry_value));
         }
-        if (created_at == null) {
-          stmt.setNull(5, java.sql.Types.DATE);
-        } else {
-          stmt.setTimestamp(5, new Timestamp(created_at));
+        if (created_at != null) {
+          nonNullFields.add("created_at");
+          int fieldIndex4 = index++;
+          statementSetters.add(stmt -> stmt.setTimestamp(fieldIndex4, new Timestamp(created_at)));
         }
-        if (updated_at == null) {
-          stmt.setNull(6, java.sql.Types.DATE);
-        } else {
-          stmt.setTimestamp(6, new Timestamp(updated_at));
+        if (updated_at != null) {
+          nonNullFields.add("updated_at");
+          int fieldIndex5 = index++;
+          statementSetters.add(stmt -> stmt.setTimestamp(fieldIndex5, new Timestamp(updated_at)));
         }
       }
-    }, getInsertStatement(Arrays.<String>asList("entry_type", "entry_scope", "entry_key", "entry_value", "created_at", "updated_at")));
+
+      @Override
+      public String getStatement() {
+        return getInsertStatement(nonNullFields);
+      }
+
+      @Override
+      public void setStatement(PreparedStatement statement) throws SQLException {
+        for (AttrSetter setter : statementSetters) {
+          setter.set(statement);
+        }
+      }
+    };
+
+    long __id = realCreate(statementCreator);
     TestStore newInst = new TestStore(__id, entry_type, entry_scope, entry_key, entry_value, created_at, updated_at, databases);
     newInst.setCreated(true);
     cachedById.put(__id, newInst);
@@ -101,19 +120,35 @@ public class BaseTestStorePersistenceImpl extends AbstractDatabaseModel<TestStor
     return newInst;
   }
 
-
   public TestStore create() throws IOException {
-    long __id = realCreate(new AttrSetter() {
-      public void set(PreparedStatement stmt) throws SQLException {
+    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+      private final List<String> nonNullFields = new ArrayList<>();
+      private final List<AttrSetter> statementSetters = new ArrayList<>();
+
+      {
+        int index = 1;
       }
-    }, getInsertStatement(Arrays.<String>asList()));
+
+      @Override
+      public String getStatement() {
+        return getInsertStatement(nonNullFields);
+      }
+
+      @Override
+      public void setStatement(PreparedStatement statement) throws SQLException {
+        for (AttrSetter setter : statementSetters) {
+          setter.set(statement);
+        }
+      }
+    };
+
+    long __id = realCreate(statementCreator);
     TestStore newInst = new TestStore(__id, null, null, null, null, null, null, databases);
     newInst.setCreated(true);
     cachedById.put(__id, newInst);
     clearForeignKeyCache();
     return newInst;
   }
-
 
   public TestStore createDefaultInstance() throws IOException {
     return create();

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseUserPersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseUserPersistenceImpl.java
@@ -289,68 +289,50 @@ public class BaseUserPersistenceImpl extends AbstractDatabaseModel<User> impleme
   protected void setAttrs(User model, PreparedStatement stmt, boolean setNull) throws SQLException {
     int index = 1;
     {
-      stmt.setString(index, model.getHandle());
-      ++index;
+      stmt.setString(index++, model.getHandle());
     }
     if (setNull && model.getCreatedAtMillis() == null) {
-      stmt.setNull(index, java.sql.Types.INTEGER);
-      ++index;
+      stmt.setNull(index++, java.sql.Types.INTEGER);
     } else if (model.getCreatedAtMillis() != null) {
-      stmt.setLong(index, model.getCreatedAtMillis());
-      ++index;
+      stmt.setLong(index++, model.getCreatedAtMillis());
     }
     {
-      stmt.setInt(index, model.getNumPosts());
-      ++index;
+      stmt.setInt(index++, model.getNumPosts());
     }
     if (setNull && model.getSomeDate() == null) {
-      stmt.setNull(index, java.sql.Types.DATE);
-      ++index;
+      stmt.setNull(index++, java.sql.Types.DATE);
     } else if (model.getSomeDate() != null) {
-      stmt.setDate(index, new Date(model.getSomeDate()));
-      ++index;
+      stmt.setDate(index++, new Date(model.getSomeDate()));
     }
     if (setNull && model.getSomeDatetime() == null) {
-      stmt.setNull(index, java.sql.Types.DATE);
-      ++index;
+      stmt.setNull(index++, java.sql.Types.DATE);
     } else if (model.getSomeDatetime() != null) {
-      stmt.setTimestamp(index, new Timestamp(model.getSomeDatetime()));
-      ++index;
+      stmt.setTimestamp(index++, new Timestamp(model.getSomeDatetime()));
     }
     if (setNull && model.getBio() == null) {
-      stmt.setNull(index, java.sql.Types.CHAR);
-      ++index;
+      stmt.setNull(index++, java.sql.Types.CHAR);
     } else if (model.getBio() != null) {
-      stmt.setString(index, model.getBio());
-      ++index;
+      stmt.setString(index++, model.getBio());
     }
     if (setNull && model.getSomeBinary() == null) {
-      stmt.setNull(index, java.sql.Types.BINARY);
-      ++index;
+      stmt.setNull(index++, java.sql.Types.BINARY);
     } else if (model.getSomeBinary() != null) {
-      stmt.setBytes(index, model.getSomeBinary());
-      ++index;
+      stmt.setBytes(index++, model.getSomeBinary());
     }
     if (setNull && model.getSomeFloat() == null) {
-      stmt.setNull(index, java.sql.Types.DOUBLE);
-      ++index;
+      stmt.setNull(index++, java.sql.Types.DOUBLE);
     } else if (model.getSomeFloat() != null) {
-      stmt.setDouble(index, model.getSomeFloat());
-      ++index;
+      stmt.setDouble(index++, model.getSomeFloat());
     }
     if (setNull && model.getSomeDecimal() == null) {
-      stmt.setNull(index, java.sql.Types.DECIMAL);
-      ++index;
+      stmt.setNull(index++, java.sql.Types.DECIMAL);
     } else if (model.getSomeDecimal() != null) {
-      stmt.setDouble(index, model.getSomeDecimal());
-      ++index;
+      stmt.setDouble(index++, model.getSomeDecimal());
     }
     if (setNull && model.isSomeBoolean() == null) {
-      stmt.setNull(index, java.sql.Types.BOOLEAN);
-      ++index;
+      stmt.setNull(index++, java.sql.Types.BOOLEAN);
     } else if (model.isSomeBoolean() != null) {
-      stmt.setBoolean(index, model.isSomeBoolean());
-      ++index;
+      stmt.setBoolean(index++, model.isSomeBoolean());
     }
     stmt.setLong(index, model.getId());
   }

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseUserPersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseUserPersistenceImpl.java
@@ -287,53 +287,72 @@ public class BaseUserPersistenceImpl extends AbstractDatabaseModel<User> impleme
 
   @Override
   protected void setAttrs(User model, PreparedStatement stmt, boolean setNull) throws SQLException {
+    int index = 1;
     {
-      stmt.setString(1, model.getHandle());
+      stmt.setString(index, model.getHandle());
+      ++index;
     }
     if (setNull && model.getCreatedAtMillis() == null) {
-      stmt.setNull(2, java.sql.Types.INTEGER);
-    } else {
-      stmt.setLong(2, model.getCreatedAtMillis());
+      stmt.setNull(index, java.sql.Types.INTEGER);
+      ++index;
+    } else if (model.getCreatedAtMillis() != null) {
+      stmt.setLong(index, model.getCreatedAtMillis());
+      ++index;
     }
     {
-      stmt.setInt(3, model.getNumPosts());
+      stmt.setInt(index, model.getNumPosts());
+      ++index;
     }
     if (setNull && model.getSomeDate() == null) {
-      stmt.setNull(4, java.sql.Types.DATE);
-    } else {
-      stmt.setDate(4, new Date(model.getSomeDate()));
+      stmt.setNull(index, java.sql.Types.DATE);
+      ++index;
+    } else if (model.getSomeDate() != null) {
+      stmt.setDate(index, new Date(model.getSomeDate()));
+      ++index;
     }
     if (setNull && model.getSomeDatetime() == null) {
-      stmt.setNull(5, java.sql.Types.DATE);
-    } else {
-      stmt.setTimestamp(5, new Timestamp(model.getSomeDatetime()));
+      stmt.setNull(index, java.sql.Types.DATE);
+      ++index;
+    } else if (model.getSomeDatetime() != null) {
+      stmt.setTimestamp(index, new Timestamp(model.getSomeDatetime()));
+      ++index;
     }
     if (setNull && model.getBio() == null) {
-      stmt.setNull(6, java.sql.Types.CHAR);
-    } else {
-      stmt.setString(6, model.getBio());
+      stmt.setNull(index, java.sql.Types.CHAR);
+      ++index;
+    } else if (model.getBio() != null) {
+      stmt.setString(index, model.getBio());
+      ++index;
     }
     if (setNull && model.getSomeBinary() == null) {
-      stmt.setNull(7, java.sql.Types.BINARY);
-    } else {
-      stmt.setBytes(7, model.getSomeBinary());
+      stmt.setNull(index, java.sql.Types.BINARY);
+      ++index;
+    } else if (model.getSomeBinary() != null) {
+      stmt.setBytes(index, model.getSomeBinary());
+      ++index;
     }
     if (setNull && model.getSomeFloat() == null) {
-      stmt.setNull(8, java.sql.Types.DOUBLE);
-    } else {
-      stmt.setDouble(8, model.getSomeFloat());
+      stmt.setNull(index, java.sql.Types.DOUBLE);
+      ++index;
+    } else if (model.getSomeFloat() != null) {
+      stmt.setDouble(index, model.getSomeFloat());
+      ++index;
     }
     if (setNull && model.getSomeDecimal() == null) {
-      stmt.setNull(9, java.sql.Types.DECIMAL);
-    } else {
-      stmt.setDouble(9, model.getSomeDecimal());
+      stmt.setNull(index, java.sql.Types.DECIMAL);
+      ++index;
+    } else if (model.getSomeDecimal() != null) {
+      stmt.setDouble(index, model.getSomeDecimal());
+      ++index;
     }
     if (setNull && model.isSomeBoolean() == null) {
-      stmt.setNull(10, java.sql.Types.BOOLEAN);
-    } else {
-      stmt.setBoolean(10, model.isSomeBoolean());
+      stmt.setNull(index, java.sql.Types.BOOLEAN);
+      ++index;
+    } else if (model.isSomeBoolean() != null) {
+      stmt.setBoolean(index, model.isSomeBoolean());
+      ++index;
     }
-    stmt.setLong(11, model.getId());
+    stmt.setLong(index, model.getId());
   }
 
   @Override

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseUserPersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseUserPersistenceImpl.java
@@ -23,6 +23,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.util.function.Supplier;
 
 import com.rapleaf.jack.AbstractDatabaseModel;
 import com.rapleaf.jack.BaseDatabaseConnection;
@@ -64,52 +65,74 @@ public class BaseUserPersistenceImpl extends AbstractDatabaseModel<User> impleme
   }
 
   public User create(final String handle, final Long created_at_millis, final int num_posts, final Long some_date, final Long some_datetime, final String bio, final byte[] some_binary, final Double some_float, final Double some_decimal, final Boolean some_boolean) throws IOException {
-    long __id = realCreate(new AttrSetter() {
-      public void set(PreparedStatement stmt) throws SQLException {
-          stmt.setString(1, handle);
-        if (created_at_millis == null) {
-          stmt.setNull(2, java.sql.Types.INTEGER);
-        } else {
-          stmt.setLong(2, created_at_millis);
+    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+      private final List<String> nonNullFields = new ArrayList<>();
+      private final List<AttrSetter> statementSetters = new ArrayList<>();
+
+      {
+        int index = 1;
+        nonNullFields.add("handle");
+        int fieldIndex0 = index++;
+        statementSetters.add(stmt -> stmt.setString(fieldIndex0, handle));
+        if (created_at_millis != null) {
+          nonNullFields.add("created_at_millis");
+          int fieldIndex1 = index++;
+          statementSetters.add(stmt -> stmt.setLong(fieldIndex1, created_at_millis));
         }
-          stmt.setInt(3, num_posts);
-        if (some_date == null) {
-          stmt.setNull(4, java.sql.Types.DATE);
-        } else {
-          stmt.setDate(4, new Date(some_date));
+        nonNullFields.add("num_posts");
+        int fieldIndex2 = index++;
+        statementSetters.add(stmt -> stmt.setInt(fieldIndex2, num_posts));
+        if (some_date != null) {
+          nonNullFields.add("some_date");
+          int fieldIndex3 = index++;
+          statementSetters.add(stmt -> stmt.setDate(fieldIndex3, new Date(some_date)));
         }
-        if (some_datetime == null) {
-          stmt.setNull(5, java.sql.Types.DATE);
-        } else {
-          stmt.setTimestamp(5, new Timestamp(some_datetime));
+        if (some_datetime != null) {
+          nonNullFields.add("some_datetime");
+          int fieldIndex4 = index++;
+          statementSetters.add(stmt -> stmt.setTimestamp(fieldIndex4, new Timestamp(some_datetime)));
         }
-        if (bio == null) {
-          stmt.setNull(6, java.sql.Types.CHAR);
-        } else {
-          stmt.setString(6, bio);
+        if (bio != null) {
+          nonNullFields.add("bio");
+          int fieldIndex5 = index++;
+          statementSetters.add(stmt -> stmt.setString(fieldIndex5, bio));
         }
-        if (some_binary == null) {
-          stmt.setNull(7, java.sql.Types.BINARY);
-        } else {
-          stmt.setBytes(7, some_binary);
+        if (some_binary != null) {
+          nonNullFields.add("some_binary");
+          int fieldIndex6 = index++;
+          statementSetters.add(stmt -> stmt.setBytes(fieldIndex6, some_binary));
         }
-        if (some_float == null) {
-          stmt.setNull(8, java.sql.Types.DOUBLE);
-        } else {
-          stmt.setDouble(8, some_float);
+        if (some_float != null) {
+          nonNullFields.add("some_float");
+          int fieldIndex7 = index++;
+          statementSetters.add(stmt -> stmt.setDouble(fieldIndex7, some_float));
         }
-        if (some_decimal == null) {
-          stmt.setNull(9, java.sql.Types.DECIMAL);
-        } else {
-          stmt.setDouble(9, some_decimal);
+        if (some_decimal != null) {
+          nonNullFields.add("some_decimal");
+          int fieldIndex8 = index++;
+          statementSetters.add(stmt -> stmt.setDouble(fieldIndex8, some_decimal));
         }
-        if (some_boolean == null) {
-          stmt.setNull(10, java.sql.Types.BOOLEAN);
-        } else {
-          stmt.setBoolean(10, some_boolean);
+        if (some_boolean != null) {
+          nonNullFields.add("some_boolean");
+          int fieldIndex9 = index++;
+          statementSetters.add(stmt -> stmt.setBoolean(fieldIndex9, some_boolean));
         }
       }
-    }, getInsertStatement(Arrays.<String>asList("handle", "created_at_millis", "num_posts", "some_date", "some_datetime", "bio", "some_binary", "some_float", "some_decimal", "some_boolean")));
+
+      @Override
+      public String getStatement() {
+        return getInsertStatement(nonNullFields);
+      }
+
+      @Override
+      public void setStatement(PreparedStatement statement) throws SQLException {
+        for (AttrSetter setter : statementSetters) {
+          setter.set(statement);
+        }
+      }
+    };
+
+    long __id = realCreate(statementCreator);
     User newInst = new User(__id, handle, created_at_millis, num_posts, some_date, some_datetime, bio, some_binary, some_float, some_decimal, some_boolean, databases);
     newInst.setCreated(true);
     cachedById.put(__id, newInst);
@@ -117,21 +140,41 @@ public class BaseUserPersistenceImpl extends AbstractDatabaseModel<User> impleme
     return newInst;
   }
 
-
   public User create(final String handle, final int num_posts) throws IOException {
-    long __id = realCreate(new AttrSetter() {
-      public void set(PreparedStatement stmt) throws SQLException {
-          stmt.setString(1, handle);
-          stmt.setInt(2, num_posts);
+    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+      private final List<String> nonNullFields = new ArrayList<>();
+      private final List<AttrSetter> statementSetters = new ArrayList<>();
+
+      {
+        int index = 1;
+        nonNullFields.add("handle");
+        int fieldIndex0 = index++;
+        statementSetters.add(stmt -> stmt.setString(fieldIndex0, handle));
+        nonNullFields.add("num_posts");
+        int fieldIndex2 = index++;
+        statementSetters.add(stmt -> stmt.setInt(fieldIndex2, num_posts));
       }
-    }, getInsertStatement(Arrays.<String>asList("handle", "num_posts")));
+
+      @Override
+      public String getStatement() {
+        return getInsertStatement(nonNullFields);
+      }
+
+      @Override
+      public void setStatement(PreparedStatement statement) throws SQLException {
+        for (AttrSetter setter : statementSetters) {
+          setter.set(statement);
+        }
+      }
+    };
+
+    long __id = realCreate(statementCreator);
     User newInst = new User(__id, handle, null, num_posts, null, null, null, null, null, null, null, databases);
     newInst.setCreated(true);
     cachedById.put(__id, newInst);
     clearForeignKeyCache();
     return newInst;
   }
-
 
   public User createDefaultInstance() throws IOException {
     return create("", 0);

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseUserPersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseUserPersistenceImpl.java
@@ -56,7 +56,7 @@ public class BaseUserPersistenceImpl extends AbstractDatabaseModel<User> impleme
   }
 
   public User create(final String handle, final Long created_at_millis, final int num_posts, final Long some_date, final Long some_datetime, final String bio, final byte[] some_binary, final Double some_float, final Double some_decimal, final Boolean some_boolean) throws IOException {
-    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+    StatementCreator statementCreator = new StatementCreator() {
       private final List<String> nonNullFields = new ArrayList<>();
       private final List<AttrSetter> statementSetters = new ArrayList<>();
 
@@ -142,7 +142,7 @@ public class BaseUserPersistenceImpl extends AbstractDatabaseModel<User> impleme
   }
 
   public User create(final String handle, final int num_posts) throws IOException {
-    InsertStatementCreator statementCreator = new InsertStatementCreator() {
+    StatementCreator statementCreator = new StatementCreator() {
       private final List<String> nonNullFields = new ArrayList<>();
       private final List<AttrSetter> statementSetters = new ArrayList<>();
 

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseUserPersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseUserPersistenceImpl.java
@@ -286,11 +286,11 @@ public class BaseUserPersistenceImpl extends AbstractDatabaseModel<User> impleme
   }
 
   @Override
-  protected void setAttrs(User model, PreparedStatement stmt) throws SQLException {
+  protected void setAttrs(User model, PreparedStatement stmt, boolean setNull) throws SQLException {
     {
       stmt.setString(1, model.getHandle());
     }
-    if (model.getCreatedAtMillis() == null) {
+    if (setNull && model.getCreatedAtMillis() == null) {
       stmt.setNull(2, java.sql.Types.INTEGER);
     } else {
       stmt.setLong(2, model.getCreatedAtMillis());
@@ -298,37 +298,37 @@ public class BaseUserPersistenceImpl extends AbstractDatabaseModel<User> impleme
     {
       stmt.setInt(3, model.getNumPosts());
     }
-    if (model.getSomeDate() == null) {
+    if (setNull && model.getSomeDate() == null) {
       stmt.setNull(4, java.sql.Types.DATE);
     } else {
       stmt.setDate(4, new Date(model.getSomeDate()));
     }
-    if (model.getSomeDatetime() == null) {
+    if (setNull && model.getSomeDatetime() == null) {
       stmt.setNull(5, java.sql.Types.DATE);
     } else {
       stmt.setTimestamp(5, new Timestamp(model.getSomeDatetime()));
     }
-    if (model.getBio() == null) {
+    if (setNull && model.getBio() == null) {
       stmt.setNull(6, java.sql.Types.CHAR);
     } else {
       stmt.setString(6, model.getBio());
     }
-    if (model.getSomeBinary() == null) {
+    if (setNull && model.getSomeBinary() == null) {
       stmt.setNull(7, java.sql.Types.BINARY);
     } else {
       stmt.setBytes(7, model.getSomeBinary());
     }
-    if (model.getSomeFloat() == null) {
+    if (setNull && model.getSomeFloat() == null) {
       stmt.setNull(8, java.sql.Types.DOUBLE);
     } else {
       stmt.setDouble(8, model.getSomeFloat());
     }
-    if (model.getSomeDecimal() == null) {
+    if (setNull && model.getSomeDecimal() == null) {
       stmt.setNull(9, java.sql.Types.DECIMAL);
     } else {
       stmt.setDouble(9, model.getSomeDecimal());
     }
-    if (model.isSomeBoolean() == null) {
+    if (setNull && model.isSomeBoolean() == null) {
       stmt.setNull(10, java.sql.Types.BOOLEAN);
     } else {
       stmt.setBoolean(10, model.isSomeBoolean());

--- a/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseUserPersistenceImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/test_project/database_1/impl/BaseUserPersistenceImpl.java
@@ -10,9 +10,6 @@ import java.sql.SQLRecoverableException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -23,21 +20,15 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Date;
 import java.sql.Timestamp;
-import java.util.function.Supplier;
 
 import com.rapleaf.jack.AbstractDatabaseModel;
 import com.rapleaf.jack.BaseDatabaseConnection;
-import com.rapleaf.jack.queries.where_operators.IWhereOperator;
 import com.rapleaf.jack.queries.WhereConstraint;
 import com.rapleaf.jack.queries.WhereClause;
-import com.rapleaf.jack.queries.ModelQuery;
-import com.rapleaf.jack.ModelWithId;
-import com.rapleaf.jack.util.JackUtility;
 import com.rapleaf.jack.test_project.database_1.iface.IUserPersistence;
 import com.rapleaf.jack.test_project.database_1.models.User;
 import com.rapleaf.jack.test_project.database_1.query.UserQueryBuilder;
 import com.rapleaf.jack.test_project.database_1.query.UserDeleteBuilder;
-
 
 import com.rapleaf.jack.test_project.IDatabases;
 
@@ -71,47 +62,57 @@ public class BaseUserPersistenceImpl extends AbstractDatabaseModel<User> impleme
 
       {
         int index = 1;
+
         nonNullFields.add("handle");
         int fieldIndex0 = index++;
         statementSetters.add(stmt -> stmt.setString(fieldIndex0, handle));
+
         if (created_at_millis != null) {
           nonNullFields.add("created_at_millis");
           int fieldIndex1 = index++;
           statementSetters.add(stmt -> stmt.setLong(fieldIndex1, created_at_millis));
         }
+
         nonNullFields.add("num_posts");
         int fieldIndex2 = index++;
         statementSetters.add(stmt -> stmt.setInt(fieldIndex2, num_posts));
+
         if (some_date != null) {
           nonNullFields.add("some_date");
           int fieldIndex3 = index++;
           statementSetters.add(stmt -> stmt.setDate(fieldIndex3, new Date(some_date)));
         }
+
         if (some_datetime != null) {
           nonNullFields.add("some_datetime");
           int fieldIndex4 = index++;
           statementSetters.add(stmt -> stmt.setTimestamp(fieldIndex4, new Timestamp(some_datetime)));
         }
+
         if (bio != null) {
           nonNullFields.add("bio");
           int fieldIndex5 = index++;
           statementSetters.add(stmt -> stmt.setString(fieldIndex5, bio));
         }
+
         if (some_binary != null) {
           nonNullFields.add("some_binary");
           int fieldIndex6 = index++;
           statementSetters.add(stmt -> stmt.setBytes(fieldIndex6, some_binary));
         }
+
         if (some_float != null) {
           nonNullFields.add("some_float");
           int fieldIndex7 = index++;
           statementSetters.add(stmt -> stmt.setDouble(fieldIndex7, some_float));
         }
+
         if (some_decimal != null) {
           nonNullFields.add("some_decimal");
           int fieldIndex8 = index++;
           statementSetters.add(stmt -> stmt.setDouble(fieldIndex8, some_decimal));
         }
+
         if (some_boolean != null) {
           nonNullFields.add("some_boolean");
           int fieldIndex9 = index++;
@@ -147,9 +148,11 @@ public class BaseUserPersistenceImpl extends AbstractDatabaseModel<User> impleme
 
       {
         int index = 1;
+
         nonNullFields.add("handle");
         int fieldIndex0 = index++;
         statementSetters.add(stmt -> stmt.setString(fieldIndex0, handle));
+
         nonNullFields.add("num_posts");
         int fieldIndex2 = index++;
         statementSetters.add(stmt -> stmt.setInt(fieldIndex2, num_posts));


### PR DESCRIPTION
@bpodgursky, I guess this can prevent the exception throwing from newly added optional fields if you only create new models, instead of creating the basic model first and update the optional fields.

Unit tests have not been added yet.
