### PR TITLE
Update gem versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "http://rubygems.org"
-gem "activesupport", ">=3.0.0"
-gem "i18n", "0.5.0"
+gem "activesupport", "~> 4.1"
+gem "i18n", "~> 0.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,27 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.0.6)
-    i18n (0.5.0)
+    activesupport (4.2.5)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    concurrent-ruby (1.0.5)
+    i18n (0.9.1)
+      concurrent-ruby (~> 1.0)
+    json (1.8.6)
+    minitest (5.10.3)
+    thread_safe (0.3.6)
+    tzinfo (1.2.4)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (>= 3.0.0)
-  i18n (= 0.5.0)
+  activesupport (~> 4.1)
+  i18n (~> 0.9)
 
 BUNDLED WITH
-   1.15.1
+   1.15.4

--- a/jack-core/src/Gemfile
+++ b/jack-core/src/Gemfile
@@ -1,4 +1,3 @@
 source "http://rubygems.org"
-gem "activesupport", ">=3.0.0"
-gem "i18n", "0.5.0"
-
+gem "activesupport", "~> 4.1"
+gem "i18n", "~> 0.9"

--- a/jack-core/src/Gemfile.lock
+++ b/jack-core/src/Gemfile.lock
@@ -1,15 +1,27 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.0.6)
-    i18n (0.5.0)
+    activesupport (4.2.5)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    concurrent-ruby (1.0.5)
+    i18n (0.9.1)
+      concurrent-ruby (~> 1.0)
+    json (1.8.6)
+    minitest (5.10.3)
+    thread_safe (0.3.6)
+    tzinfo (1.2.4)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (>= 3.0.0)
-  i18n (= 0.5.0)
+  activesupport (~> 4.1)
+  i18n (~> 0.9)
 
 BUNDLED WITH
-   1.12.5
+   1.15.4


### PR DESCRIPTION
`rails`-`3.0.6` and `i18n`-`0.5.0` have security vulnerability issues.
