### PR TITLE
Sub Query

### DIFF
--- a/jack-core/src/com/rapleaf/jack/queries/AbstractExecution.java
+++ b/jack-core/src/com/rapleaf/jack/queries/AbstractExecution.java
@@ -19,6 +19,9 @@ public abstract class AbstractExecution {
     this.dbConnection = dbConnection;
   }
 
+  /**
+   * @return fully prepared SQL statement
+   */
   public String getSqlStatement() {
     return this.getPreparedStatement(Optional.empty()).toString();
   }
@@ -26,8 +29,8 @@ public abstract class AbstractExecution {
   protected PreparedStatement getPreparedStatement(Optional<Integer> options) {
     PreparedStatement preparedStatement;
     preparedStatement = options
-        .map(integer -> dbConnection.getPreparedStatement(getQueryStatement(), integer))
-        .orElseGet(() -> dbConnection.getPreparedStatement(getQueryStatement()));
+        .map(integer -> dbConnection.getPreparedStatement(getRawStatement(), integer))
+        .orElseGet(() -> dbConnection.getPreparedStatement(getRawStatement()));
     setStatementParameters(preparedStatement, getParameters());
     return preparedStatement;
   }
@@ -52,7 +55,10 @@ public abstract class AbstractExecution {
     }
   }
 
-  protected abstract String getQueryStatement();
+  /**
+   * @return SQL statement with ? as placeholders for parameters
+   */
+  public abstract String getRawStatement();
 
   protected abstract Collection<Object> getParameters();
 

--- a/jack-core/src/com/rapleaf/jack/queries/AbstractExecution.java
+++ b/jack-core/src/com/rapleaf/jack/queries/AbstractExecution.java
@@ -1,6 +1,5 @@
 package com.rapleaf.jack.queries;
 
-import java.io.IOException;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Collection;
@@ -9,6 +8,7 @@ import java.util.Optional;
 
 import com.rapleaf.jack.BaseDatabaseConnection;
 import com.rapleaf.jack.exception.BulkOperationException;
+import com.rapleaf.jack.exception.JackRuntimeException;
 
 public abstract class AbstractExecution {
   protected static int MAX_CONNECTION_RETRIES = 1;
@@ -19,11 +19,11 @@ public abstract class AbstractExecution {
     this.dbConnection = dbConnection;
   }
 
-  public String getSqlStatement() throws IOException {
+  public String getSqlStatement() {
     return this.getPreparedStatement(Optional.empty()).toString();
   }
 
-  protected PreparedStatement getPreparedStatement(Optional<Integer> options) throws IOException {
+  protected PreparedStatement getPreparedStatement(Optional<Integer> options) {
     PreparedStatement preparedStatement;
     preparedStatement = options
         .map(integer -> dbConnection.getPreparedStatement(getQueryStatement(), integer))
@@ -38,7 +38,7 @@ public abstract class AbstractExecution {
     }
   }
 
-  private void setStatementParameters(PreparedStatement preparedStatement, Collection<Object> parameters) throws IOException {
+  private void setStatementParameters(PreparedStatement preparedStatement, Collection<Object> parameters) {
     int index = 0;
     for (Object parameter : parameters) {
       if (parameter == null) {
@@ -47,7 +47,7 @@ public abstract class AbstractExecution {
       try {
         preparedStatement.setObject(++index, parameter);
       } catch (SQLException e) {
-        throw new IOException(e);
+        throw new JackRuntimeException(e);
       }
     }
   }

--- a/jack-core/src/com/rapleaf/jack/queries/AbstractExecution.java
+++ b/jack-core/src/com/rapleaf/jack/queries/AbstractExecution.java
@@ -4,6 +4,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Optional;
 
 import com.rapleaf.jack.BaseDatabaseConnection;
@@ -60,7 +61,7 @@ public abstract class AbstractExecution {
    */
   public abstract String getQueryStatement();
 
-  protected abstract Collection<Object> getParameters();
+  protected abstract List<Object> getParameters();
 
   static String getClauseFromColumns(Collection<Column> columns, String initialKeyword, String separator, String terminalKeyword) {
     if (columns.isEmpty()) {

--- a/jack-core/src/com/rapleaf/jack/queries/AbstractExecution.java
+++ b/jack-core/src/com/rapleaf/jack/queries/AbstractExecution.java
@@ -29,8 +29,8 @@ public abstract class AbstractExecution {
   protected PreparedStatement getPreparedStatement(Optional<Integer> options) {
     PreparedStatement preparedStatement;
     preparedStatement = options
-        .map(integer -> dbConnection.getPreparedStatement(getRawStatement(), integer))
-        .orElseGet(() -> dbConnection.getPreparedStatement(getRawStatement()));
+        .map(integer -> dbConnection.getPreparedStatement(getQueryStatement(), integer))
+        .orElseGet(() -> dbConnection.getPreparedStatement(getQueryStatement()));
     setStatementParameters(preparedStatement, getParameters());
     return preparedStatement;
   }
@@ -58,7 +58,7 @@ public abstract class AbstractExecution {
   /**
    * @return SQL statement with ? as placeholders for parameters
    */
-  public abstract String getRawStatement();
+  public abstract String getQueryStatement();
 
   protected abstract Collection<Object> getParameters();
 

--- a/jack-core/src/com/rapleaf/jack/queries/AbstractTable.java
+++ b/jack-core/src/com/rapleaf/jack/queries/AbstractTable.java
@@ -10,7 +10,7 @@ import com.google.common.collect.Sets;
 import com.rapleaf.jack.AttributesWithId;
 import com.rapleaf.jack.ModelWithId;
 
-public class AbstractTable<A extends AttributesWithId, M extends ModelWithId> implements Table<A, M> {
+public class AbstractTable<A extends AttributesWithId, M extends ModelWithId> implements Table {
   protected final String name;
   protected final String alias;
   protected final Class<A> attributesType;
@@ -59,7 +59,6 @@ public class AbstractTable<A extends AttributesWithId, M extends ModelWithId> im
     return attributesType;
   }
 
-  @Override
   public Class<M> getModelType() {
     return modelType;
   }

--- a/jack-core/src/com/rapleaf/jack/queries/AbstractTable.java
+++ b/jack-core/src/com/rapleaf/jack/queries/AbstractTable.java
@@ -35,6 +35,10 @@ public class AbstractTable<A extends AttributesWithId, M extends ModelWithId> im
     this.allColumns = table.allColumns;
   }
 
+  public AbstractTable<A, M> alias(String alias) {
+    return new AbstractTable<>(name, alias, attributesType, modelType);
+  }
+
   @Override
   public String getName() {
     return name;

--- a/jack-core/src/com/rapleaf/jack/queries/Column.java
+++ b/jack-core/src/com/rapleaf/jack/queries/Column.java
@@ -118,6 +118,10 @@ public class Column<T> {
     }
   }
 
+  public GenericConstraint equalTo(GenericQuery subQuery) {
+    return new GenericConstraint<T>(this, new EqualTo<T>(subQuery));
+  }
+
   public GenericConstraint notEqualTo(T value) {
     if (value != null) {
       if (isDateColumn()) {
@@ -138,6 +142,10 @@ public class Column<T> {
     }
   }
 
+  public GenericConstraint notEqualTo(GenericQuery subQuery) {
+    return new GenericConstraint<T>(this, new NotEqualTo<T>(subQuery));
+  }
+
   public GenericConstraint greaterThan(T value) {
     if (isDateColumn()) {
       return createDateConstraint(new GreaterThan<Long>(Long.class.cast(value)));
@@ -148,6 +156,10 @@ public class Column<T> {
 
   public GenericConstraint greaterThan(Column<T> column) {
     return new GenericConstraint<T>(this, new GreaterThan<T>(column));
+  }
+
+  public GenericConstraint greaterThan(GenericQuery subQuery) {
+    return new GenericConstraint<T>(this, new GreaterThan<T>(subQuery));
   }
 
   public GenericConstraint greaterThanOrEqualTo(T value) {
@@ -162,6 +174,10 @@ public class Column<T> {
     return new GenericConstraint<T>(this, new GreaterThanOrEqualTo<T>(value));
   }
 
+  public GenericConstraint greaterThanOrEqualTo(GenericQuery subQuery) {
+    return new GenericConstraint<T>(this, new GreaterThanOrEqualTo<T>(subQuery));
+  }
+
   public GenericConstraint lessThan(T value) {
     if (isDateColumn()) {
       return createDateConstraint(new LessThan<Long>(Long.class.cast(value)));
@@ -174,6 +190,10 @@ public class Column<T> {
     return new GenericConstraint<T>(this, new LessThan<T>(column));
   }
 
+  public GenericConstraint lessThan(GenericQuery subQuery) {
+    return new GenericConstraint<T>(this, new LessThan<T>(subQuery));
+  }
+
   public GenericConstraint lessThanOrEqualTo(T value) {
     if (isDateColumn()) {
       return createDateConstraint(new LessThanOrEqualTo<Long>(Long.class.cast(value)));
@@ -184,6 +204,10 @@ public class Column<T> {
 
   public GenericConstraint lessThanOrEqualTo(Column<T> value) {
     return new GenericConstraint<T>(this, new LessThanOrEqualTo<T>(value));
+  }
+
+  public GenericConstraint lessThanOrEqualTo(GenericQuery subQuery) {
+    return new GenericConstraint<T>(this, new LessThanOrEqualTo<T>(subQuery));
   }
 
   public GenericConstraint between(T min, T max) {

--- a/jack-core/src/com/rapleaf/jack/queries/Column.java
+++ b/jack-core/src/com/rapleaf/jack/queries/Column.java
@@ -282,6 +282,10 @@ public class Column<T> {
     }
   }
 
+  public GenericConstraint in(GenericQuery subQuery) {
+    return new GenericConstraint<T>(this, new In<T>(subQuery));
+  }
+
   public GenericConstraint notIn(T value, T... otherValues) {
     if (isDateColumn()) {
       return createDateConstraint(new NotIn<Long>(Long.class.cast(value), Arrays.copyOf(otherValues, otherValues.length, Long[].class)));
@@ -296,6 +300,10 @@ public class Column<T> {
     } else {
       return new GenericConstraint<T>(this, new NotIn<T>(values));
     }
+  }
+
+  public GenericConstraint notIn(GenericQuery subQuery) {
+    return new GenericConstraint<T>(this, new NotIn<T>(subQuery));
   }
 
   public GenericConstraint matches(String pattern) {

--- a/jack-core/src/com/rapleaf/jack/queries/Column.java
+++ b/jack-core/src/com/rapleaf/jack/queries/Column.java
@@ -42,31 +42,48 @@ public class Column<T> {
     this.type = that.type;
   }
 
+  /**
+   * Construct ID column. This constructor is mainly for internal use.
+   */
   public static Column<Long> fromId(String table) {
     return new Column<Long>(table, null, Long.class);
   }
 
+  /**
+   * Construct column other than ID, timestamp or date. This constructor is mainly for internal use.
+   */
   public static <T> Column<T> fromField(String table, Enum field, Class<T> fieldType) {
     return new Column<T>(table, field, fieldType);
   }
 
+  /**
+   * Construct timestamp column. This constructor is mainly for internal use.
+   */
   public static Column<Long> fromTimestamp(String table, Enum field) {
     return new Column<Long>(table, field, java.sql.Timestamp.class);
   }
 
+  /**
+   * Construct date column. This constructor is mainly for internal use.
+   */
   public static Column<Long> fromDate(String table, Enum field) {
     return new Column<Long>(table, field, java.sql.Date.class);
   }
 
-  public static <T> Column<T> from(String table, Column<T> column) {
-    return new Column<T>(table, column.field, column.type);
-  }
-
+  /**
+   * Convert column type.
+   * <p>
+   * This method is typically used in WHERE clause. For example:
+   * User.ID.equalTo(Post.USER_ID.as(Long.class))
+   */
   public <M> Column<M> as(Class<M> type) {
     return new Column<M>(this.table, this.field, type);
   }
 
-  <T> Column<T> asIn(String tableAlias) {
+  /**
+   * Change column alias.
+   */
+  <K> Column<K> asIn(String tableAlias) {
     return new Column<>(tableAlias, this.field, type);
   }
 

--- a/jack-core/src/com/rapleaf/jack/queries/Column.java
+++ b/jack-core/src/com/rapleaf/jack/queries/Column.java
@@ -143,7 +143,7 @@ public class Column<T> {
     }
   }
 
-  public GenericConstraint equalTo(GenericQuery subQuery) {
+  public GenericConstraint equalTo(SingleValue subQuery) {
     return new GenericConstraint<T>(this, new EqualTo<T>(subQuery));
   }
 
@@ -167,7 +167,7 @@ public class Column<T> {
     }
   }
 
-  public GenericConstraint notEqualTo(GenericQuery subQuery) {
+  public GenericConstraint notEqualTo(SingleValue subQuery) {
     return new GenericConstraint<T>(this, new NotEqualTo<T>(subQuery));
   }
 
@@ -183,7 +183,7 @@ public class Column<T> {
     return new GenericConstraint<T>(this, new GreaterThan<T>(column));
   }
 
-  public GenericConstraint greaterThan(GenericQuery subQuery) {
+  public GenericConstraint greaterThan(SingleValue subQuery) {
     return new GenericConstraint<T>(this, new GreaterThan<T>(subQuery));
   }
 
@@ -199,7 +199,7 @@ public class Column<T> {
     return new GenericConstraint<T>(this, new GreaterThanOrEqualTo<T>(value));
   }
 
-  public GenericConstraint greaterThanOrEqualTo(GenericQuery subQuery) {
+  public GenericConstraint greaterThanOrEqualTo(SingleValue subQuery) {
     return new GenericConstraint<T>(this, new GreaterThanOrEqualTo<T>(subQuery));
   }
 
@@ -215,7 +215,7 @@ public class Column<T> {
     return new GenericConstraint<T>(this, new LessThan<T>(column));
   }
 
-  public GenericConstraint lessThan(GenericQuery subQuery) {
+  public GenericConstraint lessThan(SingleValue subQuery) {
     return new GenericConstraint<T>(this, new LessThan<T>(subQuery));
   }
 
@@ -231,7 +231,7 @@ public class Column<T> {
     return new GenericConstraint<T>(this, new LessThanOrEqualTo<T>(value));
   }
 
-  public GenericConstraint lessThanOrEqualTo(GenericQuery subQuery) {
+  public GenericConstraint lessThanOrEqualTo(SingleValue subQuery) {
     return new GenericConstraint<T>(this, new LessThanOrEqualTo<T>(subQuery));
   }
 
@@ -307,7 +307,7 @@ public class Column<T> {
     }
   }
 
-  public GenericConstraint in(GenericQuery subQuery) {
+  public GenericConstraint in(MultiValue subQuery) {
     return new GenericConstraint<T>(this, new In<T>(subQuery));
   }
 
@@ -327,7 +327,7 @@ public class Column<T> {
     }
   }
 
-  public GenericConstraint notIn(GenericQuery subQuery) {
+  public GenericConstraint notIn(MultiValue subQuery) {
     return new GenericConstraint<T>(this, new NotIn<T>(subQuery));
   }
 

--- a/jack-core/src/com/rapleaf/jack/queries/Column.java
+++ b/jack-core/src/com/rapleaf/jack/queries/Column.java
@@ -58,8 +58,16 @@ public class Column<T> {
     return new Column<Long>(table, field, java.sql.Date.class);
   }
 
+  public static <T> Column<T> from(String table, Column<T> column) {
+    return new Column<T>(table, column.field, column.type);
+  }
+
   public <M> Column<M> as(Class<M> type) {
     return new Column<M>(this.table, this.field, type);
+  }
+
+  <T> Column<T> asIn(String tableAlias) {
+    return new Column<>(tableAlias, this.field, type);
   }
 
   public String getTable() {

--- a/jack-core/src/com/rapleaf/jack/queries/Column.java
+++ b/jack-core/src/com/rapleaf/jack/queries/Column.java
@@ -81,9 +81,9 @@ public class Column<T> {
   }
 
   /**
-   * Change column alias.
+   * Change table alias.
    */
-  <K> Column<K> asIn(String tableAlias) {
+  <K> Column<K> forTable(String tableAlias) {
     return new Column<>(tableAlias, this.field, type);
   }
 

--- a/jack-core/src/com/rapleaf/jack/queries/Column.java
+++ b/jack-core/src/com/rapleaf/jack/queries/Column.java
@@ -143,8 +143,8 @@ public class Column<T> {
     }
   }
 
-  public GenericConstraint equalTo(SingleValue subQuery) {
-    return new GenericConstraint<T>(this, new EqualTo<T>(subQuery));
+  public GenericConstraint equalTo(SingleValue<T> singleValue) {
+    return new GenericConstraint<T>(this, new EqualTo<T>(singleValue));
   }
 
   public GenericConstraint notEqualTo(T value) {
@@ -167,8 +167,8 @@ public class Column<T> {
     }
   }
 
-  public GenericConstraint notEqualTo(SingleValue subQuery) {
-    return new GenericConstraint<T>(this, new NotEqualTo<T>(subQuery));
+  public GenericConstraint notEqualTo(SingleValue<T> singleValue) {
+    return new GenericConstraint<T>(this, new NotEqualTo<T>(singleValue));
   }
 
   public GenericConstraint greaterThan(T value) {
@@ -183,8 +183,8 @@ public class Column<T> {
     return new GenericConstraint<T>(this, new GreaterThan<T>(column));
   }
 
-  public GenericConstraint greaterThan(SingleValue subQuery) {
-    return new GenericConstraint<T>(this, new GreaterThan<T>(subQuery));
+  public GenericConstraint greaterThan(SingleValue<T> singleValue) {
+    return new GenericConstraint<T>(this, new GreaterThan<T>(singleValue));
   }
 
   public GenericConstraint greaterThanOrEqualTo(T value) {
@@ -199,8 +199,8 @@ public class Column<T> {
     return new GenericConstraint<T>(this, new GreaterThanOrEqualTo<T>(value));
   }
 
-  public GenericConstraint greaterThanOrEqualTo(SingleValue subQuery) {
-    return new GenericConstraint<T>(this, new GreaterThanOrEqualTo<T>(subQuery));
+  public GenericConstraint greaterThanOrEqualTo(SingleValue<T> singleValue) {
+    return new GenericConstraint<T>(this, new GreaterThanOrEqualTo<T>(singleValue));
   }
 
   public GenericConstraint lessThan(T value) {
@@ -215,8 +215,8 @@ public class Column<T> {
     return new GenericConstraint<T>(this, new LessThan<T>(column));
   }
 
-  public GenericConstraint lessThan(SingleValue subQuery) {
-    return new GenericConstraint<T>(this, new LessThan<T>(subQuery));
+  public GenericConstraint lessThan(SingleValue<T> singleValue) {
+    return new GenericConstraint<T>(this, new LessThan<T>(singleValue));
   }
 
   public GenericConstraint lessThanOrEqualTo(T value) {
@@ -231,8 +231,8 @@ public class Column<T> {
     return new GenericConstraint<T>(this, new LessThanOrEqualTo<T>(value));
   }
 
-  public GenericConstraint lessThanOrEqualTo(SingleValue subQuery) {
-    return new GenericConstraint<T>(this, new LessThanOrEqualTo<T>(subQuery));
+  public GenericConstraint lessThanOrEqualTo(SingleValue<T> singleValue) {
+    return new GenericConstraint<T>(this, new LessThanOrEqualTo<T>(singleValue));
   }
 
   public GenericConstraint between(T min, T max) {
@@ -307,8 +307,8 @@ public class Column<T> {
     }
   }
 
-  public GenericConstraint in(MultiValue subQuery) {
-    return new GenericConstraint<T>(this, new In<T>(subQuery));
+  public GenericConstraint in(MultiValue<T> multiValue) {
+    return new GenericConstraint<T>(this, new In<T>(multiValue));
   }
 
   public GenericConstraint notIn(T value, T... otherValues) {
@@ -327,8 +327,8 @@ public class Column<T> {
     }
   }
 
-  public GenericConstraint notIn(MultiValue subQuery) {
-    return new GenericConstraint<T>(this, new NotIn<T>(subQuery));
+  public GenericConstraint notIn(MultiValue<T> multiValue) {
+    return new GenericConstraint<T>(this, new NotIn<T>(multiValue));
   }
 
   public GenericConstraint matches(String pattern) {

--- a/jack-core/src/com/rapleaf/jack/queries/GenericDeletion.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericDeletion.java
@@ -17,11 +17,11 @@ public class GenericDeletion extends AbstractExecution {
   private static final Logger LOG = LoggerFactory.getLogger(GenericDeletion.class);
 
   private final boolean allowBulkOperation;
-  private final Table table;
+  private final AbstractTable table;
   private final List<GenericConstraint> whereConstraints;
   private final List<Object> whereParameters;
 
-  private GenericDeletion(BaseDatabaseConnection dbConnection, boolean allowBulkOperation, Table table) {
+  private GenericDeletion(BaseDatabaseConnection dbConnection, boolean allowBulkOperation, AbstractTable table) {
     super(dbConnection);
     this.allowBulkOperation = allowBulkOperation;
     this.table = table;
@@ -42,7 +42,7 @@ public class GenericDeletion extends AbstractExecution {
       this.allowBulkOperation = allowBulkOperation;
     }
 
-    public GenericDeletion from(Table table) {
+    public GenericDeletion from(AbstractTable table) {
       return new GenericDeletion(dbConnection, allowBulkOperation, table);
     }
   }

--- a/jack-core/src/com/rapleaf/jack/queries/GenericDeletion.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericDeletion.java
@@ -79,7 +79,7 @@ public class GenericDeletion extends AbstractExecution {
   }
 
   @Override
-  protected String getQueryStatement() {
+  public String getRawStatement() {
     return getFromClause() +
         getWhereClause();
   }

--- a/jack-core/src/com/rapleaf/jack/queries/GenericDeletion.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericDeletion.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.SQLRecoverableException;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -93,7 +92,7 @@ public class GenericDeletion extends AbstractExecution {
   }
 
   @Override
-  protected Collection<Object> getParameters() {
+  protected List<Object> getParameters() {
     return whereParameters;
   }
 }

--- a/jack-core/src/com/rapleaf/jack/queries/GenericDeletion.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericDeletion.java
@@ -79,7 +79,7 @@ public class GenericDeletion extends AbstractExecution {
   }
 
   @Override
-  public String getRawStatement() {
+  public String getQueryStatement() {
     return getFromClause() +
         getWhereClause();
   }

--- a/jack-core/src/com/rapleaf/jack/queries/GenericInsertion.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericInsertion.java
@@ -111,7 +111,7 @@ public class GenericInsertion extends AbstractExecution {
   }
 
   @Override
-  protected String getQueryStatement() {
+  public String getRawStatement() {
     return getInsertClause()
         + getColumnsClause()
         + getValuesClause();

--- a/jack-core/src/com/rapleaf/jack/queries/GenericInsertion.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericInsertion.java
@@ -111,7 +111,7 @@ public class GenericInsertion extends AbstractExecution {
   }
 
   @Override
-  public String getRawStatement() {
+  public String getQueryStatement() {
     return getInsertClause()
         + getColumnsClause()
         + getValuesClause();

--- a/jack-core/src/com/rapleaf/jack/queries/GenericInsertion.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericInsertion.java
@@ -6,13 +6,11 @@ import java.sql.SQLException;
 import java.sql.SQLRecoverableException;
 import java.sql.Statement;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -25,11 +23,11 @@ import com.rapleaf.jack.util.JackUtility;
 public class GenericInsertion extends AbstractExecution {
   private static final Logger LOG = LoggerFactory.getLogger(GenericInsertion.class);
 
-  private final Table table;
+  private final AbstractTable table;
   private final Map<Column, List<Object>> values;
   private int rowCount = 0;
 
-  private GenericInsertion(BaseDatabaseConnection dbConnection, Table table) {
+  private GenericInsertion(BaseDatabaseConnection dbConnection, AbstractTable table) {
     super(dbConnection);
     this.table = table;
     this.values = Maps.newLinkedHashMap();
@@ -46,7 +44,7 @@ public class GenericInsertion extends AbstractExecution {
       this.dbConnection = dbConnection;
     }
 
-    public GenericInsertion into(Table table) {
+    public GenericInsertion into(AbstractTable table) {
       return new GenericInsertion(dbConnection, table);
     }
   }

--- a/jack-core/src/com/rapleaf/jack/queries/GenericInsertion.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericInsertion.java
@@ -118,7 +118,7 @@ public class GenericInsertion extends AbstractExecution {
   }
 
   @Override
-  protected Collection<Object> getParameters() {
+  protected List<Object> getParameters() {
     List<Object> parameters = Lists.newLinkedList();
     for (int i = 0; i < rowCount; ++i) {
       for (List<Object> list : values.values()) {

--- a/jack-core/src/com/rapleaf/jack/queries/GenericQuery.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericQuery.java
@@ -26,13 +26,13 @@ public class GenericQuery extends AbstractExecution {
   private static final Logger LOG = LoggerFactory.getLogger(GenericQuery.class);
   protected static int MAX_CONNECTION_RETRIES = 1;
 
-  final List<Table> includedTables;
+  private final List<Table> includedTables;
+  private final Set<Column> selectedColumns;
   private final PostQueryAction postQueryAction;
   private final List<JoinCondition> joinConditions;
   private final List<GenericConstraint> whereConstraints;
   private final List<Object> parameters;
   private final List<OrderCriterion> orderCriteria;
-  final Set<Column> selectedColumns;
   private final Set<Column> groupByColumns;
   private Optional<LimitCriterion> limitCriteria;
   private boolean selectDistinct;
@@ -40,13 +40,13 @@ public class GenericQuery extends AbstractExecution {
   private GenericQuery(BaseDatabaseConnection dbConnection, Table table, PostQueryAction postQueryAction) {
     super(dbConnection);
     this.includedTables = Lists.newArrayList(table);
+    this.selectedColumns = Sets.newHashSet();
     this.postQueryAction = postQueryAction;
     this.joinConditions = Lists.newArrayList();
     this.whereConstraints = Lists.newArrayList();
     this.parameters = Lists.newArrayList();
     parameters.addAll(table.getParameters());
     this.orderCriteria = Lists.newArrayList();
-    this.selectedColumns = Sets.newHashSet();
     this.groupByColumns = Sets.newHashSet();
     this.limitCriteria = Optional.empty();
     this.selectDistinct = false;
@@ -241,6 +241,14 @@ public class GenericQuery extends AbstractExecution {
   @Override
   public List<Object> getParameters() {
     return parameters;
+  }
+
+  List<Table> getIncludedTables() {
+    return includedTables;
+  }
+
+  Set<Column> getSelectedColumns() {
+    return selectedColumns;
   }
 
   private String getSelectClause() {

--- a/jack-core/src/com/rapleaf/jack/queries/GenericQuery.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericQuery.java
@@ -164,6 +164,14 @@ public class GenericQuery extends AbstractExecution {
     return new SubTable(this, alias);
   }
 
+  public SingleValue asSingleValue(Column column) {
+    return new SingleValue(getQueryStatement(), getParameters());
+  }
+
+  public MultiValue asMultiValue(Column column) {
+    return new MultiValue(getQueryStatement(), getParameters());
+  }
+
   public Records fetch() throws IOException {
     int retryCount = 0;
     final QueryStatistics.Measurer statTracker = new QueryStatistics.Measurer();

--- a/jack-core/src/com/rapleaf/jack/queries/GenericQuery.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericQuery.java
@@ -220,7 +220,7 @@ public class GenericQuery extends AbstractExecution {
   }
 
   @Override
-  protected String getQueryStatement() {
+  public String getRawStatement() {
     return getSelectClause()
         + getFromClause()
         + getJoinClause()

--- a/jack-core/src/com/rapleaf/jack/queries/GenericQuery.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericQuery.java
@@ -220,7 +220,7 @@ public class GenericQuery extends AbstractExecution {
   }
 
   @Override
-  public String getRawStatement() {
+  public String getQueryStatement() {
     return getSelectClause()
         + getFromClause()
         + getJoinClause()

--- a/jack-core/src/com/rapleaf/jack/queries/GenericQuery.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericQuery.java
@@ -26,13 +26,13 @@ public class GenericQuery extends AbstractExecution {
   private static final Logger LOG = LoggerFactory.getLogger(GenericQuery.class);
   protected static int MAX_CONNECTION_RETRIES = 1;
 
-  private final List<Table> includedTables;
+  final List<Table> includedTables;
   private final PostQueryAction postQueryAction;
   private final List<JoinCondition> joinConditions;
   private final List<GenericConstraint> whereConstraints;
   private final List<Object> parameters;
   private final List<OrderCriterion> orderCriteria;
-  private final Set<Column> selectedColumns;
+  final Set<Column> selectedColumns;
   private final Set<Column> groupByColumns;
   private Optional<LimitCriterion> limitCriteria;
   private boolean selectDistinct;
@@ -44,6 +44,7 @@ public class GenericQuery extends AbstractExecution {
     this.joinConditions = Lists.newArrayList();
     this.whereConstraints = Lists.newArrayList();
     this.parameters = Lists.newArrayList();
+    parameters.addAll(table.getParameters());
     this.orderCriteria = Lists.newArrayList();
     this.selectedColumns = Sets.newHashSet();
     this.groupByColumns = Sets.newHashSet();
@@ -79,14 +80,17 @@ public class GenericQuery extends AbstractExecution {
   }
 
   public JoinConditionBuilder leftJoin(Table table) {
+    this.parameters.addAll(table.getParameters());
     return new JoinConditionBuilder(this, JoinType.LEFT_JOIN, table);
   }
 
   public JoinConditionBuilder rightJoin(Table table) {
+    this.parameters.addAll(table.getParameters());
     return new JoinConditionBuilder(this, JoinType.RIGHT_JOIN, table);
   }
 
   public JoinConditionBuilder innerJoin(Table table) {
+    this.parameters.addAll(table.getParameters());
     return new JoinConditionBuilder(this, JoinType.INNER_JOIN, table);
   }
 
@@ -154,6 +158,10 @@ public class GenericQuery extends AbstractExecution {
   public GenericQuery distinct() {
     this.selectDistinct = true;
     return this;
+  }
+
+  public SubTable asSubTable(String alias) {
+    return new SubTable(this, alias);
   }
 
   public Records fetch() throws IOException {
@@ -231,7 +239,7 @@ public class GenericQuery extends AbstractExecution {
   }
 
   @Override
-  public Collection<Object> getParameters() {
+  public List<Object> getParameters() {
     return parameters;
   }
 

--- a/jack-core/src/com/rapleaf/jack/queries/GenericQuery.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericQuery.java
@@ -231,7 +231,7 @@ public class GenericQuery extends AbstractExecution {
   }
 
   @Override
-  protected Collection<Object> getParameters() {
+  public Collection<Object> getParameters() {
     return parameters;
   }
 

--- a/jack-core/src/com/rapleaf/jack/queries/GenericQuery.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericQuery.java
@@ -164,12 +164,12 @@ public class GenericQuery extends AbstractExecution {
     return new SubTable(this, alias);
   }
 
-  public SingleValue asSingleValue(Column column) {
-    return new SingleValue(getQueryStatement(), getParameters());
+  public <T> SingleValue<T> asSingleValue(Column<T> column) {
+    return new SingleValue<>(getQueryStatement(), getParameters());
   }
 
-  public MultiValue asMultiValue(Column column) {
-    return new MultiValue(getQueryStatement(), getParameters());
+  public <T> MultiValue<T> asMultiValue(Column<T> column) {
+    return new MultiValue<>(getQueryStatement(), getParameters());
   }
 
   public Records fetch() throws IOException {

--- a/jack-core/src/com/rapleaf/jack/queries/GenericQuery.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericQuery.java
@@ -6,6 +6,7 @@ import java.sql.SQLException;
 import java.sql.SQLRecoverableException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -27,7 +28,7 @@ public class GenericQuery extends AbstractExecution {
   protected static int MAX_CONNECTION_RETRIES = 1;
 
   private final List<Table> includedTables;
-  private final Set<Column> selectedColumns;
+  private Set<Column> selectedColumns;
   private final PostQueryAction postQueryAction;
   private final List<JoinCondition> joinConditions;
   private final List<GenericConstraint> whereConstraints;
@@ -165,10 +166,12 @@ public class GenericQuery extends AbstractExecution {
   }
 
   public <T> SingleValue<T> asSingleValue(Column<T> column) {
+    selectedColumns = Collections.singleton(column);
     return new SingleValue<>(getQueryStatement(), getParameters());
   }
 
   public <T> MultiValue<T> asMultiValue(Column<T> column) {
+    selectedColumns = Collections.singleton(column);
     return new MultiValue<>(getQueryStatement(), getParameters());
   }
 

--- a/jack-core/src/com/rapleaf/jack/queries/GenericTable.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericTable.java
@@ -15,12 +15,12 @@ import com.rapleaf.jack.exception.JackRuntimeException;
 
 public abstract class GenericTable<T extends GenericTable<T>> {
 
-  public final Table<?, ?> table;
+  public final AbstractTable<?, ?> table;
   public final Column<Long> id;
   private final Class<T> tableType;
   protected final List<Column<?>> columns;
 
-  protected GenericTable(Table<?, ?> table, Class<T> tableType, Column<?> firstColumn, Column<?>... otherColumns) {
+  protected GenericTable(AbstractTable<?, ?> table, Class<T> tableType, Column<?> firstColumn, Column<?>... otherColumns) {
     this.table = table;
     this.id = Column.fromId(table.getAlias());
     this.tableType = tableType;
@@ -31,20 +31,20 @@ public abstract class GenericTable<T extends GenericTable<T>> {
 
   public abstract T as(String alias);
 
-  protected Table<?, ?> getAliasTable(String alias) {
+  protected AbstractTable<?, ?> getAliasTable(String alias) {
     try {
       Method method = table.getClass().getMethod("as", String.class);
-      return (Table<?, ?>)method.invoke(null, alias);
+      return (AbstractTable<?, ?>)method.invoke(null, alias);
     } catch (Exception e) {
       throw new JackRuntimeException(e);
     }
   }
 
   public static abstract class Builder<T extends GenericTable<T>> {
-    protected final Table<?, ?> table;
+    protected final AbstractTable<?, ?> table;
     protected final Set<String> allColumns;
 
-    protected Builder(Table<?, ?> table) {
+    protected Builder(AbstractTable<?, ?> table) {
       this.table = table;
       this.allColumns = table.getAllColumns().stream()
           .map(Column::getField)

--- a/jack-core/src/com/rapleaf/jack/queries/GenericUpdate.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericUpdate.java
@@ -95,7 +95,7 @@ public class GenericUpdate extends AbstractExecution {
   }
 
   @Override
-  protected String getQueryStatement() {
+  public String getRawStatement() {
     return getUpdateClause() +
         getSetClause() +
         getWhereClause();

--- a/jack-core/src/com/rapleaf/jack/queries/GenericUpdate.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericUpdate.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.SQLRecoverableException;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -130,7 +129,7 @@ public class GenericUpdate extends AbstractExecution {
   }
 
   @Override
-  protected Collection<Object> getParameters() {
+  protected List<Object> getParameters() {
     List<Object> parameters = Lists.newLinkedList();
     parameters.addAll(values.values());
     parameters.addAll(whereParameters);

--- a/jack-core/src/com/rapleaf/jack/queries/GenericUpdate.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericUpdate.java
@@ -95,7 +95,7 @@ public class GenericUpdate extends AbstractExecution {
   }
 
   @Override
-  public String getRawStatement() {
+  public String getQueryStatement() {
     return getUpdateClause() +
         getSetClause() +
         getWhereClause();

--- a/jack-core/src/com/rapleaf/jack/queries/GenericUpdate.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericUpdate.java
@@ -21,12 +21,12 @@ public class GenericUpdate extends AbstractExecution {
   private static final Logger LOG = LoggerFactory.getLogger(GenericUpdate.class);
 
   private final boolean allowBulkOperation;
-  private final Table table;
+  private final AbstractTable table;
   private final Map<Column, Object> values;
   private final List<GenericConstraint> whereConstraints;
   private final List<Object> whereParameters;
 
-  private GenericUpdate(BaseDatabaseConnection dbConnection, boolean allowBulkOperation, Table table) {
+  private GenericUpdate(BaseDatabaseConnection dbConnection, boolean allowBulkOperation, AbstractTable table) {
     super(dbConnection);
     this.allowBulkOperation = allowBulkOperation;
     this.table = table;
@@ -48,7 +48,7 @@ public class GenericUpdate extends AbstractExecution {
       this.allowBulkOperation = allowBulkOperation;
     }
 
-    public GenericUpdate table(Table table) {
+    public GenericUpdate table(AbstractTable table) {
       return new GenericUpdate(dbConnection, allowBulkOperation, table);
     }
   }

--- a/jack-core/src/com/rapleaf/jack/queries/IndexedTable.java
+++ b/jack-core/src/com/rapleaf/jack/queries/IndexedTable.java
@@ -7,7 +7,7 @@ import com.rapleaf.jack.ModelWithId;
 
 public class IndexedTable<A extends AttributesWithId, M extends ModelWithId> extends AbstractTable<A, M> {
 
-  private final Table<A, M> table;
+  private final AbstractTable<A, M> table;
   private final Set<IndexHint> indexHints;
 
   public IndexedTable(AbstractTable<A, M> table, Set<IndexHint> indexHints) {

--- a/jack-core/src/com/rapleaf/jack/queries/MultiValue.java
+++ b/jack-core/src/com/rapleaf/jack/queries/MultiValue.java
@@ -2,8 +2,12 @@ package com.rapleaf.jack.queries;
 
 import java.util.List;
 
-public class MultiValue extends ValueExpression {
+public class MultiValue<T> extends ValueExpression<T> {
   public MultiValue(String queryStatement, List<Object> parameters) {
     super(queryStatement, parameters);
+  }
+
+  public <M> MultiValue<M> as(Class<M> type) {
+    return new MultiValue<>(queryStatement, parameters);
   }
 }

--- a/jack-core/src/com/rapleaf/jack/queries/MultiValue.java
+++ b/jack-core/src/com/rapleaf/jack/queries/MultiValue.java
@@ -1,0 +1,9 @@
+package com.rapleaf.jack.queries;
+
+import java.util.List;
+
+public class MultiValue extends ValueExpression {
+  public MultiValue(String queryStatement, List<Object> parameters) {
+    super(queryStatement, parameters);
+  }
+}

--- a/jack-core/src/com/rapleaf/jack/queries/Record.java
+++ b/jack-core/src/com/rapleaf/jack/queries/Record.java
@@ -83,7 +83,7 @@ public class Record {
     return value == null ? null : (Boolean)value;
   }
 
-  public <A extends AttributesWithId, M extends ModelWithId> A getAttributes(Table<A, M> tableType) {
+  public <A extends AttributesWithId, M extends ModelWithId> A getAttributes(AbstractTable<A, M> tableType) {
     String tableName = tableType.getAlias();
     Constructor<A> constructor;
     try {
@@ -128,7 +128,7 @@ public class Record {
     return attribute;
   }
 
-  public <A extends AttributesWithId, M extends ModelWithId, D extends GenericDatabases> M getModel(Table<A, M> tableType, D databases) {
+  public <A extends AttributesWithId, M extends ModelWithId, D extends GenericDatabases> M getModel(AbstractTable<A, M> tableType, D databases) {
     try {
       AttributesWithId attributes = getAttributes(tableType);
       if (attributes == null) {

--- a/jack-core/src/com/rapleaf/jack/queries/Records.java
+++ b/jack-core/src/com/rapleaf/jack/queries/Records.java
@@ -104,7 +104,7 @@ public class Records implements Iterable<Record> {
     return results;
   }
 
-  public <A extends AttributesWithId, M extends ModelWithId> List<A> getAttributes(Table<A, M> tableType) {
+  public <A extends AttributesWithId, M extends ModelWithId> List<A> getAttributes(AbstractTable<A, M> tableType) {
     List<A> results = Lists.newArrayList();
     for (Record record : records) {
       results.add(record.getAttributes(tableType));
@@ -112,7 +112,7 @@ public class Records implements Iterable<Record> {
     return results;
   }
 
-  public <A extends AttributesWithId, M extends ModelWithId, D extends GenericDatabases> List<M> getModels(Table<A, M> tableType, D databases) {
+  public <A extends AttributesWithId, M extends ModelWithId, D extends GenericDatabases> List<M> getModels(AbstractTable<A, M> tableType, D databases) {
     List<M> results = Lists.newArrayList();
     for (Record record : records) {
       results.add(record.getModel(tableType, databases));

--- a/jack-core/src/com/rapleaf/jack/queries/SingleValue.java
+++ b/jack-core/src/com/rapleaf/jack/queries/SingleValue.java
@@ -1,0 +1,9 @@
+package com.rapleaf.jack.queries;
+
+import java.util.List;
+
+public class SingleValue extends ValueExpression {
+  public SingleValue(String queryStatement, List<Object> parameters) {
+    super(queryStatement, parameters);
+  }
+}

--- a/jack-core/src/com/rapleaf/jack/queries/SingleValue.java
+++ b/jack-core/src/com/rapleaf/jack/queries/SingleValue.java
@@ -2,8 +2,12 @@ package com.rapleaf.jack.queries;
 
 import java.util.List;
 
-public class SingleValue extends ValueExpression {
+public class SingleValue<T> extends ValueExpression<T> {
   public SingleValue(String queryStatement, List<Object> parameters) {
     super(queryStatement, parameters);
+  }
+
+  public <M> SingleValue<M> as(Class<M> type) {
+    return new SingleValue<>(queryStatement, parameters);
   }
 }

--- a/jack-core/src/com/rapleaf/jack/queries/SubTable.java
+++ b/jack-core/src/com/rapleaf/jack/queries/SubTable.java
@@ -1,0 +1,87 @@
+package com.rapleaf.jack.queries;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.Sets;
+
+public class SubTable implements Table {
+  private static final String ALIAS_PREFIX = "t";
+
+  private final GenericQuery subQuery;
+  private final String alias;
+  private final Set<Column> selectedColumns;
+
+  SubTable(GenericQuery subQuery, String alias) {
+    this.subQuery = subQuery;
+    this.alias = ALIAS_PREFIX + alias;
+    this.selectedColumns = Sets.newHashSet();
+  }
+
+  @Override
+  public String getName() {
+    return null;
+  }
+
+  @Override
+  public String getAlias() {
+    return null;
+  }
+
+  @Override
+  public Set<Column> getAllColumns() {
+    Set<Column> columns = Sets.newHashSet();
+
+    if (subQuery.selectedColumns.isEmpty()) {
+      for (Table<?, ?> table : subQuery.includedTables) {
+        for (Column column : table.getAllColumns()) {
+          columns.add(column.asIn(alias));
+        }
+      }
+    } else {
+      for (Column column : subQuery.selectedColumns) {
+        columns.add(column.asIn(alias));
+      }
+    }
+
+    return columns;
+  }
+
+  @Override
+  public String getSqlKeyword() {
+    return String.format("(%s) as %s", subQuery.getQueryStatement(), alias);
+  }
+
+  @Override
+  public Class getAttributesType() {
+    return null;
+  }
+
+  @Override
+  public Class getModelType() {
+    return null;
+  }
+
+  @Override
+  public List<?> getParameters() {
+    return subQuery.getParameters();
+  }
+
+  public <T> Column<T> column(Column<T> column) {
+    return column.asIn(alias);
+  }
+
+  public Collection<Column> columns(Collection<Column> columns) {
+    return columns.stream().map(c -> c.asIn(alias)).collect(Collectors.toSet());
+  }
+
+  public Collection<Column> columns(Column column, Column... columns) {
+    Set<Column> aliasedColumns = Sets.newHashSetWithExpectedSize(1 + columns.length);
+    aliasedColumns.add(column.asIn(alias));
+    aliasedColumns.addAll(Arrays.stream(columns).map(c -> c.asIn(alias)).collect(Collectors.toSet()));
+    return aliasedColumns;
+  }
+}

--- a/jack-core/src/com/rapleaf/jack/queries/SubTable.java
+++ b/jack-core/src/com/rapleaf/jack/queries/SubTable.java
@@ -13,22 +13,20 @@ public class SubTable implements Table {
 
   private final GenericQuery subQuery;
   private final String alias;
-  private final Set<Column> selectedColumns;
 
   SubTable(GenericQuery subQuery, String alias) {
     this.subQuery = subQuery;
     this.alias = ALIAS_PREFIX + alias;
-    this.selectedColumns = Sets.newHashSet();
   }
 
   @Override
   public String getName() {
-    return null;
+    return alias;
   }
 
   @Override
   public String getAlias() {
-    return null;
+    return alias;
   }
 
   @Override
@@ -36,7 +34,7 @@ public class SubTable implements Table {
     Set<Column> columns = Sets.newHashSet();
 
     if (subQuery.selectedColumns.isEmpty()) {
-      for (Table<?, ?> table : subQuery.includedTables) {
+      for (Table table : subQuery.includedTables) {
         for (Column column : table.getAllColumns()) {
           columns.add(column.asIn(alias));
         }
@@ -53,16 +51,6 @@ public class SubTable implements Table {
   @Override
   public String getSqlKeyword() {
     return String.format("(%s) as %s", subQuery.getQueryStatement(), alias);
-  }
-
-  @Override
-  public Class getAttributesType() {
-    return null;
-  }
-
-  @Override
-  public Class getModelType() {
-    return null;
   }
 
   @Override

--- a/jack-core/src/com/rapleaf/jack/queries/SubTable.java
+++ b/jack-core/src/com/rapleaf/jack/queries/SubTable.java
@@ -37,12 +37,12 @@ public class SubTable implements Table {
     if (subQuery.getSelectedColumns().isEmpty()) {
       for (Table table : subQuery.getIncludedTables()) {
         for (Column column : table.getAllColumns()) {
-          columns.add(column.asIn(alias));
+          columns.add(column.forTable(alias));
         }
       }
     } else {
       for (Column column : subQuery.getSelectedColumns()) {
-        columns.add(column.asIn(alias));
+        columns.add(column.forTable(alias));
       }
     }
 
@@ -60,17 +60,17 @@ public class SubTable implements Table {
   }
 
   public <T> Column<T> column(Column<T> column) {
-    return column.asIn(alias);
+    return column.forTable(alias);
   }
 
   public Collection<Column> columns(Collection<Column> columns) {
-    return columns.stream().map(c -> c.asIn(alias)).collect(Collectors.toSet());
+    return columns.stream().map(c -> c.forTable(alias)).collect(Collectors.toSet());
   }
 
   public Collection<Column> columns(Column column, Column... columns) {
     Set<Column> aliasedColumns = Sets.newHashSetWithExpectedSize(1 + columns.length);
-    aliasedColumns.add(column.asIn(alias));
-    aliasedColumns.addAll(Arrays.stream(columns).map(c -> c.asIn(alias)).collect(Collectors.toSet()));
+    aliasedColumns.add(column.forTable(alias));
+    aliasedColumns.addAll(Arrays.stream(columns).map(c -> c.forTable(alias)).collect(Collectors.toSet()));
     return aliasedColumns;
   }
 

--- a/jack-core/src/com/rapleaf/jack/queries/SubTable.java
+++ b/jack-core/src/com/rapleaf/jack/queries/SubTable.java
@@ -9,14 +9,12 @@ import java.util.stream.Collectors;
 import com.google.common.collect.Sets;
 
 public class SubTable implements Table {
-  private static final String ALIAS_PREFIX = "t";
-
   private final GenericQuery subQuery;
   private final String alias;
 
   SubTable(GenericQuery subQuery, String alias) {
     this.subQuery = subQuery;
-    this.alias = ALIAS_PREFIX + alias;
+    this.alias = alias;
   }
 
   @Override

--- a/jack-core/src/com/rapleaf/jack/queries/SubTable.java
+++ b/jack-core/src/com/rapleaf/jack/queries/SubTable.java
@@ -33,14 +33,14 @@ public class SubTable implements Table {
   public Set<Column> getAllColumns() {
     Set<Column> columns = Sets.newHashSet();
 
-    if (subQuery.selectedColumns.isEmpty()) {
-      for (Table table : subQuery.includedTables) {
+    if (subQuery.getSelectedColumns().isEmpty()) {
+      for (Table table : subQuery.getIncludedTables()) {
         for (Column column : table.getAllColumns()) {
           columns.add(column.asIn(alias));
         }
       }
     } else {
-      for (Column column : subQuery.selectedColumns) {
+      for (Column column : subQuery.getSelectedColumns()) {
         columns.add(column.asIn(alias));
       }
     }

--- a/jack-core/src/com/rapleaf/jack/queries/SubTable.java
+++ b/jack-core/src/com/rapleaf/jack/queries/SubTable.java
@@ -8,6 +8,9 @@ import java.util.stream.Collectors;
 
 import com.google.common.collect.Sets;
 
+import com.rapleaf.jack.AttributesWithId;
+import com.rapleaf.jack.ModelWithId;
+
 public class SubTable implements Table {
   private final GenericQuery subQuery;
   private final String alias;
@@ -69,5 +72,9 @@ public class SubTable implements Table {
     aliasedColumns.add(column.asIn(alias));
     aliasedColumns.addAll(Arrays.stream(columns).map(c -> c.asIn(alias)).collect(Collectors.toSet()));
     return aliasedColumns;
+  }
+
+  public <A extends AttributesWithId, M extends ModelWithId> AbstractTable<A, M> model(AbstractTable<A, M> table) {
+    return table.alias(alias);
   }
 }

--- a/jack-core/src/com/rapleaf/jack/queries/Table.java
+++ b/jack-core/src/com/rapleaf/jack/queries/Table.java
@@ -1,5 +1,7 @@
 package com.rapleaf.jack.queries;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import com.rapleaf.jack.AttributesWithId;
@@ -18,5 +20,9 @@ public interface Table<A extends AttributesWithId, M extends ModelWithId> {
   public Class<A> getAttributesType();
 
   public Class<M> getModelType();
+
+  default List<?> getParameters() {
+    return Collections.emptyList();
+  }
 
 }

--- a/jack-core/src/com/rapleaf/jack/queries/Table.java
+++ b/jack-core/src/com/rapleaf/jack/queries/Table.java
@@ -4,10 +4,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import com.rapleaf.jack.AttributesWithId;
-import com.rapleaf.jack.ModelWithId;
-
-public interface Table<A extends AttributesWithId, M extends ModelWithId> {
+public interface Table {
 
   public String getName();
 
@@ -16,10 +13,6 @@ public interface Table<A extends AttributesWithId, M extends ModelWithId> {
   public Set<Column> getAllColumns();
 
   public String getSqlKeyword();
-
-  public Class<A> getAttributesType();
-
-  public Class<M> getModelType();
 
   default List<?> getParameters() {
     return Collections.emptyList();

--- a/jack-core/src/com/rapleaf/jack/queries/ValueExpression.java
+++ b/jack-core/src/com/rapleaf/jack/queries/ValueExpression.java
@@ -1,0 +1,21 @@
+package com.rapleaf.jack.queries;
+
+import java.util.List;
+
+public abstract class ValueExpression {
+  private final String queryStatement;
+  private final List<Object> parameters;
+
+  ValueExpression(String queryStatement, List<Object> parameters) {
+    this.queryStatement = queryStatement;
+    this.parameters = parameters;
+  }
+
+  public String getQueryStatement() {
+    return queryStatement;
+  }
+
+  public List<Object> getParameters() {
+    return parameters;
+  }
+}

--- a/jack-core/src/com/rapleaf/jack/queries/ValueExpression.java
+++ b/jack-core/src/com/rapleaf/jack/queries/ValueExpression.java
@@ -2,9 +2,9 @@ package com.rapleaf.jack.queries;
 
 import java.util.List;
 
-public abstract class ValueExpression {
-  private final String queryStatement;
-  private final List<Object> parameters;
+public abstract class ValueExpression<T> {
+  final String queryStatement;
+  final List<Object> parameters;
 
   ValueExpression(String queryStatement, List<Object> parameters) {
     this.queryStatement = queryStatement;

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/EqualTo.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/EqualTo.java
@@ -1,8 +1,11 @@
 package com.rapleaf.jack.queries.where_operators;
 
+import java.util.Collection;
+
 import com.google.common.base.Preconditions;
 
 import com.rapleaf.jack.queries.Column;
+import com.rapleaf.jack.queries.GenericQuery;
 
 public class EqualTo<V> extends WhereOperator<V> {
 
@@ -19,5 +22,9 @@ public class EqualTo<V> extends WhereOperator<V> {
   public EqualTo(Column<V> column) {
     super("= " + column.getSqlKeyword());
     Preconditions.checkNotNull(column);
+  }
+
+  public EqualTo(GenericQuery subQuery) {
+    super("= (" + subQuery.getQueryStatement() + ")", (Collection<V>)subQuery.getParameters());
   }
 }

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/EqualTo.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/EqualTo.java
@@ -24,7 +24,7 @@ public class EqualTo<V> extends WhereOperator<V> {
     Preconditions.checkNotNull(column);
   }
 
-  public EqualTo(SingleValue subQuery) {
+  public EqualTo(SingleValue<V> subQuery) {
     super("= (" + subQuery.getQueryStatement() + ")", (Collection<V>)subQuery.getParameters());
   }
 }

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/EqualTo.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/EqualTo.java
@@ -5,7 +5,7 @@ import java.util.Collection;
 import com.google.common.base.Preconditions;
 
 import com.rapleaf.jack.queries.Column;
-import com.rapleaf.jack.queries.GenericQuery;
+import com.rapleaf.jack.queries.SingleValue;
 
 public class EqualTo<V> extends WhereOperator<V> {
 
@@ -24,7 +24,7 @@ public class EqualTo<V> extends WhereOperator<V> {
     Preconditions.checkNotNull(column);
   }
 
-  public EqualTo(GenericQuery subQuery) {
+  public EqualTo(SingleValue subQuery) {
     super("= (" + subQuery.getQueryStatement() + ")", (Collection<V>)subQuery.getParameters());
   }
 }

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/GreaterThan.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/GreaterThan.java
@@ -18,7 +18,7 @@ public class GreaterThan<V> extends WhereOperator<V> {
     Preconditions.checkNotNull(column);
   }
 
-  public GreaterThan(SingleValue subQuery) {
+  public GreaterThan(SingleValue<V> subQuery) {
     super("> (" + subQuery.getQueryStatement() + ")", (Collection<V>)subQuery.getParameters());
   }
 }

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/GreaterThan.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/GreaterThan.java
@@ -1,8 +1,11 @@
 package com.rapleaf.jack.queries.where_operators;
 
+import java.util.Collection;
+
 import com.google.common.base.Preconditions;
 
 import com.rapleaf.jack.queries.Column;
+import com.rapleaf.jack.queries.GenericQuery;
 
 public class GreaterThan<V> extends WhereOperator<V> {
 
@@ -13,5 +16,9 @@ public class GreaterThan<V> extends WhereOperator<V> {
   public GreaterThan(Column<V> column) {
     super("> " + column.getSqlKeyword());
     Preconditions.checkNotNull(column);
+  }
+
+  public GreaterThan(GenericQuery subQuery) {
+    super("> (" + subQuery.getQueryStatement() + ")", (Collection<V>)subQuery.getParameters());
   }
 }

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/GreaterThan.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/GreaterThan.java
@@ -5,7 +5,7 @@ import java.util.Collection;
 import com.google.common.base.Preconditions;
 
 import com.rapleaf.jack.queries.Column;
-import com.rapleaf.jack.queries.GenericQuery;
+import com.rapleaf.jack.queries.SingleValue;
 
 public class GreaterThan<V> extends WhereOperator<V> {
 
@@ -18,7 +18,7 @@ public class GreaterThan<V> extends WhereOperator<V> {
     Preconditions.checkNotNull(column);
   }
 
-  public GreaterThan(GenericQuery subQuery) {
+  public GreaterThan(SingleValue subQuery) {
     super("> (" + subQuery.getQueryStatement() + ")", (Collection<V>)subQuery.getParameters());
   }
 }

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/GreaterThanOrEqualTo.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/GreaterThanOrEqualTo.java
@@ -1,6 +1,9 @@
 package com.rapleaf.jack.queries.where_operators;
 
+import java.util.Collection;
+
 import com.rapleaf.jack.queries.Column;
+import com.rapleaf.jack.queries.GenericQuery;
 
 public class GreaterThanOrEqualTo<V> extends WhereOperator<V> {
 
@@ -10,5 +13,9 @@ public class GreaterThanOrEqualTo<V> extends WhereOperator<V> {
 
   public GreaterThanOrEqualTo(Column<V> column) {
     super(">= " + column.getSqlKeyword());
+  }
+
+  public GreaterThanOrEqualTo(GenericQuery subQuery) {
+    super(">= (" + subQuery.getQueryStatement() + ")", (Collection<V>)subQuery.getParameters());
   }
 }

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/GreaterThanOrEqualTo.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/GreaterThanOrEqualTo.java
@@ -15,7 +15,7 @@ public class GreaterThanOrEqualTo<V> extends WhereOperator<V> {
     super(">= " + column.getSqlKeyword());
   }
 
-  public GreaterThanOrEqualTo(SingleValue subQuery) {
+  public GreaterThanOrEqualTo(SingleValue<V> subQuery) {
     super(">= (" + subQuery.getQueryStatement() + ")", (Collection<V>)subQuery.getParameters());
   }
 }

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/GreaterThanOrEqualTo.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/GreaterThanOrEqualTo.java
@@ -3,7 +3,7 @@ package com.rapleaf.jack.queries.where_operators;
 import java.util.Collection;
 
 import com.rapleaf.jack.queries.Column;
-import com.rapleaf.jack.queries.GenericQuery;
+import com.rapleaf.jack.queries.SingleValue;
 
 public class GreaterThanOrEqualTo<V> extends WhereOperator<V> {
 
@@ -15,7 +15,7 @@ public class GreaterThanOrEqualTo<V> extends WhereOperator<V> {
     super(">= " + column.getSqlKeyword());
   }
 
-  public GreaterThanOrEqualTo(GenericQuery subQuery) {
+  public GreaterThanOrEqualTo(SingleValue subQuery) {
     super(">= (" + subQuery.getQueryStatement() + ")", (Collection<V>)subQuery.getParameters());
   }
 }

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/In.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/In.java
@@ -16,7 +16,7 @@ public class In<V> extends WhereOperator<V> {
     this.sqlStatement = createSqlStatement();
   }
 
-  public In(MultiValue subQuery) {
+  public In(MultiValue<V> subQuery) {
     super("IN (" + subQuery.getQueryStatement() + ")", (Collection<V>)subQuery.getParameters());
     this.sqlStatement = getSqlStatement();
   }

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/In.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/In.java
@@ -2,19 +2,26 @@ package com.rapleaf.jack.queries.where_operators;
 
 import java.util.Collection;
 
+import com.rapleaf.jack.queries.GenericQuery;
+
 public class In<V> extends WhereOperator<V> {
 
   public In(V value1, V... otherValues) {
     super(null, value1, otherValues);
+    this.sqlStatement = createSqlStatement();
   }
 
   public In(Collection<V> collection) {
     super(null, collection);
+    this.sqlStatement = createSqlStatement();
   }
 
-  @Override
-  public String getSqlStatement() {
+  public In(GenericQuery subQuery) {
+    super("IN (" + subQuery.getQueryStatement() + ")", (Collection<V>)subQuery.getParameters());
+    this.sqlStatement = getSqlStatement();
+  }
 
+  private String createSqlStatement() {
     StringBuilder sb = new StringBuilder("IN (");
 
     if (getParameters().isEmpty()) {

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/In.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/In.java
@@ -2,7 +2,7 @@ package com.rapleaf.jack.queries.where_operators;
 
 import java.util.Collection;
 
-import com.rapleaf.jack.queries.GenericQuery;
+import com.rapleaf.jack.queries.MultiValue;
 
 public class In<V> extends WhereOperator<V> {
 
@@ -16,7 +16,7 @@ public class In<V> extends WhereOperator<V> {
     this.sqlStatement = createSqlStatement();
   }
 
-  public In(GenericQuery subQuery) {
+  public In(MultiValue subQuery) {
     super("IN (" + subQuery.getQueryStatement() + ")", (Collection<V>)subQuery.getParameters());
     this.sqlStatement = getSqlStatement();
   }

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/JackMatchers.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/JackMatchers.java
@@ -14,11 +14,11 @@ public class JackMatchers {
     return new EqualTo<T>(value);
   }
 
-  public static <T> IWhereOperator<T> equalTo(SingleValue subQuery) {
-    if (subQuery == null) {
+  public static <T> IWhereOperator<T> equalTo(SingleValue<T> singleValue) {
+    if (singleValue == null) {
       return new IsNull<T>();
     }
-    return new EqualTo<T>(subQuery);
+    return new EqualTo<T>(singleValue);
   }
 
   public static <T> IWhereOperator<T> notEqualTo(T value) {
@@ -28,11 +28,11 @@ public class JackMatchers {
     return new NotEqualTo<T>(value);
   }
 
-  public static <T> IWhereOperator<T> notEqualTo(SingleValue subQuery) {
-    if (subQuery == null) {
+  public static <T> IWhereOperator<T> notEqualTo(SingleValue<T> singleValue) {
+    if (singleValue == null) {
       return new IsNotNull<T>();
     }
-    return new NotEqualTo<T>(subQuery);
+    return new NotEqualTo<T>(singleValue);
   }
 
   public static <T> IsNull<T> isNull() {
@@ -51,8 +51,8 @@ public class JackMatchers {
     return new In<T>(values);
   }
 
-  public static <T> In<T> in(MultiValue subQuery) {
-    return new In<T>(subQuery);
+  public static <T> In<T> in(MultiValue<T> multiValue) {
+    return new In<T>(multiValue);
   }
 
   public static <T> NotIn<T> notIn(T value1, T... otherValues) {
@@ -66,40 +66,40 @@ public class JackMatchers {
     return new NotIn<T>(values);
   }
 
-  public static <T> NotIn<T> notIn(MultiValue subQuery) {
-    return new NotIn<T>(subQuery);
+  public static <T> NotIn<T> notIn(MultiValue<T> multiValue) {
+    return new NotIn<T>(multiValue);
   }
 
   public static <T extends Comparable<T>> GreaterThan<T> greaterThan(T value) {
     return new GreaterThan<T>(value);
   }
 
-  public static <T extends Comparable<T>> GreaterThan<T> greaterThan(SingleValue subQuery) {
-    return new GreaterThan<T>(subQuery);
+  public static <T extends Comparable<T>> GreaterThan<T> greaterThan(SingleValue<T> singleValue) {
+    return new GreaterThan<T>(singleValue);
   }
 
   public static <T extends Comparable<T>> LessThan<T> lessThan(T value) {
     return new LessThan<T>(value);
   }
 
-  public static <T extends Comparable<T>> LessThan<T> lessThan(SingleValue subQuery) {
-    return new LessThan<T>(subQuery);
+  public static <T extends Comparable<T>> LessThan<T> lessThan(SingleValue<T> singleValue) {
+    return new LessThan<T>(singleValue);
   }
 
   public static <T extends Comparable<T>> GreaterThanOrEqualTo<T> greaterThanOrEqualTo(T value) {
     return new GreaterThanOrEqualTo<T>(value);
   }
 
-  public static <T extends Comparable<T>> GreaterThanOrEqualTo<T> greaterThanOrEqualTo(SingleValue subQuery) {
-    return new GreaterThanOrEqualTo<T>(subQuery);
+  public static <T extends Comparable<T>> GreaterThanOrEqualTo<T> greaterThanOrEqualTo(SingleValue<T> singleValue) {
+    return new GreaterThanOrEqualTo<T>(singleValue);
   }
 
   public static <T extends Comparable<T>> LessThanOrEqualTo<T> lessThanOrEqualTo(T value) {
     return new LessThanOrEqualTo<T>(value);
   }
 
-  public static <T extends Comparable<T>> LessThanOrEqualTo<T> lessThanOrEqualTo(SingleValue subQuery) {
-    return new LessThanOrEqualTo<T>(subQuery);
+  public static <T extends Comparable<T>> LessThanOrEqualTo<T> lessThanOrEqualTo(SingleValue<T> singleValue) {
+    return new LessThanOrEqualTo<T>(singleValue);
   }
 
   public static <T extends Comparable<T>> Between<T> between(T min, T max) {

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/JackMatchers.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/JackMatchers.java
@@ -2,6 +2,8 @@ package com.rapleaf.jack.queries.where_operators;
 
 import java.util.Collection;
 
+import com.rapleaf.jack.queries.GenericQuery;
+
 public class JackMatchers {
 
   public static <T> IWhereOperator<T> equalTo(T value) {
@@ -11,11 +13,25 @@ public class JackMatchers {
     return new EqualTo<T>(value);
   }
 
+  public static <T> IWhereOperator<T> equalTo(GenericQuery subQuery) {
+    if (subQuery == null) {
+      return new IsNull<T>();
+    }
+    return new EqualTo<T>(subQuery);
+  }
+
   public static <T> IWhereOperator<T> notEqualTo(T value) {
     if (value == null) {
       return new IsNotNull<T>();
     }
     return new NotEqualTo<T>(value);
+  }
+
+  public static <T> IWhereOperator<T> notEqualTo(GenericQuery subQuery) {
+    if (subQuery == null) {
+      return new IsNotNull<T>();
+    }
+    return new NotEqualTo<T>(subQuery);
   }
 
   public static <T> IsNull<T> isNull() {
@@ -34,6 +50,10 @@ public class JackMatchers {
     return new In<T>(values);
   }
 
+  public static <T> In<T> in(GenericQuery subQuery) {
+    return new In<T>(subQuery);
+  }
+
   public static <T> NotIn<T> notIn(T value1, T... otherValues) {
     return new NotIn<T>(value1, otherValues);
   }
@@ -45,20 +65,40 @@ public class JackMatchers {
     return new NotIn<T>(values);
   }
 
+  public static <T> NotIn<T> notIn(GenericQuery subQuery) {
+    return new NotIn<T>(subQuery);
+  }
+
   public static <T extends Comparable<T>> GreaterThan<T> greaterThan(T value) {
     return new GreaterThan<T>(value);
+  }
+
+  public static <T extends Comparable<T>> GreaterThan<T> greaterThan(GenericQuery subQuery) {
+    return new GreaterThan<T>(subQuery);
   }
 
   public static <T extends Comparable<T>> LessThan<T> lessThan(T value) {
     return new LessThan<T>(value);
   }
 
+  public static <T extends Comparable<T>> LessThan<T> lessThan(GenericQuery subQuery) {
+    return new LessThan<T>(subQuery);
+  }
+
   public static <T extends Comparable<T>> GreaterThanOrEqualTo<T> greaterThanOrEqualTo(T value) {
     return new GreaterThanOrEqualTo<T>(value);
   }
 
+  public static <T extends Comparable<T>> GreaterThanOrEqualTo<T> greaterThanOrEqualTo(GenericQuery subQuery) {
+    return new GreaterThanOrEqualTo<T>(subQuery);
+  }
+
   public static <T extends Comparable<T>> LessThanOrEqualTo<T> lessThanOrEqualTo(T value) {
     return new LessThanOrEqualTo<T>(value);
+  }
+
+  public static <T extends Comparable<T>> LessThanOrEqualTo<T> lessThanOrEqualTo(GenericQuery subQuery) {
+    return new LessThanOrEqualTo<T>(subQuery);
   }
 
   public static <T extends Comparable<T>> Between<T> between(T min, T max) {

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/JackMatchers.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/JackMatchers.java
@@ -2,7 +2,8 @@ package com.rapleaf.jack.queries.where_operators;
 
 import java.util.Collection;
 
-import com.rapleaf.jack.queries.GenericQuery;
+import com.rapleaf.jack.queries.MultiValue;
+import com.rapleaf.jack.queries.SingleValue;
 
 public class JackMatchers {
 
@@ -13,7 +14,7 @@ public class JackMatchers {
     return new EqualTo<T>(value);
   }
 
-  public static <T> IWhereOperator<T> equalTo(GenericQuery subQuery) {
+  public static <T> IWhereOperator<T> equalTo(SingleValue subQuery) {
     if (subQuery == null) {
       return new IsNull<T>();
     }
@@ -27,7 +28,7 @@ public class JackMatchers {
     return new NotEqualTo<T>(value);
   }
 
-  public static <T> IWhereOperator<T> notEqualTo(GenericQuery subQuery) {
+  public static <T> IWhereOperator<T> notEqualTo(SingleValue subQuery) {
     if (subQuery == null) {
       return new IsNotNull<T>();
     }
@@ -50,7 +51,7 @@ public class JackMatchers {
     return new In<T>(values);
   }
 
-  public static <T> In<T> in(GenericQuery subQuery) {
+  public static <T> In<T> in(MultiValue subQuery) {
     return new In<T>(subQuery);
   }
 
@@ -65,7 +66,7 @@ public class JackMatchers {
     return new NotIn<T>(values);
   }
 
-  public static <T> NotIn<T> notIn(GenericQuery subQuery) {
+  public static <T> NotIn<T> notIn(MultiValue subQuery) {
     return new NotIn<T>(subQuery);
   }
 
@@ -73,7 +74,7 @@ public class JackMatchers {
     return new GreaterThan<T>(value);
   }
 
-  public static <T extends Comparable<T>> GreaterThan<T> greaterThan(GenericQuery subQuery) {
+  public static <T extends Comparable<T>> GreaterThan<T> greaterThan(SingleValue subQuery) {
     return new GreaterThan<T>(subQuery);
   }
 
@@ -81,7 +82,7 @@ public class JackMatchers {
     return new LessThan<T>(value);
   }
 
-  public static <T extends Comparable<T>> LessThan<T> lessThan(GenericQuery subQuery) {
+  public static <T extends Comparable<T>> LessThan<T> lessThan(SingleValue subQuery) {
     return new LessThan<T>(subQuery);
   }
 
@@ -89,7 +90,7 @@ public class JackMatchers {
     return new GreaterThanOrEqualTo<T>(value);
   }
 
-  public static <T extends Comparable<T>> GreaterThanOrEqualTo<T> greaterThanOrEqualTo(GenericQuery subQuery) {
+  public static <T extends Comparable<T>> GreaterThanOrEqualTo<T> greaterThanOrEqualTo(SingleValue subQuery) {
     return new GreaterThanOrEqualTo<T>(subQuery);
   }
 
@@ -97,7 +98,7 @@ public class JackMatchers {
     return new LessThanOrEqualTo<T>(value);
   }
 
-  public static <T extends Comparable<T>> LessThanOrEqualTo<T> lessThanOrEqualTo(GenericQuery subQuery) {
+  public static <T extends Comparable<T>> LessThanOrEqualTo<T> lessThanOrEqualTo(SingleValue subQuery) {
     return new LessThanOrEqualTo<T>(subQuery);
   }
 

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/LessThan.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/LessThan.java
@@ -18,7 +18,7 @@ public class LessThan<V> extends WhereOperator<V> {
     Preconditions.checkNotNull(column);
   }
 
-  public LessThan(SingleValue subQuery) {
+  public LessThan(SingleValue<V> subQuery) {
     super("< (" + subQuery.getQueryStatement() + ")", (Collection<V>)subQuery.getParameters());
   }
 }

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/LessThan.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/LessThan.java
@@ -5,7 +5,7 @@ import java.util.Collection;
 import com.google.common.base.Preconditions;
 
 import com.rapleaf.jack.queries.Column;
-import com.rapleaf.jack.queries.GenericQuery;
+import com.rapleaf.jack.queries.SingleValue;
 
 public class LessThan<V> extends WhereOperator<V> {
 
@@ -18,7 +18,7 @@ public class LessThan<V> extends WhereOperator<V> {
     Preconditions.checkNotNull(column);
   }
 
-  public LessThan(GenericQuery subQuery) {
+  public LessThan(SingleValue subQuery) {
     super("< (" + subQuery.getQueryStatement() + ")", (Collection<V>)subQuery.getParameters());
   }
 }

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/LessThan.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/LessThan.java
@@ -1,8 +1,11 @@
 package com.rapleaf.jack.queries.where_operators;
 
+import java.util.Collection;
+
 import com.google.common.base.Preconditions;
 
 import com.rapleaf.jack.queries.Column;
+import com.rapleaf.jack.queries.GenericQuery;
 
 public class LessThan<V> extends WhereOperator<V> {
 
@@ -13,5 +16,9 @@ public class LessThan<V> extends WhereOperator<V> {
   public LessThan(Column<V> column) {
     super("< " + column.getSqlKeyword());
     Preconditions.checkNotNull(column);
+  }
+
+  public LessThan(GenericQuery subQuery) {
+    super("< (" + subQuery.getQueryStatement() + ")", (Collection<V>)subQuery.getParameters());
   }
 }

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/LessThanOrEqualTo.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/LessThanOrEqualTo.java
@@ -1,6 +1,9 @@
 package com.rapleaf.jack.queries.where_operators;
 
+import java.util.Collection;
+
 import com.rapleaf.jack.queries.Column;
+import com.rapleaf.jack.queries.GenericQuery;
 
 public class LessThanOrEqualTo<V> extends WhereOperator<V> {
 
@@ -10,5 +13,9 @@ public class LessThanOrEqualTo<V> extends WhereOperator<V> {
 
   public LessThanOrEqualTo(Column<V> column) {
     super("<= " + column.getSqlKeyword());
+  }
+
+  public LessThanOrEqualTo(GenericQuery subQuery) {
+    super("<= (" + subQuery.getQueryStatement() + ")", (Collection<V>)subQuery.getParameters());
   }
 }

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/LessThanOrEqualTo.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/LessThanOrEqualTo.java
@@ -15,7 +15,7 @@ public class LessThanOrEqualTo<V> extends WhereOperator<V> {
     super("<= " + column.getSqlKeyword());
   }
 
-  public LessThanOrEqualTo(SingleValue subQuery) {
+  public LessThanOrEqualTo(SingleValue<V> subQuery) {
     super("<= (" + subQuery.getQueryStatement() + ")", (Collection<V>)subQuery.getParameters());
   }
 }

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/LessThanOrEqualTo.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/LessThanOrEqualTo.java
@@ -3,7 +3,7 @@ package com.rapleaf.jack.queries.where_operators;
 import java.util.Collection;
 
 import com.rapleaf.jack.queries.Column;
-import com.rapleaf.jack.queries.GenericQuery;
+import com.rapleaf.jack.queries.SingleValue;
 
 public class LessThanOrEqualTo<V> extends WhereOperator<V> {
 
@@ -15,7 +15,7 @@ public class LessThanOrEqualTo<V> extends WhereOperator<V> {
     super("<= " + column.getSqlKeyword());
   }
 
-  public LessThanOrEqualTo(GenericQuery subQuery) {
+  public LessThanOrEqualTo(SingleValue subQuery) {
     super("<= (" + subQuery.getQueryStatement() + ")", (Collection<V>)subQuery.getParameters());
   }
 }

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/NotEqualTo.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/NotEqualTo.java
@@ -1,8 +1,11 @@
 package com.rapleaf.jack.queries.where_operators;
 
+import java.util.Collection;
+
 import com.google.common.base.Preconditions;
 
 import com.rapleaf.jack.queries.Column;
+import com.rapleaf.jack.queries.GenericQuery;
 
 public class NotEqualTo<V> extends WhereOperator<V> {
 
@@ -19,5 +22,9 @@ public class NotEqualTo<V> extends WhereOperator<V> {
   public NotEqualTo(Column<V> column) {
     super("<> " + column.getSqlKeyword());
     Preconditions.checkNotNull(column);
+  }
+
+  public NotEqualTo(GenericQuery subQuery) {
+    super("<> (" + subQuery.getQueryStatement() + ")", (Collection<V>)subQuery.getParameters());
   }
 }

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/NotEqualTo.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/NotEqualTo.java
@@ -24,7 +24,7 @@ public class NotEqualTo<V> extends WhereOperator<V> {
     Preconditions.checkNotNull(column);
   }
 
-  public NotEqualTo(SingleValue subQuery) {
+  public NotEqualTo(SingleValue<V> subQuery) {
     super("<> (" + subQuery.getQueryStatement() + ")", (Collection<V>)subQuery.getParameters());
   }
 }

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/NotEqualTo.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/NotEqualTo.java
@@ -5,7 +5,7 @@ import java.util.Collection;
 import com.google.common.base.Preconditions;
 
 import com.rapleaf.jack.queries.Column;
-import com.rapleaf.jack.queries.GenericQuery;
+import com.rapleaf.jack.queries.SingleValue;
 
 public class NotEqualTo<V> extends WhereOperator<V> {
 
@@ -24,7 +24,7 @@ public class NotEqualTo<V> extends WhereOperator<V> {
     Preconditions.checkNotNull(column);
   }
 
-  public NotEqualTo(GenericQuery subQuery) {
+  public NotEqualTo(SingleValue subQuery) {
     super("<> (" + subQuery.getQueryStatement() + ")", (Collection<V>)subQuery.getParameters());
   }
 }

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/NotIn.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/NotIn.java
@@ -2,7 +2,7 @@ package com.rapleaf.jack.queries.where_operators;
 
 import java.util.Collection;
 
-import com.rapleaf.jack.queries.GenericQuery;
+import com.rapleaf.jack.queries.MultiValue;
 
 public class NotIn<V> extends WhereOperator<V> {
 
@@ -19,7 +19,7 @@ public class NotIn<V> extends WhereOperator<V> {
     this.sqlStatement = createSqlStatement();
   }
 
-  public NotIn(GenericQuery subQuery) {
+  public NotIn(MultiValue subQuery) {
     super("NOT IN (" + subQuery.getQueryStatement() + ")", (Collection<V>)subQuery.getParameters());
   }
 

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/NotIn.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/NotIn.java
@@ -19,7 +19,7 @@ public class NotIn<V> extends WhereOperator<V> {
     this.sqlStatement = createSqlStatement();
   }
 
-  public NotIn(MultiValue subQuery) {
+  public NotIn(MultiValue<V> subQuery) {
     super("NOT IN (" + subQuery.getQueryStatement() + ")", (Collection<V>)subQuery.getParameters());
   }
 

--- a/jack-core/src/com/rapleaf/jack/queries/where_operators/NotIn.java
+++ b/jack-core/src/com/rapleaf/jack/queries/where_operators/NotIn.java
@@ -2,10 +2,13 @@ package com.rapleaf.jack.queries.where_operators;
 
 import java.util.Collection;
 
+import com.rapleaf.jack.queries.GenericQuery;
+
 public class NotIn<V> extends WhereOperator<V> {
 
   public NotIn(V value1, V... otherValues) {
     super(null, value1, otherValues);
+    this.sqlStatement = createSqlStatement();
   }
 
   public NotIn(Collection<V> values) {
@@ -13,10 +16,14 @@ public class NotIn<V> extends WhereOperator<V> {
     if (getParameters().isEmpty()) {
       throw new IllegalArgumentException("SQL does not accept an empty list as a parameter of NOT IN().");
     }
+    this.sqlStatement = createSqlStatement();
   }
 
-  @Override
-  public String getSqlStatement() {
+  public NotIn(GenericQuery subQuery) {
+    super("NOT IN (" + subQuery.getQueryStatement() + ")", (Collection<V>)subQuery.getParameters());
+  }
+
+  private String createSqlStatement() {
     StringBuilder sb = new StringBuilder("NOT IN (");
 
     for (int i = 0; i < getParameters().size(); i++) {

--- a/jack-store/src/com/rapleaf/jack/store/JsTable.java
+++ b/jack-store/src/com/rapleaf/jack/store/JsTable.java
@@ -2,18 +2,18 @@ package com.rapleaf.jack.store;
 
 import com.google.common.base.Preconditions;
 
+import com.rapleaf.jack.queries.AbstractTable;
 import com.rapleaf.jack.queries.Column;
 import com.rapleaf.jack.queries.GenericTable;
-import com.rapleaf.jack.queries.Table;
 
 public class JsTable extends GenericTable<JsTable> {
-  public final Table<?, ?> table;
+  public final AbstractTable<?, ?> table;
   public final Column<Long> scope;
   public final Column<Integer> type;
   public final Column<String> key;
   public final Column<String> value;
 
-  private JsTable(Table<?, ?> table, Column<Long> scope, Column<Integer> type, Column<String> key, Column<String> value) {
+  private JsTable(AbstractTable<?, ?> table, Column<Long> scope, Column<Integer> type, Column<String> key, Column<String> value) {
     super(table, JsTable.class, scope, type, key, value);
     this.table = table;
     this.scope = scope;
@@ -27,7 +27,7 @@ public class JsTable extends GenericTable<JsTable> {
     return JsTable.from(getAliasTable(alias)).create();
   }
 
-  public static Builder from(Table<?, ?> table) {
+  public static Builder from(AbstractTable<?, ?> table) {
     return new Builder(table);
   }
 
@@ -37,7 +37,7 @@ public class JsTable extends GenericTable<JsTable> {
     private Column<String> key;
     private Column<String> value;
 
-    private Builder(Table<?, ?> table) {
+    private Builder(AbstractTable<?, ?> table) {
       super(table);
     }
 

--- a/jack-test/test/java/com/rapleaf/jack/queries/TestGenericQuery.java
+++ b/jack-test/test/java/com/rapleaf/jack/queries/TestGenericQuery.java
@@ -39,15 +39,15 @@ import static org.junit.Assert.fail;
 public class TestGenericQuery {
   protected static final IDatabase1 db = new DatabasesImpl().getDatabase1();
 
-  protected final IUserPersistence users = db.users();
-  protected final ICommentPersistence comments = db.comments();
-  protected final IPostPersistence posts = db.posts();
+  private final IUserPersistence users = db.users();
+  private final ICommentPersistence comments = db.comments();
+  private final IPostPersistence posts = db.posts();
 
-  protected User userA, userB, userC, userD, userE, userF, userG, userH;
-  protected Post postA, postB, postC;
-  protected Comment commentA, commentB, commentC, commentD;
-  protected long date, datetime;
-  protected Records results1, results2;
+  private User userA, userB, userC, userD, userE, userF, userG, userH;
+  private Post postA, postB, postC;
+  private Comment commentA, commentB, commentC, commentD;
+  private long date, datetime;
+  private Records results1, results2;
 
   @Before
   public void prepare() throws Exception {

--- a/jack-test/test/java/com/rapleaf/jack/queries/TestGenericQuery.java
+++ b/jack-test/test/java/com/rapleaf/jack/queries/TestGenericQuery.java
@@ -37,17 +37,17 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class TestGenericQuery {
-  private static final IDatabase1 db = new DatabasesImpl().getDatabase1();
+  protected static final IDatabase1 db = new DatabasesImpl().getDatabase1();
 
-  private final IUserPersistence users = db.users();
-  private final ICommentPersistence comments = db.comments();
-  private final IPostPersistence posts = db.posts();
+  protected final IUserPersistence users = db.users();
+  protected final ICommentPersistence comments = db.comments();
+  protected final IPostPersistence posts = db.posts();
 
-  private User userA, userB, userC, userD, userE, userF, userG, userH;
-  private Post postA, postB, postC;
-  private Comment commentA, commentB, commentC, commentD;
-  private long date, datetime;
-  private Records results1, results2;
+  protected User userA, userB, userC, userD, userE, userF, userG, userH;
+  protected Post postA, postB, postC;
+  protected Comment commentA, commentB, commentC, commentD;
+  protected long date, datetime;
+  protected Records results1, results2;
 
   @Before
   public void prepare() throws Exception {
@@ -937,12 +937,12 @@ public class TestGenericQuery {
     String selectStatement = db.createQuery()
         .from(User.TBL)
         .select(User.TBL.getAllColumns())
-        .getQueryStatement();
+        .getSqlStatement();
 
     String selectDistinctStatement = db.createQuery()
         .from(User.TBL)
         .select(User.TBL.getAllColumns()).distinct()
-        .getQueryStatement();
+        .getSqlStatement();
 
     assertFalse(selectStatement.contains("SELECT DISTINCT"));
     assertTrue(selectDistinctStatement.contains("SELECT DISTINCT"));

--- a/jack-test/test/java/com/rapleaf/jack/queries/TestGenericTable.java
+++ b/jack-test/test/java/com/rapleaf/jack/queries/TestGenericTable.java
@@ -34,7 +34,7 @@ public class TestGenericTable {
       handle, num_posts
     }
 
-    private UserTable(Table<?, ?> table, Column<String> handle, Column<Integer> numPosts) {
+    private UserTable(AbstractTable<?, ?> table, Column<String> handle, Column<Integer> numPosts) {
       super(table, UserTable.class, handle, numPosts);
       this.handle = handle;
       this.numPosts = numPosts;

--- a/jack-test/test/java/com/rapleaf/jack/queries/TestSubQuery.java
+++ b/jack-test/test/java/com/rapleaf/jack/queries/TestSubQuery.java
@@ -1,46 +1,261 @@
 package com.rapleaf.jack.queries;
 
+import java.io.IOException;
+
+import com.google.common.collect.Lists;
 import org.joda.time.DateTime;
+import org.junit.Before;
 import org.junit.Test;
 
+import com.rapleaf.jack.JackTestCase;
+import com.rapleaf.jack.test_project.DatabasesImpl;
+import com.rapleaf.jack.test_project.database_1.IDatabase1;
+import com.rapleaf.jack.test_project.database_1.iface.IPostPersistence;
+import com.rapleaf.jack.test_project.database_1.iface.IUserPersistence;
+import com.rapleaf.jack.test_project.database_1.models.Post;
 import com.rapleaf.jack.test_project.database_1.models.User;
 
-public class TestSubQuery extends TestGenericQuery {
+import static org.junit.Assert.assertEquals;
 
-  @Test
-  public void testSubQuery() throws Exception {
-    GenericQuery subQuery = db.createQuery().from(User.TBL)
-        .where(User.ID.greaterThan(0L))
-        .select(AggregatedColumn.MIN(User.ID));
+public class TestSubQuery extends JackTestCase {
+  private static final IDatabase1 db = new DatabasesImpl().getDatabase1();
 
-    GenericQuery query = db.createQuery().from(User.TBL)
-        .where(User.ID.greaterThan(subQuery));
+  private final IUserPersistence users = db.users();
+  private final IPostPersistence posts = db.posts();
 
-    System.out.println(query.getSqlStatement());
-    System.out.println(query.fetch());
-  }
+  private User userA, userB, userC;
+  private Post postA, postB, postC;
 
-  @Test
-  public void testDate() throws Exception {
-    userA = users.createDefaultInstance().setSomeDatetime(DateTime.parse("2017-09-10").getMillis());
-    userB = users.createDefaultInstance().setSomeDatetime(DateTime.parse("2017-09-11").getMillis());
-    userC = users.createDefaultInstance().setSomeDatetime(DateTime.parse("2017-09-12").getMillis());
+  private Records records;
+
+  @Before
+  public void prepare() throws Exception {
+    users.deleteAll();
+    posts.deleteAll();
+
+    userA = users.createDefaultInstance().setNumPosts(12).setBio("A").setSomeDatetime(DateTime.parse("2017-09-10").getMillis());
+    userB = users.createDefaultInstance().setNumPosts(11).setBio("B").setSomeDatetime(DateTime.parse("2017-09-11").getMillis());
+    userC = users.createDefaultInstance().setNumPosts(10).setBio("C").setSomeDatetime(DateTime.parse("2017-09-12").getMillis());
     userA.save();
     userB.save();
     userC.save();
 
-    GenericQuery query = db.createQuery()
-        .from(User.TBL)
-        .where(User.SOME_DATETIME.equalTo(
-            db.createQuery()
-                .from(User.TBL)
-                .select(AggregatedColumn.MAX(User.SOME_DATETIME))
-            )
-        );
+    postA = posts.createDefaultInstance().setUserId(userA.getIntId()).setTitle("title1");
+    postB = posts.createDefaultInstance().setUserId(userB.getIntId()).setTitle("title2");
+    postC = posts.createDefaultInstance().setUserId(userC.getIntId()).setTitle("title3");
+    postA.save();
+    postB.save();
+    postC.save();
+  }
 
-    System.out.println(query.getQueryStatement());
-    System.out.println(userC.getSomeDatetime());
-    System.out.println(query.fetch().get(0).get(User.SOME_DATETIME));
+  @Test
+  public void testWhereClauseSingleValueSubQuery() throws Exception {
+    /*
+     * single sub query with one result
+     */
+    SingleValue<Long> userId = db.createQuery()
+        .from(User.TBL)
+        .where(User.BIO.equalTo("B"))
+        .asSingleValue(User.ID);
+
+    records = db.createQuery()
+        .from(User.TBL)
+        .where(User.ID.equalTo(userId))
+        .fetch();
+
+    assertEquals(1, records.size());
+    assertEquals(userB, records.get(0).getModel(User.TBL, db.getDatabases()));
+
+    /*
+     * single sub query with aggregation
+     */
+    SingleValue<Integer> maxNumPosts = db.createQuery()
+        .from(User.TBL)
+        .asSingleValue(AggregatedColumn.MAX(User.NUM_POSTS));
+
+    records = db.createQuery()
+        .from(User.TBL)
+        .where(User.NUM_POSTS.equalTo(maxNumPosts))
+        .fetch();
+
+    assertEquals(1, records.size());
+    assertEquals(userA, records.get(0).getModel(User.TBL, db.getDatabases()));
+
+    /*
+     * test date column
+     */
+    SingleValue<Long> maxDatetime = db.createQuery()
+        .from(User.TBL)
+        .asSingleValue(AggregatedColumn.MAX(User.SOME_DATETIME));
+
+    records = db.createQuery()
+        .from(User.TBL)
+        .where(User.SOME_DATETIME.equalTo(maxDatetime))
+        .fetch();
+
+    assertEquals(1, records.size());
+    assertEquals(userC, records.get(0).getModel(User.TBL, db.getDatabases()));
+  }
+
+  @Test(expected = IOException.class)
+  public void testWhereClauseSingleValueSubQueryException() throws Exception {
+    /*
+     * exception will be thrown when multi value is incorrectly assigned to single value,
+     */
+    SingleValue<Long> userIds = db.createQuery()
+        .from(User.TBL)
+        .asSingleValue(User.ID);
+
+    records = db.createQuery()
+        .from(User.TBL)
+        .where(User.ID.equalTo(userIds))
+        .fetch();
+  }
+
+  @Test
+  public void testWhereClauseMultiValueSubQuery() throws Exception {
+    /*
+     * single-row sub query
+     */
+    MultiValue<Long> userId = db.createQuery()
+        .from(User.TBL)
+        .where(User.BIO.equalTo("A"))
+        .asMultiValue(User.ID);
+
+    records = db.createQuery()
+        .from(User.TBL)
+        .where(User.ID.in(userId))
+        .fetch();
+
+    assertEquals(1, records.size());
+    assertEquals(userA, records.get(0).getModel(User.TBL, db.getDatabases()));
+
+    /*
+     * multiple-row sub query
+     */
+    MultiValue<Long> userIds = db.createQuery()
+        .from(User.TBL)
+        .where(User.BIO.notEqualTo("A"))
+        .asMultiValue(User.ID);
+
+    records = db.createQuery()
+        .from(User.TBL)
+        .where(User.ID.in(userIds))
+        .orderBy(User.ID)
+        .fetch();
+
+    assertEquals(2, records.size());
+    assertEquals(userB, records.get(0).getModel(User.TBL, db.getDatabases()));
+    assertEquals(userC, records.get(1).getModel(User.TBL, db.getDatabases()));
+  }
+
+  @Test
+  public void testFromClauseSubQuery() throws Exception {
+    /*
+     * sub query with where clause
+     */
+    // sub query result: userB, userC
+    SubTable subQuery = db.createQuery()
+        .from(User.TBL)
+        .where(User.SOME_DATETIME.notEqualTo(DateTime.parse("2017-09-10").getMillis()))
+        .asSubTable("subQuery");
+
+    records = db.createQuery()
+        .from(subQuery)
+        .fetch();
+
+    assertEquals(2, records.size());
+    assertEquals(userB, records.get(0).getModel(subQuery.model(User.TBL), db.getDatabases()));
+    assertEquals(userB, records.get(0).getModel(User.TBL.alias("subQuery"), db.getDatabases()));
+    assertEquals(userC, records.get(1).getModel(subQuery.model(User.TBL), db.getDatabases()));
+    assertEquals(userC, records.get(1).getModel(User.TBL.alias("subQuery"), db.getDatabases()));
+
+    /*
+     * sub query with select clause
+     */
+    // sub query result: userB, userC
+    SubTable subQueryWithSelectClause = db.createQuery()
+        .from(User.TBL)
+        .where(User.NUM_POSTS.notEqualTo(12))
+        .select(User.ID, User.NUM_POSTS)
+        .asSubTable("selectClause");
+
+    records = db.createQuery()
+        .from(subQueryWithSelectClause)
+        .select(subQueryWithSelectClause.column(User.ID), subQueryWithSelectClause.column(User.NUM_POSTS))
+        .fetch();
+
+    assertEquals(2, records.size());
+    assertEquals(Lists.newArrayList(userB.getId(), userC.getId()), records.gets(subQueryWithSelectClause.column(User.ID)));
+    assertEquals(Lists.newArrayList(userB.getNumPosts(), userC.getNumPosts()), records.gets(subQueryWithSelectClause.column(User.NUM_POSTS)));
+
+    /*
+     * sub query with order and limit clause
+     */
+    // sub query result: userC, userB
+    SubTable subQueryWithOrderClause = db.createQuery()
+        .from(User.TBL)
+        .orderBy(User.BIO, QueryOrder.DESC)
+        .limit(2)
+        .asSubTable("orderClause");
+
+    records = db.createQuery()
+        .from(subQueryWithOrderClause)
+        .fetch();
+
+    assertEquals(2, records.size());
+    assertEquals(userC, records.get(0).getModel(subQueryWithOrderClause.model(User.TBL), db.getDatabases()));
+    assertEquals(userB, records.get(1).getModel(subQueryWithOrderClause.model(User.TBL), db.getDatabases()));
+
+    /*
+     * nested sub query
+     */
+    // t1 result: userB, userC
+    SubTable t1 = db.createQuery()
+        .from(User.TBL)
+        .where(User.BIO.notEqualTo("A"))
+        .asSubTable("t1");
+
+    // t2 result: userB
+    SubTable t2 = db.createQuery()
+        .from(t1)
+        .where(t1.column(User.NUM_POSTS).greaterThan(10))
+        .asSubTable("t2");
+
+    // final result: userB
+    records = db.createQuery()
+        .from(t2)
+        .fetch();
+
+    assertEquals(1, records.size());
+    assertEquals(userB, records.get(0).getModel(t2.model(User.TBL), db.getDatabases()));
+  }
+
+  @Test
+  public void testJoinClauseSubQuery() throws Exception {
+    // post table result: postB, postC
+    SubTable postTable = db.createQuery()
+        .from(Post.TBL)
+        .where(Post.USER_ID.notEqualTo(userA.getIntId()))
+        // order by clause does not affect the final query result
+        .orderBy(Post.ID)
+        .asSubTable("post_table");
+
+    // query result: userC / postC, userB / postB
+    records = db.createQuery()
+        .from(User.TBL)
+        .innerJoin(postTable)
+        .on(postTable.column(Post.USER_ID).as(Long.class).equalTo(User.ID))
+        .orderBy(postTable.column(Post.USER_ID), QueryOrder.DESC)
+        .fetch();
+
+    assertEquals(2, records.size());
+    assertEquals(userC, records.get(0).getModel(User.TBL, db.getDatabases()));
+    assertEquals(postC, records.get(0).getModel(Post.TBL.alias("post_table"), db.getDatabases()));
+    assertEquals(postC, records.get(0).getModel(postTable.model(Post.TBL), db.getDatabases()));
+    assertEquals(userB, records.get(1).getModel(User.TBL, db.getDatabases()));
+    assertEquals(postB, records.get(1).getModel(Post.TBL.alias("post_table"), db.getDatabases()));
+    assertEquals(postB, records.get(1).getModel(postTable.model(Post.TBL), db.getDatabases()));
   }
 
 }

--- a/jack-test/test/java/com/rapleaf/jack/queries/TestSubQuery.java
+++ b/jack-test/test/java/com/rapleaf/jack/queries/TestSubQuery.java
@@ -1,0 +1,46 @@
+package com.rapleaf.jack.queries;
+
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import com.rapleaf.jack.test_project.database_1.models.User;
+
+public class TestSubQuery extends TestGenericQuery {
+
+  @Test
+  public void testSubQuery() throws Exception {
+    GenericQuery subQuery = db.createQuery().from(User.TBL)
+        .where(User.ID.greaterThan(0L))
+        .select(AggregatedColumn.MIN(User.ID));
+
+    GenericQuery query = db.createQuery().from(User.TBL)
+        .where(User.ID.greaterThan(subQuery));
+
+    System.out.println(query.getSqlStatement());
+    System.out.println(query.fetch());
+  }
+
+  @Test
+  public void testDate() throws Exception {
+    userA = users.createDefaultInstance().setSomeDatetime(DateTime.parse("2017-09-10").getMillis());
+    userB = users.createDefaultInstance().setSomeDatetime(DateTime.parse("2017-09-11").getMillis());
+    userC = users.createDefaultInstance().setSomeDatetime(DateTime.parse("2017-09-12").getMillis());
+    userA.save();
+    userB.save();
+    userC.save();
+
+    GenericQuery query = db.createQuery()
+        .from(User.TBL)
+        .where(User.SOME_DATETIME.equalTo(
+            db.createQuery()
+                .from(User.TBL)
+                .select(AggregatedColumn.MAX(User.SOME_DATETIME))
+            )
+        );
+
+    System.out.println(query.getQueryStatement());
+    System.out.println(userC.getSomeDatetime());
+    System.out.println(query.fetch().get(0).get(User.SOME_DATETIME));
+  }
+
+}


### PR DESCRIPTION
Summary
====

As promised to @bpodgursky and many others, Jack will support sub query by the end of this quarter. This pull request adds three new methods in `GenericQuery` such that it can be used as sub query in another `GenericQuery`:
- `GenericQuery#asSingleValue` - works for single value operators (e.g. `equalTo`, `greaterThan`) in `WHERE` clause:
  ```java
  SingleValue<Long> userId = db.createQuery()
      .from(User.TBL)
      .where(User.BIO.equalTo("B"))
      .asSingleValue(User.ID);

  records = db.createQuery()
      .from(User.TBL)
      .where(User.ID.equalTo(userId))
      .fetch();
  ```

- `GenericQuery#asMultiValue` - works for multi value operators (`IN` and `NOT IN`) in `WHERE` clause:
  ```java
  MultiValue<Long> userIds = db.createQuery()
      .from(User.TBL)
      .where(User.BIO.notEqualTo("A"))
      .asMultiValue(User.ID);

  Records records = db.createQuery()
      .from(User.TBL)
      .where(User.ID.in(userIds))
      .orderBy(User.ID)
      .fetch();
  ```

- `GenericQuery#asSubTable` - works in `FROM` clause
  ```java
  SubTable subTable = db.createQuery()
    .from(User.TBL)
    .where(User.SOME_DATETIME.notEqualTo(DateTime.parse("2017-09-10").getMillis()))
    .asSubTable("subTable");

  Records records = db.createQuery()
    .from(subTable)
    .fetch();

  // get back model in sub query
  User user = record.getModel(User.TBL.alias("subTable"), db.getDatabases()))
  // or
  User user = record.getModel(subTable.model(User.TBL), db.getDatabases()))
  ```

**See [`TestSubQuery.java`](https://github.com/LiveRamp/jack/pull/206/files#diff-0f3216fc6df1225e70a5c6dd4b61a2e2) for more examples.**

Implementation
====
The new methods convert `GenericQuery` into `SingleValue`, `MultiValue` and `SubTable` respectively. The former two extends `ValueExpression` interface, which represents a SQL query that will evaluates to some typed value. `SubTable` extends `Table` interface. It basically wrapps up a `GenericQuery` object.

Notes
====
- It is possible to eliminate `SingleValue` and `MultiValue` in the implementation. However, I think adding these two classes will make user to be more aware of the type of the sub queries they write.
- If multiple rows are returned in the `SingleValue` sub query, a runtime exception will be thrown from SQL complaining that the result should only contain one row. There is no way to add compile time check for this kind of error.
- There are totally three types of sub queries in SQL: in `select`, `from`, and `where` clause. The `select` sub query is not supported in this pull request yet. I feel that kind of sub query is not as useful as the latter two. But I can work on that if anyone feels that that is necessary.
- There are lots of corner cases in SQL sub query. I am pretty sure many of them are not covered by the current unit tests. Please help me find more of them. **Any review is welcome.**
