### PR TITLE
Avoid Joda DateTimeFormat

### DIFF
--- a/jack-core/src/com/rapleaf/jack/util/JackUtility.java
+++ b/jack-core/src/com/rapleaf/jack/util/JackUtility.java
@@ -8,17 +8,15 @@ import java.util.function.Function;
 
 import com.google.common.collect.ImmutableMap;
 import org.joda.time.DateTime;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 
 public final class JackUtility {
 
-  public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormat.forPattern("yyyy-MM-dd");
-  public static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss");
+  private static final String DATE_FORMAT = "yyyy-MM-dd";
+  private static final String TIMESTAMP_FORMAT = "yyyy-MM-dd HH:mm:ss";
 
   public static final Map<Class<?>, Function<Long, String>> FORMATTER_FUNCTION_MAP = ImmutableMap.of(
-      java.sql.Date.class, new DateFormatter(DATE_FORMATTER),
-      java.sql.Timestamp.class, new DateFormatter(TIMESTAMP_FORMATTER)
+      java.sql.Date.class, date -> new DateTime(date).toString(DATE_FORMAT),
+      java.sql.Timestamp.class, dateTime -> new DateTime(dateTime).toString(TIMESTAMP_FORMAT)
   );
 
   private JackUtility() {
@@ -29,20 +27,6 @@ public final class JackUtility {
       throw new IllegalArgumentException(l + " cannot be cast to int without changing its value.");
     }
     return (int)l;
-  }
-
-  private static final class DateFormatter implements Function<Long, String> {
-
-    private final DateTimeFormatter formatter;
-
-    DateFormatter(final DateTimeFormatter formatter) {
-      this.formatter = formatter;
-    }
-
-    @Override
-    public String apply(final Long date) {
-      return new DateTime(date).toString(formatter);
-    }
   }
 
   public static boolean hasColumn(ResultSet rs, String columnName) throws SQLException {

--- a/jack-test/test/java/com/rapleaf/jack/util/TestJackUtility.java
+++ b/jack-test/test/java/com/rapleaf/jack/util/TestJackUtility.java
@@ -1,0 +1,27 @@
+package com.rapleaf.jack.util;
+
+
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestJackUtility {
+  @Test
+  public void testDateTimeFormat() {
+    assertEquals(
+        "2018-01-15 18:15:23",
+        JackUtility.FORMATTER_FUNCTION_MAP.get(java.sql.Timestamp.class)
+            .apply(new DateTime(2018, 1, 15, 18, 15, 23).getMillis())
+    );
+  }
+
+  @Test
+  public void testDateFormat() {
+    assertEquals(
+        "2018-01-15",
+        JackUtility.FORMATTER_FUNCTION_MAP.get(java.sql.Date.class)
+            .apply(new DateTime(2018, 1, 15, 0, 0, 0).getMillis())
+    );
+  }
+}


### PR DESCRIPTION
This is a not-completely-rational attempt to fix the mysterious `NoSuchMethodError` by removing the explicit reference of the complaint method. This is way safer than #220.

```
Exception in thread "main" java.lang.NoSuchMethodError: org.joda.time.DateTime.toString(Lorg/joda/time/format/DateTimeFormatter;)Ljava/lang/String;
    at com.rapleaf.jack.util.JackUtility$DateFormatter.apply(JackUtility.java:44)
    at com.rapleaf.jack.util.JackUtility$DateFormatter.apply(JackUtility.java:34)
    at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
    at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1374)
    at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
    at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
    at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
    at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
    at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
    at com.rapleaf.jack.queries.Column.createDateConstraint(Column.java:365)
    at com.rapleaf.jack.queries.Column.lessThan(Column.java:206)
```

It does make this class slightly simpler. So it's fine to keep this change even if it does not fix this issue.
