### PR TITLE
Evaluate schema.rb instead of parsing it like a string

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "http://rubygems.org"
 gem "activesupport", "~> 4.1"
 gem "i18n", "~> 0.9"
+gem 'fattr'
 
 group :test do
   gem "rspec", "~> 3.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
       tzinfo (~> 1.1)
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
+    fattr (2.4.0)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
     json (1.8.6)
@@ -35,6 +36,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 4.1)
+  fattr
   i18n (~> 0.9)
   rspec (~> 3.7)
 

--- a/jack-core/src/Gemfile
+++ b/jack-core/src/Gemfile
@@ -1,3 +1,4 @@
 source "http://rubygems.org"
 gem "activesupport", "~> 4.1"
 gem "i18n", "~> 0.9"
+gem 'fattr'

--- a/jack-core/src/Gemfile.lock
+++ b/jack-core/src/Gemfile.lock
@@ -8,6 +8,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     concurrent-ruby (1.0.5)
+    fattr (2.4.0)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
     json (1.8.6)
@@ -21,7 +22,8 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 4.1)
+  fattr
   i18n (~> 0.9)
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/jack-core/src/rb/field_defn.rb
+++ b/jack-core/src/rb/field_defn.rb
@@ -213,19 +213,6 @@ class FieldDefn
         "Column.fromField(alias, _Fields.#{name}, #{java_type(true)}.class);"
     end
   end
-  
-  def self.parse_option_fields(s)
-    options = eval(sprintf('{%s}', s))
-    options.each do |k, v|
-      # Jack relies on values being valid drop-ins in generated Java code.
-      # Strings must be wrapped in quotes.
-      if v.is_a?(String) or v.is_a?(Symbol)
-        options[k] = sprintf('"%s"', v)
-      end
-    end
-      
-    options
-  end
 
   def serial_version_uid_component
     s = sprintf("%s%s%s", name, data_type, ordinal)

--- a/jack-core/src/rb/model_defn.rb
+++ b/jack-core/src/rb/model_defn.rb
@@ -14,27 +14,15 @@
 
 class ModelDefn
   attr_accessor :namespace, :database_defn
-  attr_reader :fields, :table_name, :model_name, :migration_number
+  attr_accessor :fields, :table_name, :model_name, :migration_number
   attr_accessor :associations
 
   include HashRegexHelpers
 
-  def initialize(decl_line, migration_number)
+  def initialize(migration_number)
     @fields = []
     @associations = []
     @migration_number = migration_number
-
-    @table_name = decl_line.match(/^\s*create_table "([^")]*)".*$/)[1]
-    @model_name = @table_name.singularize.camelcase
-
-    if extract_hash_value(decl_line, :id, false)
-      raise "Table #{@table_name} appears not to have a primary key, which is currently unsupported."
-    end
-
-    # check if the primary key has been renamed
-    if extract_hash_value(decl_line, :primary_key, /"(?<value>|')/)
-      raise "Table #{@table_name} appears to have a renamed primary key, which is currently unsupported."
-    end
   end
 
   def create_signature(only_not_null = false, excluded_field_name = nil)

--- a/jack-core/src/rb/schema_rb_parser.rb
+++ b/jack-core/src/rb/schema_rb_parser.rb
@@ -54,7 +54,7 @@ module ActiveRecord
 
   class Index
     include FromHash
-    attr_accessor :name, :fields, :unique, :length, :table
+    attr_accessor :name, :fields, :unique, :length, :table, :using
   end
 
   class Table


### PR DESCRIPTION
Only todo is honor FORBIDDEN_FIELD_NAMES, although no such columns appear in our schema.rb. I diffed the output from this against the old output and it was identical. 