### PR TITLE
Allow clients to request the transactor to retry queries

### DIFF
--- a/jack-core/src/com/rapleaf/jack/transaction/DbPoolManager.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/DbPoolManager.java
@@ -175,7 +175,5 @@ class DbPoolManager<DB extends IDb> implements IDbManager<DB> {
       connection.getObject().setAutoCommit(true);
       connection.getObject().setBulkOperation(false);
     }
-
   }
-
 }

--- a/jack-core/src/com/rapleaf/jack/transaction/ExecutionContext.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/ExecutionContext.java
@@ -6,16 +6,16 @@ public class ExecutionContext {
   public static final int DEFAULT_RETRY_TIMES = 1;
   public static final boolean DEFAULT_AS_TRANSACTION = false;
 
-  private final int retryTimes;
+  private final int maxRetries;
   private final boolean asTransaction;
 
-  ExecutionContext(int retryTimes, boolean asTransaction) {
-    this.retryTimes = retryTimes;
+  ExecutionContext(int maxRetries, boolean asTransaction) {
+    this.maxRetries = maxRetries;
     this.asTransaction = asTransaction;
   }
 
-  public int getRetryTimes() {
-    return retryTimes;
+  public int getMaxRetries() {
+    return maxRetries;
   }
 
   public boolean isAsTransaction() {

--- a/jack-core/src/com/rapleaf/jack/transaction/ExecutionContext.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/ExecutionContext.java
@@ -3,7 +3,7 @@ package com.rapleaf.jack.transaction;
 import com.google.common.base.Preconditions;
 
 public class ExecutionContext {
-  public static final int DEFAULT_RETRY_TIMES = 1;
+  public static final int DEFAULT_RETRY_TIMES = 0;
   public static final boolean DEFAULT_AS_TRANSACTION = false;
 
   private final int maxRetries;

--- a/jack-core/src/com/rapleaf/jack/transaction/ExecutionContext.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/ExecutionContext.java
@@ -1,0 +1,51 @@
+package com.rapleaf.jack.transaction;
+
+import com.google.common.base.Preconditions;
+
+public class ExecutionContext {
+  public static final int DEFAULT_RETRY_TIMES = 1;
+  public static final boolean DEFAULT_AS_TRANSACTION = false;
+
+  private final int retryTimes;
+  private final boolean asTransaction;
+
+  ExecutionContext(int retryTimes, boolean asTransaction) {
+    this.retryTimes = retryTimes;
+    this.asTransaction = asTransaction;
+  }
+
+  public int getRetryTimes() {
+    return retryTimes;
+  }
+
+  public boolean isAsTransaction() {
+    return asTransaction;
+  }
+
+  public static class Builder {
+    private int retryTimes;
+    private boolean asTransaction;
+
+    public Builder() {
+      reset();
+    }
+
+    public void reset() {
+      retryTimes = DEFAULT_RETRY_TIMES;
+      asTransaction = DEFAULT_AS_TRANSACTION;
+    }
+
+    public void setRetryTimes(int retryTimes) {
+      Preconditions.checkArgument(retryTimes > 0, "Retry times must be greater than 0.");
+      this.retryTimes = retryTimes;
+    }
+
+    public void setAsTransaction(boolean asTransaction) {
+      this.asTransaction = asTransaction;
+    }
+
+    public ExecutionContext build() {
+      return new ExecutionContext(retryTimes, asTransaction);
+    }
+  }
+}

--- a/jack-core/src/com/rapleaf/jack/transaction/ITransactor.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/ITransactor.java
@@ -6,12 +6,18 @@ import com.rapleaf.jack.IDb;
 
 public interface ITransactor<DB extends IDb> extends Closeable {
 
+  ITransactor<DB> asTransaction(boolean asTransaction);
+
+  ITransactor<DB> withNumRetries(int numRetries);
+
   <T> T query(IQuery<DB, T> query);
 
+  @Deprecated
   <T> T queryAsTransaction(IQuery<DB, T> query);
 
   void execute(IExecution<DB> execution);
 
+  @Deprecated
   void executeAsTransaction(IExecution<DB> execution);
 
   @Override

--- a/jack-core/src/com/rapleaf/jack/transaction/ITransactor.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/ITransactor.java
@@ -25,11 +25,17 @@ public interface ITransactor<DB extends IDb> extends Closeable {
 
   <T> T query(IQuery<DB, T> query);
 
+  /**
+   * @deprecated use {@link #asTransaction()}
+   */
   @Deprecated
   <T> T queryAsTransaction(IQuery<DB, T> query);
 
   void execute(IExecution<DB> execution);
 
+  /**
+   * @deprecated Use {@link #asTransaction}
+   */
   @Deprecated
   void executeAsTransaction(IExecution<DB> execution);
 

--- a/jack-core/src/com/rapleaf/jack/transaction/ITransactor.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/ITransactor.java
@@ -14,7 +14,9 @@ public interface ITransactor<DB extends IDb> extends Closeable {
   ITransactor<DB> asTransaction();
 
   /**
-   * If the operation fails, retries it up to numRetries before failing and returning the operation to the client.
+   * If the next operation fails, retries it up to numRetries before failing and returning the operation to the client.
+   * Note that this does not take into account the initial attempt i.e: setting this number to 1 would result in a
+   * maximum of 2 total executions.
    *
    * @param numRetries
    * @return

--- a/jack-core/src/com/rapleaf/jack/transaction/ITransactor.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/ITransactor.java
@@ -6,7 +6,7 @@ import com.rapleaf.jack.IDb;
 
 public interface ITransactor<DB extends IDb> extends Closeable {
 
-  ITransactor<DB> asTransaction(boolean asTransaction);
+  ITransactor<DB> asTransaction();
 
   ITransactor<DB> withNumRetries(int numRetries);
 

--- a/jack-core/src/com/rapleaf/jack/transaction/ITransactor.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/ITransactor.java
@@ -6,9 +6,20 @@ import com.rapleaf.jack.IDb;
 
 public interface ITransactor<DB extends IDb> extends Closeable {
 
+  /**
+   * Run the next operation as a transaction.
+   *
+   * @return
+   */
   ITransactor<DB> asTransaction();
 
-  ITransactor<DB> withNumRetries(int numRetries);
+  /**
+   * If the operation fails, retries it up to numRetries before failing and returning the operation to the client.
+   *
+   * @param numRetries
+   * @return
+   */
+  ITransactor<DB> withMaxRetry(int numRetries);
 
   <T> T query(IQuery<DB, T> query);
 

--- a/jack-core/src/com/rapleaf/jack/transaction/TransactorImpl.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/TransactorImpl.java
@@ -43,8 +43,8 @@ public class TransactorImpl<DB extends IDb> implements ITransactor<DB> {
 
 
   @Override
-  public ITransactor<DB> asTransaction(boolean asTransaction) {
-    contextBuilder.setAsTransaction(asTransaction);
+  public ITransactor<DB> asTransaction() {
+    contextBuilder.setAsTransaction(true);
     return this;
   }
 
@@ -57,14 +57,14 @@ public class TransactorImpl<DB extends IDb> implements ITransactor<DB> {
   @Override
   @Deprecated
   public <T> T queryAsTransaction(IQuery<DB, T> query) {
-    asTransaction(true);
+    asTransaction();
     return query(query);
   }
 
   @Override
   @Deprecated
   public void executeAsTransaction(IExecution<DB> execution) {
-    asTransaction(true);
+    asTransaction();
     execute(execution);
   }
 

--- a/jack-core/src/com/rapleaf/jack/transaction/TransactorImpl.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/TransactorImpl.java
@@ -2,6 +2,7 @@ package com.rapleaf.jack.transaction;
 
 import java.util.concurrent.Callable;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.joda.time.Duration;
 import org.slf4j.Logger;
@@ -162,6 +163,11 @@ public class TransactorImpl<DB extends IDb> implements ITransactor<DB> {
 
   DbMetrics getDbMetrics() {
     return dbManager.getMetrics();
+  }
+
+  @VisibleForTesting
+  ExecutionContext getExecutionContext() {
+    return contextBuilder.build();
   }
 
   public static class Builder<DB extends IDb> implements ITransactor.Builder<DB, TransactorImpl<DB>> {

--- a/jack-core/src/com/rapleaf/jack/transaction/TransactorImpl.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/TransactorImpl.java
@@ -49,7 +49,7 @@ public class TransactorImpl<DB extends IDb> implements ITransactor<DB> {
   }
 
   @Override
-  public ITransactor<DB> withNumRetries(int numRetries) {
+  public ITransactor<DB> withMaxRetry(int numRetries) {
     contextBuilder.setRetryTimes(numRetries);
     return this;
   }

--- a/jack-core/src/com/rapleaf/jack/util/ExponentialBackoff.java
+++ b/jack-core/src/com/rapleaf/jack/util/ExponentialBackoff.java
@@ -1,7 +1,7 @@
 package com.rapleaf.jack.util;
 
 public class ExponentialBackoff {
-  private static final long INITIAL_BACKOFF_INTERVAL = 1000l;
+  private static final long INITIAL_BACKOFF_INTERVAL = 500l;
 
   private final int maxRetries;
 

--- a/jack-core/src/com/rapleaf/jack/util/ExponentialBackoff.java
+++ b/jack-core/src/com/rapleaf/jack/util/ExponentialBackoff.java
@@ -1,0 +1,33 @@
+package com.rapleaf.jack.util;
+
+public class ExponentialBackoff {
+  private static final long INITIAL_BACKOFF_INTERVAL = 1000l;
+
+  private final int maxRetries;
+
+  private int numRetries;
+  private long backoffMs;
+
+  public ExponentialBackoff(int maxRetries) {
+    this.maxRetries = maxRetries;
+    this.numRetries = 0;
+    this.backoffMs = INITIAL_BACKOFF_INTERVAL;
+  }
+
+  public void backoff() {
+    try {
+      Thread.sleep(backoffMs);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+    if (numRetries < maxRetries) {
+      numRetries++;
+      backoffMs <<= 1;
+    }
+  }
+
+  public boolean isMaxedOut() {
+    return numRetries >= maxRetries;
+  }
+}
+

--- a/jack-core/src/com/rapleaf/jack/util/ExponentialBackoff.java
+++ b/jack-core/src/com/rapleaf/jack/util/ExponentialBackoff.java
@@ -9,9 +9,13 @@ public class ExponentialBackoff {
   private long backoffMs;
 
   public ExponentialBackoff(int maxRetries) {
+    this(maxRetries, INITIAL_BACKOFF_INTERVAL);
+  }
+
+  public ExponentialBackoff(int maxRetries, long backoffMs) {
     this.maxRetries = maxRetries;
     this.numRetries = 0;
-    this.backoffMs = INITIAL_BACKOFF_INTERVAL;
+    this.backoffMs = backoffMs;
   }
 
   public void backoff() {

--- a/jack-test/test/java/com/rapleaf/jack/util/TestExponentialBackoff.java
+++ b/jack-test/test/java/com/rapleaf/jack/util/TestExponentialBackoff.java
@@ -1,4 +1,56 @@
 package com.rapleaf.jack.util;
 
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 public class TestExponentialBackoff {
+
+  @Test
+  public void testZeroRetriesIsAlwaysMaxedOut() {
+    ExponentialBackoff eb = new ExponentialBackoff(0);
+    assertTrue(eb.isMaxedOut());
+  }
+
+  @Test
+  public void testManyRetries() {
+    int expectedRetries = 3;
+    int actualRetries = 0;
+
+    ExponentialBackoff eb = new ExponentialBackoff(expectedRetries);
+    while (!eb.isMaxedOut()) {
+      eb.backoff();
+      actualRetries++;
+    }
+
+    assertEquals(expectedRetries, actualRetries);
+  }
+
+  @Test
+  public void testBackoffIsExponential() {
+    int retries = 3;
+    long initialBackoffTimeMs = 100l;
+    long expectedWaitTime = computeExpectedWaitTime(retries, initialBackoffTimeMs);
+
+    long startTime = System.currentTimeMillis();
+    ExponentialBackoff eb = new ExponentialBackoff(retries, initialBackoffTimeMs);
+    while (!eb.isMaxedOut()) {
+      eb.backoff();
+    }
+
+    long actualWaitTime = System.currentTimeMillis() - startTime;
+
+    assertTrue(actualWaitTime >= expectedWaitTime);
+  }
+
+  private long computeExpectedWaitTime(int retries, long backoffTimeMs) {
+    long expectedWaitTime = 0;
+
+    for (int i = 0; i < retries; i++) {
+      expectedWaitTime += backoffTimeMs << i;
+    }
+
+    return expectedWaitTime;
+  }
 }

--- a/jack-test/test/java/com/rapleaf/jack/util/TestExponentialBackoff.java
+++ b/jack-test/test/java/com/rapleaf/jack/util/TestExponentialBackoff.java
@@ -1,0 +1,4 @@
+package com.rapleaf.jack.util;
+
+public class TestExponentialBackoff {
+}


### PR DESCRIPTION
@tuliren 

This change introduces the `ExecutionContext` concept. It allows a client of an `ITransactor` to configure settings to be applied on the next execution or query. Today, the only such option is whether to execute the query as a transaction, specified by `queryAsTransaction()` and `executeAsTransaction()`. However, as the number of options increases (the current PR ultimately aims to add a retry mechanism), it becomes less feasible to add methods that both set the flag and execute the query. `ExecutionContext` will be used to allow queries that look like this:

```java
transactor.asTransaction()
  .withNumRetries(3)
  .query(myQuery); // can also be .execute()
```
or
```java
transactor.withNumRetries(3).query(myQuery);
```
or even 
```java
transactor.query(myQuery);
``` 

if they would rather use the default options. In the future, if we want to add more options, we can just add a `.withNewOption()` method to the interface. 

This would require us to deprecate `queryAsTransaction` and `executeAsTransaction` since they can be replaced with the new API. What do you think of this interface? 

TODO: Add retry mechanism. Just sharing the PR to get feedback on the interface. 