### PR TITLE
Fix NoOp Operator Bug

### DIFF
--- a/jack-core/src/com/rapleaf/jack/queries/WhereClause.java
+++ b/jack-core/src/com/rapleaf/jack/queries/WhereClause.java
@@ -86,7 +86,7 @@ public class WhereClause {
     Iterator<WhereConstraint> it = whereConstraints.iterator();
     while (it.hasNext()) {
       WhereConstraint constraint = it.next();
-      sb.append(constraint.getSqlStatement());
+      sb.append("(").append(constraint.getSqlStatement()).append(")");
 
       if (it.hasNext()) {
         sb.append(" AND ");

--- a/jack-test/test/java/com/rapleaf/jack/TestModelDelete.java
+++ b/jack-test/test/java/com/rapleaf/jack/TestModelDelete.java
@@ -39,7 +39,7 @@ public class TestModelDelete {
     deleteStatement.addConstraint(new WhereConstraint<>(Post._Fields.title, equalTo("Obama")));
     deleteStatement.addConstraint(new WhereConstraint<>(Post._Fields.user_id, equalTo(5)));
 
-    String expectedStatement = "DELETE FROM posts WHERE (id in (1,50,3,10) AND `title` = ? AND `user_id` = ?)".toLowerCase();
+    String expectedStatement = "DELETE FROM posts WHERE (id in (1,50,3,10) AND (`title` = ?) AND (`user_id` = ?))".toLowerCase();
     assertEquals(expectedStatement, deleteStatement.getStatement(tableName).trim().toLowerCase());
   }
 
@@ -63,7 +63,7 @@ public class TestModelDelete {
     deleteStatement.addConstraint(new WhereConstraint<>(Post._Fields.title, equalTo("Obama")));
     deleteStatement.addConstraint(new WhereConstraint<>(Post._Fields.user_id, in(5, 10)));
 
-    String expectedStatement = "DELETE FROM posts WHERE (`title` = ? AND `user_id` IN (?, ?))".toLowerCase();
+    String expectedStatement = "DELETE FROM posts WHERE ((`title` = ?) AND (`user_id` IN (?, ?)))".toLowerCase();
     assertEquals(expectedStatement, deleteStatement.getStatement(tableName).trim().toLowerCase());
   }
 

--- a/jack-test/test/java/com/rapleaf/jack/TestModelQuery.java
+++ b/jack-test/test/java/com/rapleaf/jack/TestModelQuery.java
@@ -168,13 +168,22 @@ public class TestModelQuery {
     assertEquals(1, result.size());
     assertTrue(result.contains(casey));
 
+    // Is Null
     result = users.query().whereSomeDatetime(JackMatchers.<Long>isNull()).find();
     assertEquals(3, result.size());
 
+    // Is Not Null
     result = users.query().whereSomeDatetime(JackMatchers.<Long>isNotNull()).find();
     assertEquals(2, result.size());
     assertTrue(result.contains(brandon));
     assertTrue(result.contains(james));
+
+    // No Op
+    result = users.query()
+        .whereSomeDatetime(JackMatchers.isNotNull())
+        .whereBio(JackMatchers.noop())
+        .find();
+    assertEquals(2, result.size());
 
     // If a null parameter is passed, an exception should be thrown
     try {


### PR DESCRIPTION
`NoOp` operator specifies `is not null OR true` in the where clause. Since all where constraints are simply concatenated together, `OR true` makes the query return everything.

This bug is fixed in this PR.
