### PR TITLE
use java.time.Duration in setMaxWaitTime and setKeepAliveTime and dep…

### DIFF
--- a/jack-core/src/com/rapleaf/jack/transaction/TransactorImpl.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/TransactorImpl.java
@@ -1,9 +1,9 @@
 package com.rapleaf.jack.transaction;
 
+import java.time.Duration;
 import java.util.concurrent.Callable;
 
 import com.google.common.base.Preconditions;
-import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -188,9 +188,21 @@ public class TransactorImpl<DB extends IDb> implements ITransactor<DB> {
      * @param maxWaitTime The maximum amount of time that the {@link DbPoolManager#getConnection} method
      *                    should block before throwing an exception when the pool is exhausted. Negative values
      *                    mean that the block can be infinite.
+     * Deprecated, use the version with java.time.Duration instead.
+     */
+    @Deprecated
+    public Builder<DB> setMaxWaitTime(org.joda.time.Duration maxWaitTime) {
+      this.maxWaitMillis = maxWaitTime.getMillis();
+      return this;
+    }
+
+    /**
+     * @param maxWaitTime The maximum amount of time that the {@link DbPoolManager#getConnection} method
+     *                    should block before throwing an exception when the pool is exhausted. Negative values
+     *                    mean that the block can be infinite.
      */
     public Builder<DB> setMaxWaitTime(Duration maxWaitTime) {
-      this.maxWaitMillis = maxWaitTime.getMillis();
+      this.maxWaitMillis = maxWaitTime.toMillis();
       return this;
     }
 
@@ -206,9 +218,21 @@ public class TransactorImpl<DB extends IDb> implements ITransactor<DB> {
      * @param keepAliveTime The minimum amount of time the connection may sit idle in the pool before it is
      *                      eligible for eviction (with the extra condition that at least {@code minIdleConnections}
      *                      connections remain in the pool).
+     * Deprecated, use the version with java.time.Duration instead.
+     */
+    @Deprecated
+    public Builder<DB> setKeepAliveTime(org.joda.time.Duration keepAliveTime) {
+      this.keepAliveMillis = keepAliveTime.getMillis();
+      return this;
+    }
+
+    /***
+     * @param keepAliveTime The minimum amount of time the connection may sit idle in the pool before it is
+     *                      eligible for eviction (with the extra condition that at least {@code minIdleConnections}
+     *                      connections remain in the pool).
      */
     public Builder<DB> setKeepAliveTime(Duration keepAliveTime) {
-      this.keepAliveMillis = keepAliveTime.getMillis();
+      this.keepAliveMillis = keepAliveTime.toMillis();
       return this;
     }
 

--- a/jack-test/test/java/com/rapleaf/jack/transaction/TestDbMetrics.java
+++ b/jack-test/test/java/com/rapleaf/jack/transaction/TestDbMetrics.java
@@ -1,12 +1,12 @@
 package com.rapleaf.jack.transaction;
 
 
+import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import com.google.common.base.Stopwatch;
-import org.joda.time.Duration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -152,7 +152,7 @@ public class TestDbMetrics extends JackTestCase {
 
   @Test
   public void testAverageIdleConnections() throws Exception {
-    TransactorImpl<IDatabase1> transactor = transactorBuilder.setMetricsTracking(true).setMaxTotalConnections(2).setMinIdleConnections(1).setKeepAliveTime(Duration.millis(50)).get();
+    TransactorImpl<IDatabase1> transactor = transactorBuilder.setMetricsTracking(true).setMaxTotalConnections(2).setMinIdleConnections(1).setKeepAliveTime(Duration.ofMillis(50)).get();
     transactor.execute(a -> {sleepMillis(100);});
     long startIdleTime = stopwatch.elapsedMillis();
     sleepMillis(100);

--- a/jack-test/test/java/com/rapleaf/jack/transaction/TestDbPoolManager.java
+++ b/jack-test/test/java/com/rapleaf/jack/transaction/TestDbPoolManager.java
@@ -7,7 +7,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import com.google.common.collect.Lists;
-import org.joda.time.Duration;
+import java.time.Duration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -89,7 +89,7 @@ public class TestDbPoolManager extends JackTestCase {
   public void testKeepAliveTime() throws Exception {
     maxConnections = 15;
     minIdleConnections = 5;
-    keepAliveTime = Duration.standardSeconds(1).getMillis();
+    keepAliveTime = Duration.ofSeconds(1).toMillis();
     initializeDbPoolManager();
     getAndReturnAllConnections();
 
@@ -102,7 +102,7 @@ public class TestDbPoolManager extends JackTestCase {
   @Test(timeout = 10 * 1000L) // 10s
   public void testMaxWaitTime() throws Exception {
     maxConnections = 1;
-    maxWaitTime = Duration.standardSeconds(8).getMillis();
+    maxWaitTime = Duration.ofSeconds(8).toMillis();
     initializeDbPoolManager();
 
     executorService = Executors.newFixedThreadPool(2);
@@ -133,7 +133,7 @@ public class TestDbPoolManager extends JackTestCase {
       dbPoolManager.getConnection();
 
       // check wait time
-      int waitSeconds = getSecondsSince(startTime);
+      long waitSeconds = getSecondsSince(startTime);
       LOG.info("Second task DB waited for connection: {} seconds", waitSeconds);
       assertRoughEqual(waitSeconds, expectedWaitSeconds, 2);
 
@@ -149,7 +149,7 @@ public class TestDbPoolManager extends JackTestCase {
   @Test(timeout = 10 * 1000L) // 10s
   public void testNoAvailableConnectionAfterWait() throws Exception {
     maxConnections = 1;
-    maxWaitTime = Duration.standardSeconds(1).getMillis();
+    maxWaitTime = Duration.ofSeconds(1).toMillis();
     initializeDbPoolManager();
 
     executorService = Executors.newFixedThreadPool(2);
@@ -180,7 +180,7 @@ public class TestDbPoolManager extends JackTestCase {
         fail();
       } catch (NoAvailableConnectionException e) {
         // check exception is thrown after wait time
-        int waitSeconds = getSecondsSince(startTime);
+        long waitSeconds = getSecondsSince(startTime);
         LOG.info("Second task DB waited for connection: {} seconds", waitSeconds);
         assertRoughEqual(waitSeconds, maxWaitTime / 1000, 1);
       }
@@ -213,8 +213,8 @@ public class TestDbPoolManager extends JackTestCase {
     }
   }
 
-  private int getSecondsSince(long startTime) {
-    return Duration.millis(System.currentTimeMillis() - startTime).toStandardSeconds().getSeconds();
+  private long getSecondsSince(long startTime) {
+    return Duration.ofMillis(System.currentTimeMillis() - startTime).getSeconds();
   }
 
   private void assertIdleConnections(int idleConnections) {
@@ -238,7 +238,7 @@ public class TestDbPoolManager extends JackTestCase {
     while (true) {
       LOG.info("Active connections: {}", dbPoolManager.getConnectionPool().getNumIdle());
       if (dbPoolManager.getConnectionPool().getNumIdle() == minIdleConnections) {
-        int waitSeconds = getSecondsSince(startTime);
+        long waitSeconds = getSecondsSince(startTime);
         LOG.info("Idle connections are evicted after {} seconds", waitSeconds);
         // allow two seconds delay
         assertInRange(waitSeconds, expectedSeconds, expectedSeconds + error);
@@ -263,7 +263,7 @@ public class TestDbPoolManager extends JackTestCase {
       dbPoolManager.returnConnection(connections);
 
       // check connection use time
-      int returnTime = getSecondsSince(startTime);
+      long returnTime = getSecondsSince(startTime);
       LOG.info("First task returned DB connection in {} seconds", returnTime);
       assertTrue(returnTime >= threadProcessTime);
 

--- a/jack-test/test/java/com/rapleaf/jack/transaction/TestDbTransactorImpl.java
+++ b/jack-test/test/java/com/rapleaf/jack/transaction/TestDbTransactorImpl.java
@@ -5,7 +5,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import org.joda.time.Duration;
+import java.time.Duration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -191,7 +191,7 @@ public class TestDbTransactorImpl extends JackTestCase {
 
   @Test
   public void testWaitForConnectionTimeout() throws Exception {
-    TransactorImpl<IDatabase1> transactor = transactorBuilder.setMaxTotalConnections(1).setMaxWaitTime(Duration.millis(500)).get();
+    TransactorImpl<IDatabase1> transactor = transactorBuilder.setMaxTotalConnections(1).setMaxWaitTime(Duration.ofMillis(500)).get();
 
     executorService = Executors.newFixedThreadPool(2);
 


### PR DESCRIPTION
…recate old methods + update tests

@tuliren any reason why we use joda time instead of the native java.time?
If not, what do you think about that?