### PR TITLE
Install to private bundle

### DIFF
--- a/jack-test/pom.xml
+++ b/jack-test/pom.xml
@@ -110,8 +110,7 @@
               <executable>/bin/sh</executable>
               <arguments>
                 <argument>-c</argument>
-                <argument>bundle</argument>
-                <argument>install</argument>
+                <argument>bundle install --path vendor/bundle</argument>
               </arguments>
             </configuration>
 


### PR DESCRIPTION
The current pom.xml for jack-test assumes you have write access to your
system bundle. By specifying `--path vendor/bundle`, this does not have
to be the case and increases compatibility.

Also, the earlier syntax was actually ignoring the keyword `install`
from `bundle install`. When using `/bin/sh -c`, the entire shell script
should be passed in as an argument value.