### PR TITLE
[WIP] Remove Joda Time

### DIFF
--- a/jack-core/pom.xml
+++ b/jack-core/pom.xml
@@ -63,12 +63,6 @@
     </dependency>
 
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.7</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-pool2</artifactId>
       <version>2.4.2</version>

--- a/jack-core/src/com/rapleaf/jack/transaction/DbPoolManager.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/DbPoolManager.java
@@ -1,6 +1,7 @@
 package com.rapleaf.jack.transaction;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.NoSuchElementException;
 import java.util.concurrent.Callable;
 
@@ -11,7 +12,6 @@ import org.apache.commons.pool2.PooledObjectFactory;
 import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
-import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,8 +24,8 @@ class DbPoolManager<DB extends IDb> implements IDbManager<DB> {
 
   public static final int DEFAULT_MAX_TOTAL_CONNECTIONS = 3;
   public static final int DEFAULT_MIN_IDLE_CONNECTIONS = 1;
-  public static final long DEFAULT_MAX_WAIT_TIME = Duration.standardSeconds(30).getMillis();
-  public static final long DEFAULT_KEEP_ALIVE_TIME = Duration.standardMinutes(5).getMillis();
+  public static final long DEFAULT_MAX_WAIT_TIME = Duration.ofSeconds(30).toMillis();
+  public static final long DEFAULT_KEEP_ALIVE_TIME = Duration.ofMinutes(5).toMillis();
   public static final boolean DEFAULT_METRICS_TRACKING_ENABLED = false;
 
   private final DbMetricsImpl metrics;

--- a/jack-core/src/com/rapleaf/jack/transaction/TransactorImpl.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/TransactorImpl.java
@@ -188,18 +188,6 @@ public class TransactorImpl<DB extends IDb> implements ITransactor<DB> {
      * @param maxWaitTime The maximum amount of time that the {@link DbPoolManager#getConnection} method
      *                    should block before throwing an exception when the pool is exhausted. Negative values
      *                    mean that the block can be infinite.
-     * Deprecated, use the version with java.time.Duration instead.
-     */
-    @Deprecated
-    public Builder<DB> setMaxWaitTime(org.joda.time.Duration maxWaitTime) {
-      this.maxWaitMillis = maxWaitTime.getMillis();
-      return this;
-    }
-
-    /**
-     * @param maxWaitTime The maximum amount of time that the {@link DbPoolManager#getConnection} method
-     *                    should block before throwing an exception when the pool is exhausted. Negative values
-     *                    mean that the block can be infinite.
      */
     public Builder<DB> setMaxWaitTime(Duration maxWaitTime) {
       this.maxWaitMillis = maxWaitTime.toMillis();
@@ -211,18 +199,6 @@ public class TransactorImpl<DB extends IDb> implements ITransactor<DB> {
      */
     public Builder<DB> enableInfiniteWait() {
       this.maxWaitMillis = -1L;
-      return this;
-    }
-
-    /***
-     * @param keepAliveTime The minimum amount of time the connection may sit idle in the pool before it is
-     *                      eligible for eviction (with the extra condition that at least {@code minIdleConnections}
-     *                      connections remain in the pool).
-     * Deprecated, use the version with java.time.Duration instead.
-     */
-    @Deprecated
-    public Builder<DB> setKeepAliveTime(org.joda.time.Duration keepAliveTime) {
-      this.keepAliveMillis = keepAliveTime.getMillis();
       return this;
     }
 

--- a/jack-core/src/com/rapleaf/jack/util/JackUtility.java
+++ b/jack-core/src/com/rapleaf/jack/util/JackUtility.java
@@ -4,8 +4,6 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
@@ -17,14 +15,8 @@ public final class JackUtility {
 
   private static final ZoneId SYSTEM_ZONE = ZoneId.systemDefault();
 
-  public static final Function<LocalDateTime, Long> DATETIME_TO_MILLIS = dateTime -> dateTime.atZone(SYSTEM_ZONE).toInstant().toEpochMilli();
-  public static final Function<LocalDate, Long> DATE_TO_MILLIS = date -> date.atStartOfDay(SYSTEM_ZONE).toInstant().toEpochMilli();
-
   public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
   public static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
-  public static final Function<String, Long> DATE_STRING_TO_MILLIS = date -> DATE_TO_MILLIS.apply(LocalDate.parse(date, DATE_FORMATTER));
-  public static final Function<String, Long> DATETIME_STRING_TO_MILLIS = dateTime -> DATETIME_TO_MILLIS.apply(LocalDateTime.parse(dateTime, TIMESTAMP_FORMATTER));
 
   public static final Map<Class<?>, Function<Long, String>> FORMATTER_FUNCTION_MAP = ImmutableMap.of(
       java.sql.Date.class, new DateFormatter(DATE_FORMATTER),
@@ -50,7 +42,7 @@ public final class JackUtility {
 
     @Override
     public String apply(final Long date) {
-      return Instant.ofEpochMilli(date).atZone(JackUtility.SYSTEM_ZONE).format(formatter);
+      return Instant.ofEpochMilli(date).atZone(SYSTEM_ZONE).format(formatter);
     }
   }
 

--- a/jack-core/src/com/rapleaf/jack/util/JackUtility.java
+++ b/jack-core/src/com/rapleaf/jack/util/JackUtility.java
@@ -3,18 +3,28 @@ package com.rapleaf.jack.util;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.function.Function;
 
 import com.google.common.collect.ImmutableMap;
-import org.joda.time.DateTime;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 
 public final class JackUtility {
 
-  public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormat.forPattern("yyyy-MM-dd");
-  public static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss");
+  private static final ZoneId SYSTEM_ZONE = ZoneId.systemDefault();
+
+  public static final Function<LocalDateTime, Long> DATETIME_TO_MILLIS = dateTime -> dateTime.atZone(SYSTEM_ZONE).toInstant().toEpochMilli();
+  public static final Function<LocalDate, Long> DATE_TO_MILLIS = date -> date.atStartOfDay(SYSTEM_ZONE).toInstant().toEpochMilli();
+
+  public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+  public static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+  public static final Function<String, Long> DATE_STRING_TO_MILLIS = date -> DATE_TO_MILLIS.apply(LocalDate.parse(date, DATE_FORMATTER));
+  public static final Function<String, Long> DATETIME_STRING_TO_MILLIS = dateTime -> DATETIME_TO_MILLIS.apply(LocalDateTime.parse(dateTime, TIMESTAMP_FORMATTER));
 
   public static final Map<Class<?>, Function<Long, String>> FORMATTER_FUNCTION_MAP = ImmutableMap.of(
       java.sql.Date.class, new DateFormatter(DATE_FORMATTER),
@@ -32,7 +42,6 @@ public final class JackUtility {
   }
 
   private static final class DateFormatter implements Function<Long, String> {
-
     private final DateTimeFormatter formatter;
 
     DateFormatter(final DateTimeFormatter formatter) {
@@ -41,7 +50,7 @@ public final class JackUtility {
 
     @Override
     public String apply(final Long date) {
-      return new DateTime(date).toString(formatter);
+      return Instant.ofEpochMilli(date).atZone(JackUtility.SYSTEM_ZONE).format(formatter);
     }
   }
 

--- a/jack-store/src/com/rapleaf/jack/store/JsRecord.java
+++ b/jack-store/src/com/rapleaf/jack/store/JsRecord.java
@@ -1,5 +1,6 @@
 package com.rapleaf.jack.store;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -10,7 +11,6 @@ import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
 import com.google.gson.JsonObject;
-import org.joda.time.DateTime;
 
 import com.rapleaf.jack.exception.JackRuntimeException;
 import com.rapleaf.jack.store.iface.ValueContainer;
@@ -70,7 +70,7 @@ public class JsRecord implements ValueContainer<JsRecord> {
       case DOUBLE:
         return checkTypeAndGetNullable(key, ValueType.DOUBLE, Double::valueOf);
       case DATETIME:
-        return checkTypeAndGetNullable(key, ValueType.DATETIME, DateTime::parse);
+        return checkTypeAndGetNullable(key, ValueType.DATETIME, LocalDateTime::parse);
       case STRING:
         return checkTypeAndGetNullable(key, ValueType.STRING, Function.identity());
       default:
@@ -106,9 +106,9 @@ public class JsRecord implements ValueContainer<JsRecord> {
   }
 
   @Override
-  public DateTime getDateTime(String key) {
+  public LocalDateTime getDateTime(String key) {
     checkKey(key);
-    return checkTypeAndGetNullable(key, ValueType.DATETIME, DateTime::parse);
+    return checkTypeAndGetNullable(key, ValueType.DATETIME, LocalDateTime::parse);
   }
 
   @Override
@@ -140,7 +140,7 @@ public class JsRecord implements ValueContainer<JsRecord> {
       case DOUBLE_LIST:
         return checkTypeAndGetList(key, ValueType.DOUBLE_LIST, Double::valueOf);
       case DATETIME_LIST:
-        return checkTypeAndGetList(key, ValueType.DATETIME_LIST, DateTime::parse);
+        return checkTypeAndGetList(key, ValueType.DATETIME_LIST, LocalDateTime::parse);
       case STRING_LIST:
         return checkTypeAndGetList(key, ValueType.STRING_LIST, Function.identity());
       default:
@@ -173,9 +173,9 @@ public class JsRecord implements ValueContainer<JsRecord> {
   }
 
   @Override
-  public List<DateTime> getDateTimeList(String key) {
+  public List<LocalDateTime> getDateTimeList(String key) {
     checkKey(key);
-    return checkTypeAndGetList(key, ValueType.DATETIME_LIST, DateTime::parse);
+    return checkTypeAndGetList(key, ValueType.DATETIME_LIST, LocalDateTime::parse);
   }
 
   @Override

--- a/jack-store/src/com/rapleaf/jack/store/executors/BaseCreatorExecutor.java
+++ b/jack-store/src/com/rapleaf/jack/store/executors/BaseCreatorExecutor.java
@@ -1,6 +1,7 @@
 package com.rapleaf.jack.store.executors;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -9,7 +10,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.JsonObject;
-import org.joda.time.DateTime;
 
 import com.rapleaf.jack.IDb;
 import com.rapleaf.jack.store.JsTable;
@@ -48,8 +48,8 @@ abstract class BaseCreatorExecutor<TF, TL, E extends BaseCreatorExecutor<TF, TL,
     if (value instanceof Double) {
       return putDouble(key, (Double)value);
     }
-    if (value instanceof DateTime) {
-      return putDateTime(key, (DateTime)value);
+    if (value instanceof LocalDateTime) {
+      return putDateTime(key, (LocalDateTime)value);
     }
     if (value instanceof String) {
       return putString(key, (String)value);
@@ -92,7 +92,7 @@ abstract class BaseCreatorExecutor<TF, TL, E extends BaseCreatorExecutor<TF, TL,
   }
 
   @Override
-  public E putDateTime(String key, DateTime value) {
+  public E putDateTime(String key, LocalDateTime value) {
     types.put(key, ValueType.DATETIME);
     values.put(key, value);
     return getSelf();
@@ -131,7 +131,7 @@ abstract class BaseCreatorExecutor<TF, TL, E extends BaseCreatorExecutor<TF, TL,
     if (value instanceof Double) {
       return (E)putDoubleList(key, valueList);
     }
-    if (value instanceof DateTime) {
+    if (value instanceof LocalDateTime) {
       return (E)putDateTimeList(key, valueList);
     }
     if (value instanceof String) {
@@ -169,7 +169,7 @@ abstract class BaseCreatorExecutor<TF, TL, E extends BaseCreatorExecutor<TF, TL,
   }
 
   @Override
-  public E putDateTimeList(String key, List<DateTime> valueList) {
+  public E putDateTimeList(String key, List<LocalDateTime> valueList) {
     types.put(key, ValueType.DATETIME_LIST);
     values.put(key, nullifyEmptyList(valueList));
     return getSelf();

--- a/jack-store/src/com/rapleaf/jack/store/field/JsFields.java
+++ b/jack-store/src/com/rapleaf/jack/store/field/JsFields.java
@@ -1,9 +1,9 @@
 package com.rapleaf.jack.store.field;
 
+import java.time.LocalDateTime;
 import java.util.function.Function;
 
 import com.google.gson.JsonObject;
-import org.joda.time.DateTime;
 
 import com.rapleaf.jack.store.JsRecord;
 import com.rapleaf.jack.store.iface.ValueIndexer;
@@ -35,7 +35,7 @@ public final class JsFields {
     return new JsValueField<>(key, ValueIndexer::putDouble, JsRecord::getDouble);
   }
 
-  public static JsValueField<DateTime> createDateTimeField(String key) {
+  public static JsValueField<LocalDateTime> createDateTimeField(String key) {
     return new JsValueField<>(key, ValueIndexer::putDateTime, JsRecord::getDateTime);
   }
 
@@ -65,7 +65,7 @@ public final class JsFields {
     return new JsListField<>(key, ValueIndexer::putDoubleList, JsRecord::getDoubleList);
   }
 
-  public static JsListField<DateTime> createDateTimeListField(String key) {
+  public static JsListField<LocalDateTime> createDateTimeListField(String key) {
     return new JsListField<>(key, ValueIndexer::putDateTimeList, JsRecord::getDateTimeList);
   }
 

--- a/jack-store/src/com/rapleaf/jack/store/iface/ValueContainer.java
+++ b/jack-store/src/com/rapleaf/jack/store/iface/ValueContainer.java
@@ -1,9 +1,9 @@
 package com.rapleaf.jack.store.iface;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import com.google.gson.JsonObject;
-import org.joda.time.DateTime;
 
 public interface ValueContainer<E extends ValueContainer<E>> {
 
@@ -17,7 +17,7 @@ public interface ValueContainer<E extends ValueContainer<E>> {
 
   Double getDouble(String key);
 
-  DateTime getDateTime(String key);
+  LocalDateTime getDateTime(String key);
 
   String getString(String key);
 
@@ -33,7 +33,7 @@ public interface ValueContainer<E extends ValueContainer<E>> {
 
   List<Double> getDoubleList(String key);
 
-  List<DateTime> getDateTimeList(String key);
+  List<LocalDateTime> getDateTimeList(String key);
 
   List<String> getStringList(String key);
 

--- a/jack-store/src/com/rapleaf/jack/store/iface/ValueIndexer.java
+++ b/jack-store/src/com/rapleaf/jack/store/iface/ValueIndexer.java
@@ -1,9 +1,9 @@
 package com.rapleaf.jack.store.iface;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import com.google.gson.JsonObject;
-import org.joda.time.DateTime;
 
 public interface ValueIndexer<E extends ValueIndexer<E>> {
 
@@ -17,7 +17,7 @@ public interface ValueIndexer<E extends ValueIndexer<E>> {
 
   E putDouble(String key, Double value);
 
-  E putDateTime(String key, DateTime value);
+  E putDateTime(String key, LocalDateTime value);
 
   E putString(String key, String value);
 
@@ -33,7 +33,7 @@ public interface ValueIndexer<E extends ValueIndexer<E>> {
 
   E putDoubleList(String key, List<Double> valueList);
 
-  E putDateTimeList(String key, List<DateTime> valueList);
+  E putDateTimeList(String key, List<LocalDateTime> valueList);
 
   E putStringList(String key, List<String> valueList);
 

--- a/jack-test/test/java/com/rapleaf/jack/BaseDatabaseModelTestCase.java
+++ b/jack-test/test/java/com/rapleaf/jack/BaseDatabaseModelTestCase.java
@@ -16,9 +16,8 @@ import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.rapleaf.jack.test_project.database_1.IDatabase1;
-
 import com.rapleaf.jack.test_project.IDatabases;
+import com.rapleaf.jack.test_project.database_1.IDatabase1;
 import com.rapleaf.jack.test_project.database_1.iface.ICommentPersistence;
 import com.rapleaf.jack.test_project.database_1.iface.IImagePersistence;
 import com.rapleaf.jack.test_project.database_1.iface.IPostPersistence;

--- a/jack-test/test/java/com/rapleaf/jack/JackTestCase.java
+++ b/jack-test/test/java/com/rapleaf/jack/JackTestCase.java
@@ -1,6 +1,10 @@
 package com.rapleaf.jack;
 
 import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.function.Function;
 
 import org.apache.log4j.ConsoleAppender;
 import org.apache.log4j.Level;
@@ -8,8 +12,17 @@ import org.apache.log4j.Logger;
 import org.apache.log4j.PatternLayout;
 import org.junit.Before;
 
+import com.rapleaf.jack.util.JackUtility;
+
 public class JackTestCase {
   private static final String SEPARATOR = "--------------------";
+
+  protected static final ZoneId SYSTEM_ZONE = ZoneId.systemDefault();
+  protected static final Function<LocalDateTime, Long> DATETIME_TO_MILLIS = dateTime -> dateTime.atZone(SYSTEM_ZONE).toInstant().toEpochMilli();
+  protected static final Function<LocalDate, Long> DATE_TO_MILLIS = date -> date.atStartOfDay(SYSTEM_ZONE).toInstant().toEpochMilli();
+
+  protected static final Function<String, Long> DATE_STRING_TO_MILLIS = date -> DATE_TO_MILLIS.apply(LocalDate.parse(date, JackUtility.DATE_FORMATTER));
+  protected static final Function<String, Long> DATETIME_STRING_TO_MILLIS = dateTime -> DATETIME_TO_MILLIS.apply(LocalDateTime.parse(dateTime, JackUtility.TIMESTAMP_FORMATTER));
 
   public JackTestCase() {
     Logger rootLogger = Logger.getRootLogger();

--- a/jack-test/test/java/com/rapleaf/jack/JackTestCase.java
+++ b/jack-test/test/java/com/rapleaf/jack/JackTestCase.java
@@ -1,10 +1,11 @@
 package com.rapleaf.jack;
 
+import java.time.Duration;
+
 import org.apache.log4j.ConsoleAppender;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.PatternLayout;
-import org.joda.time.Duration;
 import org.junit.Before;
 
 public class JackTestCase {
@@ -36,7 +37,7 @@ public class JackTestCase {
 
   protected void sleepSeconds(int seconds) {
     try {
-      Thread.sleep(Duration.standardSeconds(seconds).getMillis());
+      Thread.sleep(Duration.ofSeconds(seconds).toMillis());
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
     }

--- a/jack-test/test/java/com/rapleaf/jack/TestModelQuery.java
+++ b/jack-test/test/java/com/rapleaf/jack/TestModelQuery.java
@@ -39,7 +39,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-
 public class TestModelQuery {
 
   private static final IDatabases dbs = new DatabasesImpl();

--- a/jack-test/test/java/com/rapleaf/jack/queries/TestGenericQuery.java
+++ b/jack-test/test/java/com/rapleaf/jack/queries/TestGenericQuery.java
@@ -2,6 +2,7 @@ package com.rapleaf.jack.queries;
 
 import java.io.IOException;
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -10,7 +11,6 @@ import java.util.stream.Stream;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -23,6 +23,7 @@ import com.rapleaf.jack.test_project.database_1.iface.IUserPersistence;
 import com.rapleaf.jack.test_project.database_1.models.Comment;
 import com.rapleaf.jack.test_project.database_1.models.Post;
 import com.rapleaf.jack.test_project.database_1.models.User;
+import com.rapleaf.jack.util.JackUtility;
 
 import static com.rapleaf.jack.queries.AggregatedColumn.AVG;
 import static com.rapleaf.jack.queries.AggregatedColumn.COUNT;
@@ -58,7 +59,7 @@ public class TestGenericQuery {
     results2 = null;
     // mysql with version < 5.6.4 does not support nano second resolution
     datetime = Timestamp.valueOf("2015-03-20 14:23:00").getTime();
-    date = DateTime.parse("2015-04-16").getMillis();
+    date = JackUtility.DATE_TO_MILLIS.apply(LocalDate.parse("2015-04-16"));
   }
 
   @Test

--- a/jack-test/test/java/com/rapleaf/jack/queries/TestGenericQuery.java
+++ b/jack-test/test/java/com/rapleaf/jack/queries/TestGenericQuery.java
@@ -2,7 +2,6 @@ package com.rapleaf.jack.queries;
 
 import java.io.IOException;
 import java.sql.Timestamp;
-import java.time.LocalDate;
 import java.util.Collections;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -14,6 +13,7 @@ import com.google.common.collect.Sets;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.rapleaf.jack.JackTestCase;
 import com.rapleaf.jack.exception.InvalidIndexHintException;
 import com.rapleaf.jack.test_project.DatabasesImpl;
 import com.rapleaf.jack.test_project.database_1.IDatabase1;
@@ -23,7 +23,6 @@ import com.rapleaf.jack.test_project.database_1.iface.IUserPersistence;
 import com.rapleaf.jack.test_project.database_1.models.Comment;
 import com.rapleaf.jack.test_project.database_1.models.Post;
 import com.rapleaf.jack.test_project.database_1.models.User;
-import com.rapleaf.jack.util.JackUtility;
 
 import static com.rapleaf.jack.queries.AggregatedColumn.AVG;
 import static com.rapleaf.jack.queries.AggregatedColumn.COUNT;
@@ -37,7 +36,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class TestGenericQuery {
+public class TestGenericQuery extends JackTestCase {
   protected static final IDatabase1 db = new DatabasesImpl().getDatabase1();
 
   private final IUserPersistence users = db.users();
@@ -59,7 +58,7 @@ public class TestGenericQuery {
     results2 = null;
     // mysql with version < 5.6.4 does not support nano second resolution
     datetime = Timestamp.valueOf("2015-03-20 14:23:00").getTime();
-    date = JackUtility.DATE_TO_MILLIS.apply(LocalDate.parse("2015-04-16"));
+    date = DATE_STRING_TO_MILLIS.apply("2015-04-16");
   }
 
   @Test

--- a/jack-test/test/java/com/rapleaf/jack/queries/TestGenericUpdate.java
+++ b/jack-test/test/java/com/rapleaf/jack/queries/TestGenericUpdate.java
@@ -1,6 +1,7 @@
 package com.rapleaf.jack.queries;
 
-import org.joda.time.DateTime;
+import java.time.LocalDate;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -8,6 +9,7 @@ import com.rapleaf.jack.exception.BulkOperationException;
 import com.rapleaf.jack.test_project.DatabasesImpl;
 import com.rapleaf.jack.test_project.database_1.IDatabase1;
 import com.rapleaf.jack.test_project.database_1.models.Post;
+import com.rapleaf.jack.util.JackUtility;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -23,7 +25,7 @@ public class TestGenericUpdate {
   private static final String TITLE_2 = "title2";
   private static final int USER_ID_1 = 51;
   private static final int USER_ID_2 = 52;
-  private static final long DATE = DateTime.parse("2017-08-17").getMillis();
+  private static final long DATE = JackUtility.DATE_TO_MILLIS.apply(LocalDate.parse("2017-08-17"));
 
   private Post post1;
   private Post post2;
@@ -61,7 +63,7 @@ public class TestGenericUpdate {
 
   @Test
   public void testUpdateDate() throws Exception {
-    long newDate = DateTime.parse("2017-09-10").getMillis();
+    long newDate = JackUtility.DATE_STRING_TO_MILLIS.apply("2017-09-10");
     assertEquals(DATE, db.posts().find(post1.getId()).getPostedAtMillis().longValue());
     Updates updates = db.createUpdate()
         .table(Post.TBL)

--- a/jack-test/test/java/com/rapleaf/jack/queries/TestGenericUpdate.java
+++ b/jack-test/test/java/com/rapleaf/jack/queries/TestGenericUpdate.java
@@ -5,16 +5,16 @@ import java.time.LocalDate;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.rapleaf.jack.JackTestCase;
 import com.rapleaf.jack.exception.BulkOperationException;
 import com.rapleaf.jack.test_project.DatabasesImpl;
 import com.rapleaf.jack.test_project.database_1.IDatabase1;
 import com.rapleaf.jack.test_project.database_1.models.Post;
-import com.rapleaf.jack.util.JackUtility;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-public class TestGenericUpdate {
+public class TestGenericUpdate extends JackTestCase {
   private static final IDatabase1 db = new DatabasesImpl().getDatabase1();
 
   static {
@@ -25,7 +25,7 @@ public class TestGenericUpdate {
   private static final String TITLE_2 = "title2";
   private static final int USER_ID_1 = 51;
   private static final int USER_ID_2 = 52;
-  private static final long DATE = JackUtility.DATE_TO_MILLIS.apply(LocalDate.parse("2017-08-17"));
+  private static final long DATE = DATE_TO_MILLIS.apply(LocalDate.parse("2017-08-17"));
 
   private Post post1;
   private Post post2;
@@ -63,7 +63,7 @@ public class TestGenericUpdate {
 
   @Test
   public void testUpdateDate() throws Exception {
-    long newDate = JackUtility.DATE_STRING_TO_MILLIS.apply("2017-09-10");
+    long newDate = DATE_STRING_TO_MILLIS.apply("2017-09-10");
     assertEquals(DATE, db.posts().find(post1.getId()).getPostedAtMillis().longValue());
     Updates updates = db.createUpdate()
         .table(Post.TBL)

--- a/jack-test/test/java/com/rapleaf/jack/queries/TestRecordAndRecords.java
+++ b/jack-test/test/java/com/rapleaf/jack/queries/TestRecordAndRecords.java
@@ -1,10 +1,10 @@
 package com.rapleaf.jack.queries;
 
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.util.List;
 
 import com.google.common.collect.Lists;
-import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -15,6 +15,7 @@ import com.rapleaf.jack.test_project.database_1.iface.IUserPersistence;
 import com.rapleaf.jack.test_project.database_1.models.Comment;
 import com.rapleaf.jack.test_project.database_1.models.Post;
 import com.rapleaf.jack.test_project.database_1.models.User;
+import com.rapleaf.jack.util.JackUtility;
 
 import static com.rapleaf.jack.queries.QueryOrder.ASC;
 import static org.junit.Assert.assertArrayEquals;
@@ -42,7 +43,7 @@ public class TestRecordAndRecords {
     results = null;
     // mysql with version < 5.6.4 does not support nano second resolution
     datetime = Timestamp.valueOf("2015-03-20 14:23:00").getTime();
-    date = DateTime.parse("2015-04-16").getMillis();
+    date = JackUtility.DATE_TO_MILLIS.apply(LocalDate.parse("2015-04-16"));
   }
 
   @Test

--- a/jack-test/test/java/com/rapleaf/jack/queries/TestRecordAndRecords.java
+++ b/jack-test/test/java/com/rapleaf/jack/queries/TestRecordAndRecords.java
@@ -8,6 +8,7 @@ import com.google.common.collect.Lists;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.rapleaf.jack.JackTestCase;
 import com.rapleaf.jack.test_project.DatabasesImpl;
 import com.rapleaf.jack.test_project.database_1.IDatabase1;
 import com.rapleaf.jack.test_project.database_1.iface.IPostPersistence;
@@ -15,7 +16,6 @@ import com.rapleaf.jack.test_project.database_1.iface.IUserPersistence;
 import com.rapleaf.jack.test_project.database_1.models.Comment;
 import com.rapleaf.jack.test_project.database_1.models.Post;
 import com.rapleaf.jack.test_project.database_1.models.User;
-import com.rapleaf.jack.util.JackUtility;
 
 import static com.rapleaf.jack.queries.QueryOrder.ASC;
 import static org.junit.Assert.assertArrayEquals;
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-public class TestRecordAndRecords {
+public class TestRecordAndRecords extends JackTestCase {
   private static final IDatabase1 db = new DatabasesImpl().getDatabase1();
 
   private static final double DELTA = 0.000001;
@@ -43,7 +43,7 @@ public class TestRecordAndRecords {
     results = null;
     // mysql with version < 5.6.4 does not support nano second resolution
     datetime = Timestamp.valueOf("2015-03-20 14:23:00").getTime();
-    date = JackUtility.DATE_TO_MILLIS.apply(LocalDate.parse("2015-04-16"));
+    date = DATE_TO_MILLIS.apply(LocalDate.parse("2015-04-16"));
   }
 
   @Test

--- a/jack-test/test/java/com/rapleaf/jack/queries/TestSubQuery.java
+++ b/jack-test/test/java/com/rapleaf/jack/queries/TestSubQuery.java
@@ -3,7 +3,6 @@ package com.rapleaf.jack.queries;
 import java.io.IOException;
 
 import com.google.common.collect.Lists;
-import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -14,6 +13,7 @@ import com.rapleaf.jack.test_project.database_1.iface.IPostPersistence;
 import com.rapleaf.jack.test_project.database_1.iface.IUserPersistence;
 import com.rapleaf.jack.test_project.database_1.models.Post;
 import com.rapleaf.jack.test_project.database_1.models.User;
+import com.rapleaf.jack.util.JackUtility;
 
 import static org.junit.Assert.assertEquals;
 
@@ -33,9 +33,9 @@ public class TestSubQuery extends JackTestCase {
     users.deleteAll();
     posts.deleteAll();
 
-    userA = users.createDefaultInstance().setNumPosts(12).setBio("A").setSomeDatetime(DateTime.parse("2017-09-10").getMillis());
-    userB = users.createDefaultInstance().setNumPosts(11).setBio("B").setSomeDatetime(DateTime.parse("2017-09-11").getMillis());
-    userC = users.createDefaultInstance().setNumPosts(10).setBio("C").setSomeDatetime(DateTime.parse("2017-09-12").getMillis());
+    userA = users.createDefaultInstance().setNumPosts(12).setBio("A").setSomeDatetime(JackUtility.DATE_STRING_TO_MILLIS.apply("2017-09-10"));
+    userB = users.createDefaultInstance().setNumPosts(11).setBio("B").setSomeDatetime(JackUtility.DATE_STRING_TO_MILLIS.apply("2017-09-11"));
+    userC = users.createDefaultInstance().setNumPosts(10).setBio("C").setSomeDatetime(JackUtility.DATE_STRING_TO_MILLIS.apply("2017-09-12"));
     userA.save();
     userB.save();
     userC.save();
@@ -157,7 +157,7 @@ public class TestSubQuery extends JackTestCase {
     // sub query result: userB, userC
     SubTable subQuery = db.createQuery()
         .from(User.TBL)
-        .where(User.SOME_DATETIME.notEqualTo(DateTime.parse("2017-09-10").getMillis()))
+        .where(User.SOME_DATETIME.notEqualTo(JackUtility.DATE_STRING_TO_MILLIS.apply("2017-09-10")))
         .asSubTable("subQuery");
 
     records = db.createQuery()

--- a/jack-test/test/java/com/rapleaf/jack/queries/TestSubQuery.java
+++ b/jack-test/test/java/com/rapleaf/jack/queries/TestSubQuery.java
@@ -13,7 +13,6 @@ import com.rapleaf.jack.test_project.database_1.iface.IPostPersistence;
 import com.rapleaf.jack.test_project.database_1.iface.IUserPersistence;
 import com.rapleaf.jack.test_project.database_1.models.Post;
 import com.rapleaf.jack.test_project.database_1.models.User;
-import com.rapleaf.jack.util.JackUtility;
 
 import static org.junit.Assert.assertEquals;
 
@@ -33,9 +32,9 @@ public class TestSubQuery extends JackTestCase {
     users.deleteAll();
     posts.deleteAll();
 
-    userA = users.createDefaultInstance().setNumPosts(12).setBio("A").setSomeDatetime(JackUtility.DATE_STRING_TO_MILLIS.apply("2017-09-10"));
-    userB = users.createDefaultInstance().setNumPosts(11).setBio("B").setSomeDatetime(JackUtility.DATE_STRING_TO_MILLIS.apply("2017-09-11"));
-    userC = users.createDefaultInstance().setNumPosts(10).setBio("C").setSomeDatetime(JackUtility.DATE_STRING_TO_MILLIS.apply("2017-09-12"));
+    userA = users.createDefaultInstance().setNumPosts(12).setBio("A").setSomeDatetime(DATE_STRING_TO_MILLIS.apply("2017-09-10"));
+    userB = users.createDefaultInstance().setNumPosts(11).setBio("B").setSomeDatetime(DATE_STRING_TO_MILLIS.apply("2017-09-11"));
+    userC = users.createDefaultInstance().setNumPosts(10).setBio("C").setSomeDatetime(DATE_STRING_TO_MILLIS.apply("2017-09-12"));
     userA.save();
     userB.save();
     userC.save();
@@ -157,7 +156,7 @@ public class TestSubQuery extends JackTestCase {
     // sub query result: userB, userC
     SubTable subQuery = db.createQuery()
         .from(User.TBL)
-        .where(User.SOME_DATETIME.notEqualTo(JackUtility.DATE_STRING_TO_MILLIS.apply("2017-09-10")))
+        .where(User.SOME_DATETIME.notEqualTo(DATE_STRING_TO_MILLIS.apply("2017-09-10")))
         .asSubTable("subQuery");
 
     records = db.createQuery()

--- a/jack-test/test/java/com/rapleaf/jack/store/executors/BaseExecutorTestCase.java
+++ b/jack-test/test/java/com/rapleaf/jack/store/executors/BaseExecutorTestCase.java
@@ -24,7 +24,6 @@ import com.rapleaf.jack.test_project.DatabasesImpl;
 import com.rapleaf.jack.test_project.database_1.IDatabase1;
 import com.rapleaf.jack.test_project.database_1.models.TestStore;
 import com.rapleaf.jack.transaction.ITransactor;
-import com.rapleaf.jack.util.JackUtility;
 
 public class BaseExecutorTestCase extends JackTestCase {
 
@@ -67,7 +66,7 @@ public class BaseExecutorTestCase extends JackTestCase {
   protected static final List<Double> DOUBLE_LIST_VALUE = Lists.newArrayList(100.5, 110.5);
 
   protected static final String DATETIME_LIST_KEY = "datetime-list";
-  protected static final List<java.time.LocalDateTime> DATETIME_LIST_VALUE = Lists.newArrayList(LocalDateTime.now(), LocalDateTime.now().minusDays(1));
+  protected static final List<LocalDateTime> DATETIME_LIST_VALUE = Lists.newArrayList(LocalDateTime.now(), LocalDateTime.now().minusDays(1));
 
   protected static final String STRING_LIST_KEY = "string-list";
   protected static final List<String> STRING_LIST_VALUE = Lists.newArrayList("s120", "s130", "s140");

--- a/jack-test/test/java/com/rapleaf/jack/store/executors/BaseExecutorTestCase.java
+++ b/jack-test/test/java/com/rapleaf/jack/store/executors/BaseExecutorTestCase.java
@@ -1,5 +1,6 @@
 package com.rapleaf.jack.store.executors;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
@@ -8,7 +9,6 @@ import java.util.UUID;
 import com.google.common.collect.Lists;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import org.joda.time.DateTime;
 import org.junit.Before;
 
 import com.rapleaf.jack.IDb;
@@ -24,6 +24,7 @@ import com.rapleaf.jack.test_project.DatabasesImpl;
 import com.rapleaf.jack.test_project.database_1.IDatabase1;
 import com.rapleaf.jack.test_project.database_1.models.TestStore;
 import com.rapleaf.jack.transaction.ITransactor;
+import com.rapleaf.jack.util.JackUtility;
 
 public class BaseExecutorTestCase extends JackTestCase {
 
@@ -44,7 +45,7 @@ public class BaseExecutorTestCase extends JackTestCase {
   protected static final double DOUBLE_VALUE = 30.5;
 
   protected static final String DATETIME_KEY = "datetime";
-  protected static final DateTime DATETIME_VALUE = DateTime.now();
+  protected static final LocalDateTime DATETIME_VALUE = LocalDateTime.now();
 
   protected static final String STRING_KEY = "string";
   protected static final String STRING_VALUE = "s40";
@@ -66,7 +67,7 @@ public class BaseExecutorTestCase extends JackTestCase {
   protected static final List<Double> DOUBLE_LIST_VALUE = Lists.newArrayList(100.5, 110.5);
 
   protected static final String DATETIME_LIST_KEY = "datetime-list";
-  protected static final List<DateTime> DATETIME_LIST_VALUE = Lists.newArrayList(DateTime.now(), DateTime.now().minusDays(1));
+  protected static final List<java.time.LocalDateTime> DATETIME_LIST_VALUE = Lists.newArrayList(LocalDateTime.now(), LocalDateTime.now().minusDays(1));
 
   protected static final String STRING_LIST_KEY = "string-list";
   protected static final List<String> STRING_LIST_VALUE = Lists.newArrayList("s120", "s130", "s140");

--- a/jack-test/test/java/com/rapleaf/jack/store/executors/TestRecordReader.java
+++ b/jack-test/test/java/com/rapleaf/jack/store/executors/TestRecordReader.java
@@ -1,5 +1,6 @@
 package com.rapleaf.jack.store.executors;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -7,7 +8,6 @@ import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.joda.time.DateTime;
 import org.junit.Test;
 
 import com.rapleaf.jack.store.JsRecord;
@@ -16,6 +16,7 @@ import com.rapleaf.jack.store.json.JsonDbConstants;
 import com.rapleaf.jack.store.json.JsonDbHelper;
 import com.rapleaf.jack.store.json.JsonDbTuple;
 import com.rapleaf.jack.test_project.database_1.models.TestStore;
+import com.rapleaf.jack.util.JackUtility;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -64,8 +65,8 @@ public class TestRecordReader extends BaseExecutorTestCase {
     assertEquals(recordId, record.getRecordId().longValue());
     if (nullValue) {
       assertNull(record.get(key));
-    } else if (value instanceof DateTime) {
-      assertEquals(((DateTime)value).getMillis(), ((DateTime)record.get(key)).getMillis());
+    } else if (value instanceof LocalDateTime) {
+      assertEquals(JackUtility.DATETIME_TO_MILLIS.apply((LocalDateTime)value), JackUtility.DATETIME_TO_MILLIS.apply((LocalDateTime)record.get(key)));
     } else {
       assertEquals(value, record.get(key));
     }
@@ -91,10 +92,10 @@ public class TestRecordReader extends BaseExecutorTestCase {
     assertEquals(recordId, record.getRecordId().longValue());
     if (nullValue) {
       assertTrue(record.getList(key).isEmpty());
-    } else if (values.get(0) instanceof DateTime) {
+    } else if (values.get(0) instanceof LocalDateTime) {
       assertEquals(
-          ((List<Object>)values).stream().map(v -> ((DateTime)v).getMillis()).collect(Collectors.toList()),
-          ((List<Object>)record.getList(key)).stream().map(v -> ((DateTime)v).getMillis()).collect(Collectors.toList())
+          ((List<Object>)values).stream().map(v -> JackUtility.DATETIME_TO_MILLIS.apply((LocalDateTime)v)).collect(Collectors.toList()),
+          ((List<Object>)record.getList(key)).stream().map(v -> JackUtility.DATETIME_TO_MILLIS.apply(((LocalDateTime)v))).collect(Collectors.toList())
       );
     } else {
       assertEquals(values, record.getList(key));

--- a/jack-test/test/java/com/rapleaf/jack/store/executors/TestRecordReader.java
+++ b/jack-test/test/java/com/rapleaf/jack/store/executors/TestRecordReader.java
@@ -1,6 +1,5 @@
 package com.rapleaf.jack.store.executors;
 
-import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -16,7 +15,6 @@ import com.rapleaf.jack.store.json.JsonDbConstants;
 import com.rapleaf.jack.store.json.JsonDbHelper;
 import com.rapleaf.jack.store.json.JsonDbTuple;
 import com.rapleaf.jack.test_project.database_1.models.TestStore;
-import com.rapleaf.jack.util.JackUtility;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -65,8 +63,6 @@ public class TestRecordReader extends BaseExecutorTestCase {
     assertEquals(recordId, record.getRecordId().longValue());
     if (nullValue) {
       assertNull(record.get(key));
-    } else if (value instanceof LocalDateTime) {
-      assertEquals(JackUtility.DATETIME_TO_MILLIS.apply((LocalDateTime)value), JackUtility.DATETIME_TO_MILLIS.apply((LocalDateTime)record.get(key)));
     } else {
       assertEquals(value, record.get(key));
     }
@@ -92,11 +88,6 @@ public class TestRecordReader extends BaseExecutorTestCase {
     assertEquals(recordId, record.getRecordId().longValue());
     if (nullValue) {
       assertTrue(record.getList(key).isEmpty());
-    } else if (values.get(0) instanceof LocalDateTime) {
-      assertEquals(
-          ((List<Object>)values).stream().map(v -> JackUtility.DATETIME_TO_MILLIS.apply((LocalDateTime)v)).collect(Collectors.toList()),
-          ((List<Object>)record.getList(key)).stream().map(v -> JackUtility.DATETIME_TO_MILLIS.apply(((LocalDateTime)v))).collect(Collectors.toList())
-      );
     } else {
       assertEquals(values, record.getList(key));
     }

--- a/jack-test/test/java/com/rapleaf/jack/store/executors/TestSubRecordCreator.java
+++ b/jack-test/test/java/com/rapleaf/jack/store/executors/TestSubRecordCreator.java
@@ -1,10 +1,10 @@
 package com.rapleaf.jack.store.executors;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
-import org.joda.time.DateTime;
 import org.junit.Test;
 
 import com.rapleaf.jack.queries.Record;
@@ -12,6 +12,7 @@ import com.rapleaf.jack.queries.Records;
 import com.rapleaf.jack.store.JsRecord;
 import com.rapleaf.jack.store.ValueType;
 import com.rapleaf.jack.test_project.database_1.models.TestStore;
+import com.rapleaf.jack.util.JackUtility;
 
 import static org.junit.Assert.assertEquals;
 
@@ -93,7 +94,7 @@ public class TestSubRecordCreator extends BaseExecutorTestCase {
     assertEquals(INT_VALUE, jsRecord.get(INT_KEY));
     assertEquals(LONG_VALUE, jsRecord.get(LONG_KEY));
     assertEquals(DOUBLE_VALUE, jsRecord.get(DOUBLE_KEY));
-    assertEquals(DATETIME_VALUE.getMillis(), ((DateTime)jsRecord.get(DATETIME_KEY)).getMillis());
+    assertEquals(DATETIME_VALUE, jsRecord.get(DATETIME_KEY));
     assertEquals(STRING_VALUE, jsRecord.get(STRING_KEY));
 
     assertEquals(JSON_VALUE, jsRecord.get(JSON_KEY));
@@ -102,7 +103,7 @@ public class TestSubRecordCreator extends BaseExecutorTestCase {
     assertEquals(INT_LIST_VALUE, jsRecord.getList(INT_LIST_KEY));
     assertEquals(LONG_LIST_VALUE, jsRecord.getList(LONG_LIST_KEY));
     assertEquals(DOUBLE_LIST_VALUE, jsRecord.getList(DOUBLE_LIST_KEY));
-    assertEquals(DATETIME_LIST_VALUE.stream().map(DateTime::getMillis).collect(Collectors.toList()), ((List<DateTime>)jsRecord.getList(DATETIME_LIST_KEY)).stream().map(DateTime::getMillis).collect(Collectors.toList()));
+    assertEquals(DATETIME_LIST_VALUE.stream().map(JackUtility.DATETIME_TO_MILLIS).collect(Collectors.toList()), ((List<LocalDateTime>)jsRecord.getList(DATETIME_LIST_KEY)).stream().map(JackUtility.DATETIME_TO_MILLIS).collect(Collectors.toList()));
     assertEquals(STRING_LIST_VALUE, jsRecord.getList(STRING_LIST_KEY));
   }
 

--- a/jack-test/test/java/com/rapleaf/jack/store/executors/TestSubRecordCreator.java
+++ b/jack-test/test/java/com/rapleaf/jack/store/executors/TestSubRecordCreator.java
@@ -1,8 +1,6 @@
 package com.rapleaf.jack.store.executors;
 
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
 import org.junit.Test;
@@ -12,14 +10,13 @@ import com.rapleaf.jack.queries.Records;
 import com.rapleaf.jack.store.JsRecord;
 import com.rapleaf.jack.store.ValueType;
 import com.rapleaf.jack.test_project.database_1.models.TestStore;
-import com.rapleaf.jack.util.JackUtility;
 
 import static org.junit.Assert.assertEquals;
 
 public class TestSubRecordCreator extends BaseExecutorTestCase {
 
   @Test
-  public void testSubScopeCreation2() throws Exception {
+  public void testSubScopeCreation2() {
     int size = Math.max(3, RANDOM.nextInt(10));
     List<String> names = Lists.newArrayListWithCapacity(size);
     List<Long> values = Lists.newArrayListWithCapacity(size);
@@ -71,7 +68,7 @@ public class TestSubRecordCreator extends BaseExecutorTestCase {
   }
 
   @Test
-  public void testCreateSubRecordAndRead() throws Exception {
+  public void testCreateSubRecordAndRead() {
     JsRecord jsRecord = transactor.queryAsTransaction(db ->
         jackStore.rootRecord().createSubRecord()
             .put(BOOLEAN_KEY, BOOLEAN_VALUE)
@@ -103,7 +100,7 @@ public class TestSubRecordCreator extends BaseExecutorTestCase {
     assertEquals(INT_LIST_VALUE, jsRecord.getList(INT_LIST_KEY));
     assertEquals(LONG_LIST_VALUE, jsRecord.getList(LONG_LIST_KEY));
     assertEquals(DOUBLE_LIST_VALUE, jsRecord.getList(DOUBLE_LIST_KEY));
-    assertEquals(DATETIME_LIST_VALUE.stream().map(JackUtility.DATETIME_TO_MILLIS).collect(Collectors.toList()), ((List<LocalDateTime>)jsRecord.getList(DATETIME_LIST_KEY)).stream().map(JackUtility.DATETIME_TO_MILLIS).collect(Collectors.toList()));
+    assertEquals(DATETIME_LIST_VALUE, jsRecord.getList(DATETIME_LIST_KEY));
     assertEquals(STRING_LIST_VALUE, jsRecord.getList(STRING_LIST_KEY));
   }
 

--- a/jack-test/test/java/com/rapleaf/jack/store/field/TestJsField.java
+++ b/jack-test/test/java/com/rapleaf/jack/store/field/TestJsField.java
@@ -2,7 +2,6 @@ package com.rapleaf.jack.store.field;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -10,7 +9,6 @@ import org.junit.Test;
 import com.rapleaf.jack.store.JsRecord;
 import com.rapleaf.jack.store.executors.BaseExecutorTestCase;
 import com.rapleaf.jack.store.executors.RecordUpdater;
-import com.rapleaf.jack.util.JackUtility;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -70,15 +68,7 @@ public class TestJsField extends BaseExecutorTestCase {
       return jackStore.rootRecord().read().execute(db);
     });
 
-    if (values.get(0) instanceof LocalDateTime) {
-
-      assertEquals(
-          values.stream().map(v -> JackUtility.DATETIME_TO_MILLIS.apply((LocalDateTime)v)).collect(Collectors.toList()),
-          field.getReadFunction().apply(record).stream().map(v -> JackUtility.DATETIME_TO_MILLIS.apply((LocalDateTime)v)).collect(Collectors.toList())
-      );
-    } else {
-      assertEquals(values, field.getReadFunction().apply(record));
-    }
+    assertEquals(values, field.getReadFunction().apply(record));
   }
 
 }

--- a/jack-test/test/java/com/rapleaf/jack/store/field/TestJsField.java
+++ b/jack-test/test/java/com/rapleaf/jack/store/field/TestJsField.java
@@ -1,17 +1,17 @@
 package com.rapleaf.jack.store.field;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.rapleaf.jack.store.JsRecord;
 import com.rapleaf.jack.store.executors.BaseExecutorTestCase;
 import com.rapleaf.jack.store.executors.RecordUpdater;
+import com.rapleaf.jack.util.JackUtility;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -53,8 +53,8 @@ public class TestJsField extends BaseExecutorTestCase {
       return jackStore.rootRecord().read().execute(db);
     });
 
-    if (value instanceof DateTime) {
-      assertTrue(((DateTime)value).isEqual((DateTime)field.getReadFunction().apply(record)));
+    if (value instanceof LocalDateTime) {
+      assertTrue(((LocalDateTime)value).isEqual((LocalDateTime)field.getReadFunction().apply(record)));
     } else {
       assertEquals(value, field.getReadFunction().apply(record));
     }
@@ -70,10 +70,11 @@ public class TestJsField extends BaseExecutorTestCase {
       return jackStore.rootRecord().read().execute(db);
     });
 
-    if (values.get(0) instanceof DateTime) {
+    if (values.get(0) instanceof LocalDateTime) {
+
       assertEquals(
-          values.stream().map(v -> ((DateTime)v).getMillis()).collect(Collectors.toList()),
-          field.getReadFunction().apply(record).stream().map(v -> ((DateTime)v).getMillis()).collect(Collectors.toList())
+          values.stream().map(v -> JackUtility.DATETIME_TO_MILLIS.apply((LocalDateTime)v)).collect(Collectors.toList()),
+          field.getReadFunction().apply(record).stream().map(v -> JackUtility.DATETIME_TO_MILLIS.apply((LocalDateTime)v)).collect(Collectors.toList())
       );
     } else {
       assertEquals(values, field.getReadFunction().apply(record));

--- a/jack-test/test/java/com/rapleaf/jack/transaction/TestDbMetrics.java
+++ b/jack-test/test/java/com/rapleaf/jack/transaction/TestDbMetrics.java
@@ -40,7 +40,8 @@ public class TestDbMetrics extends JackTestCase {
   @Test
   public void testTotalQueries() throws Exception {
     TransactorImpl<IDatabase1> transactor = transactorBuilder.setMetricsTracking(true).get();
-    transactor.execute(db -> {});
+    transactor.execute(db -> {
+    });
     DbMetrics dbMetrics = transactor.getDbMetrics();
 
     assertTrue(dbMetrics.getTotalQueries() == 1);
@@ -50,9 +51,15 @@ public class TestDbMetrics extends JackTestCase {
   public void testOpenedConnectionsNumber() throws Exception {
     TransactorImpl<IDatabase1> transactor = transactorBuilder.setMetricsTracking(true).setMaxTotalConnections(2).get();
 
-    Future future1 = executorService.submit(() -> transactor.execute(a -> {sleepMillis(50);}));
-    Future future2 = executorService.submit(() -> transactor.execute(a -> {sleepMillis(70);}));
-    Future future3 = executorService.submit(() -> transactor.execute(a -> {sleepMillis(90);}));
+    Future future1 = executorService.submit(() -> transactor.execute(a -> {
+      sleepMillis(50);
+    }));
+    Future future2 = executorService.submit(() -> transactor.execute(a -> {
+      sleepMillis(70);
+    }));
+    Future future3 = executorService.submit(() -> transactor.execute(a -> {
+      sleepMillis(90);
+    }));
     future1.get();
     future2.get();
     future3.get();
@@ -65,7 +72,9 @@ public class TestDbMetrics extends JackTestCase {
   @Test
   public void testMaxConnectionsProportion() throws Exception {
     TransactorImpl<IDatabase1> transactor = transactorBuilder.setMetricsTracking(true).setMaxTotalConnections(1).get();
-    transactor.execute(a -> {sleepMillis(100);});
+    transactor.execute(a -> {
+      sleepMillis(100);
+    });
     long timeActive = stopwatch.elapsedMillis();
     sleepMillis(100);
     long totalTime = stopwatch.elapsedMillis();
@@ -81,7 +90,8 @@ public class TestDbMetrics extends JackTestCase {
   @Test
   public void testMaxConnectionWaitingTime() throws Exception {
     TransactorImpl<IDatabase1> transactor = transactorBuilder.setMetricsTracking(true).setMaxTotalConnections(1).get();
-    transactor.execute(a -> {});
+    transactor.execute(a -> {
+    });
     double firstMaxConnectionWaitingTime = transactor.getDbMetrics().getMaxConnectionWaitingTime();
     int connectionCount = 5;
     final Long[] startingTimes = new Long[connectionCount];
@@ -116,7 +126,8 @@ public class TestDbMetrics extends JackTestCase {
   @Test
   public void testAverageConnectionWaitingTime() throws Exception {
     TransactorImpl<IDatabase1> transactor = transactorBuilder.setMetricsTracking(true).setMaxTotalConnections(1).get();
-    transactor.execute(a -> {});
+    transactor.execute(a -> {
+    });
     double firstAverageConnectionWaitingTime = transactor.getDbMetrics().getAverageConnectionWaitingTime();
     int connectionCount = 5;
     final Long[] startingTimes = new Long[connectionCount];
@@ -153,7 +164,9 @@ public class TestDbMetrics extends JackTestCase {
   @Test
   public void testAverageIdleConnections() throws Exception {
     TransactorImpl<IDatabase1> transactor = transactorBuilder.setMetricsTracking(true).setMaxTotalConnections(2).setMinIdleConnections(1).setKeepAliveTime(Duration.ofMillis(50)).get();
-    transactor.execute(a -> {sleepMillis(100);});
+    transactor.execute(a -> {
+      sleepMillis(100);
+    });
     long startIdleTime = stopwatch.elapsedMillis();
     sleepMillis(100);
     long idleTime = stopwatch.elapsedMillis() - startIdleTime;
@@ -169,7 +182,9 @@ public class TestDbMetrics extends JackTestCase {
   public void testAverageActiveConnections() throws Exception {
     TransactorImpl<IDatabase1> transactor = transactorBuilder.setMetricsTracking(true).get();
     long startActive = stopwatch.elapsedMillis();
-    transactor.execute(db -> {sleepMillis(100);});
+    transactor.execute(db -> {
+      sleepMillis(100);
+    });
     long activeTime = stopwatch.elapsedMillis() - startActive;
     sleepMillis(100);
     DbMetrics dbMetrics = transactor.getDbMetrics();

--- a/jack-test/test/java/com/rapleaf/jack/util/TestJackUtility.java
+++ b/jack-test/test/java/com/rapleaf/jack/util/TestJackUtility.java
@@ -1,0 +1,38 @@
+package com.rapleaf.jack.util;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestJackUtility {
+  @Test
+  public void testDateTimeToMillis() {
+    long millis = System.currentTimeMillis();
+    LocalDateTime dateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneId.systemDefault());
+    assertEquals(millis, JackUtility.DATETIME_TO_MILLIS.apply(dateTime).longValue());
+  }
+
+  @Test
+  public void testDateToMillis() {
+    long millis = LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
+    LocalDate date = LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneId.systemDefault()).toLocalDate();
+    assertEquals(millis, JackUtility.DATE_TO_MILLIS.apply(date).longValue());
+  }
+
+  @Test
+  public void testDateFormatter() {
+    String dateString = "2018-01-02";
+    assertEquals(dateString, LocalDate.parse(dateString).format(JackUtility.DATE_FORMATTER));
+  }
+
+  @Test
+  public void testTimestampFormatter() {
+    String dateTimeString = "2018-01-02 18:30:15";
+    assertEquals(dateTimeString, LocalDateTime.parse(dateTimeString, JackUtility.TIMESTAMP_FORMATTER).format(JackUtility.TIMESTAMP_FORMATTER));
+  }
+}

--- a/jack-test/test/java/com/rapleaf/jack/util/TestJackUtility.java
+++ b/jack-test/test/java/com/rapleaf/jack/util/TestJackUtility.java
@@ -7,21 +7,49 @@ import java.time.ZoneId;
 
 import org.junit.Test;
 
+import com.rapleaf.jack.JackTestCase;
+
 import static org.junit.Assert.assertEquals;
 
-public class TestJackUtility {
+public class TestJackUtility extends JackTestCase {
+  // this function is not used in production, but it is used to create
+  // mock objects in unit tests; so its correctness is important
   @Test
   public void testDateTimeToMillis() {
     long millis = System.currentTimeMillis();
     LocalDateTime dateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneId.systemDefault());
-    assertEquals(millis, JackUtility.DATETIME_TO_MILLIS.apply(dateTime).longValue());
+    assertEquals(millis, DATETIME_TO_MILLIS.apply(dateTime).longValue());
   }
 
+  // this function is not used in production, but it is used to create
+  // mock objects in unit tests; so its correctness is important
   @Test
   public void testDateToMillis() {
     long millis = LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
     LocalDate date = LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneId.systemDefault()).toLocalDate();
-    assertEquals(millis, JackUtility.DATE_TO_MILLIS.apply(date).longValue());
+    assertEquals(millis, DATE_TO_MILLIS.apply(date).longValue());
+  }
+
+  // this function is not used in production, but it is used to create
+  // mock objects in unit tests; so its correctness is important
+  @Test
+  public void testDateTimeStringToMillis() {
+    String dateTimeString = "2018-01-02 18:30:15";
+    assertEquals(
+        LocalDateTime.of(2018, 1, 2, 18, 30, 15).atZone(SYSTEM_ZONE).toInstant().toEpochMilli(),
+        DATETIME_STRING_TO_MILLIS.apply(dateTimeString).longValue()
+    );
+  }
+
+  // this function is not used in production, but it is used to create
+  // mock objects in unit tests; so its correctness is important
+  @Test
+  public void testDateStringToMillis() {
+    String dateString = "2018-01-02";
+    assertEquals(
+        LocalDate.of(2018, 1, 2).atStartOfDay(SYSTEM_ZONE).toInstant().toEpochMilli(),
+        DATE_STRING_TO_MILLIS.apply(dateString).longValue()
+    );
   }
 
   @Test


### PR DESCRIPTION
TODOs
- [ ] When persisting `LocalDateTime` in jack store, it needs to be converted to`OffsetDateTime`. Otherwise, old date time values cannot be correctly parsed.
    - LocalDateTime output: `2018-06-07T22:10:02.981`
    - Joda DateTime output: `2018-06-07T22:11:22.207-07:00`
    - Alternatively, can use `OffsetDateTime` directly.

This PR is too dangerous to merge.
