### PR TITLE
remove white spaces in model_dir_processor matching keywords

### DIFF
--- a/jack-core/src/rb/models_dir_processor.rb
+++ b/jack-core/src/rb/models_dir_processor.rb
@@ -31,9 +31,9 @@ class ModelsDirProcessor
     table_name = class_name.split('::').last.underscore.pluralize
 
     if md = model_defns_by_table_name[table_name]
-      md.associations = parse_associations(model_content_lines, "belongs_to ", md) +
-        parse_associations(model_content_lines, "has_many ", md, ":through") +
-        parse_associations(model_content_lines, "has_one ", md)
+      md.associations = parse_associations(model_content_lines, "belongs_to", md) +
+        parse_associations(model_content_lines, "has_many", md, ":through") +
+        parse_associations(model_content_lines, "has_one", md)
     else
       puts "Warning: Couldn't find any table '#{table_name}' that corresponded to model '#{class_name}'. No code will be generated for this model."
     end


### PR DESCRIPTION
This fix is to handle situations where associations are followed directly by a tab character. For example, when given the following lines in a `model.rb` file:

```
has_many\t\t  :some_name, :dependent => :destroy 
has_many \t\t  :some_other_name, :dependent => :destroy
```

the current regex impl will accept the second line, but not the first. This PR allows it to accept both
