### PR TITLE
Support aggregated column in subquery

### DIFF
--- a/jack-core/src/com/rapleaf/jack/queries/AbstractExecution.java
+++ b/jack-core/src/com/rapleaf/jack/queries/AbstractExecution.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 import com.rapleaf.jack.BaseDatabaseConnection;
 import com.rapleaf.jack.exception.BulkOperationException;
@@ -72,7 +73,8 @@ public abstract class AbstractExecution {
 
   protected abstract List<Object> getParameters();
 
-  static String getClauseFromColumns(Collection<Column> columns, String initialKeyword, String separator, String terminalKeyword) {
+  static String getClauseFromColumns(Collection<Column> columns, Function<Column, String> columnKeyword,
+                                     String initialKeyword, String separator, String terminalKeyword) {
     if (columns.isEmpty()) {
       return "";
     }
@@ -80,7 +82,7 @@ public abstract class AbstractExecution {
     StringBuilder clause = new StringBuilder(initialKeyword);
     Iterator<Column> it = columns.iterator();
     while (it.hasNext()) {
-      clause.append(it.next().getSqlKeyword());
+      clause.append(columnKeyword.apply(it.next()));
       if (it.hasNext()) {
         clause.append(separator);
       }
@@ -89,7 +91,8 @@ public abstract class AbstractExecution {
     return clause.append(terminalKeyword).toString();
   }
 
-  static <T extends QueryCondition> String getClauseFromQueryConditions(Collection<T> conditions, String initialKeyword, String separator, String terminalKeyword) {
+  static <T extends QueryCondition> String getClauseFromQueryConditions(Collection<T> conditions, String initialKeyword,
+                                                                        String separator, String terminalKeyword) {
     if (conditions.isEmpty()) {
       return "";
     }

--- a/jack-core/src/com/rapleaf/jack/queries/AbstractTable.java
+++ b/jack-core/src/com/rapleaf/jack/queries/AbstractTable.java
@@ -35,7 +35,11 @@ public class AbstractTable<A extends AttributesWithId, M extends ModelWithId> im
     this.allColumns = table.allColumns;
   }
 
-  public AbstractTable<A, M> alias(String alias) {
+  /**
+   * This method is used internally only. Users should call {@code Tbl#as}
+   * on each respective table to get an aliased reference.
+   */
+  AbstractTable<A, M> alias(String alias) {
     return new AbstractTable<>(name, alias, attributesType, modelType);
   }
 

--- a/jack-core/src/com/rapleaf/jack/queries/AggregatedColumn.java
+++ b/jack-core/src/com/rapleaf/jack/queries/AggregatedColumn.java
@@ -7,10 +7,21 @@ public class AggregatedColumn<T> extends Column<T> {
   }
 
   private final Function function;
+  private final String sqlKeyword;
+  private final String alias;
 
   private AggregatedColumn(Column column, Function function) {
-    super(column);
+    super(column.table, column.field, column.type);
     this.function = function;
+    this.sqlKeyword = function.toString() + "(" + column.getSqlKeyword() + ")";
+    this.alias = column.getSqlKeyword().replaceAll("\\.", "_") + "_" + function.name().toLowerCase();
+  }
+
+  private AggregatedColumn(Column column, Function function, String sqlKeyword, String alias) {
+    super(column.table, column.field, column.type);
+    this.function = function;
+    this.sqlKeyword = sqlKeyword;
+    this.alias = alias;
   }
 
   public static <T> AggregatedColumn<Integer> COUNT(Column<T> column) {
@@ -34,7 +45,22 @@ public class AggregatedColumn<T> extends Column<T> {
   }
 
   @Override
+  AggregatedColumn<T> forTable(String tableAlias) {
+    return new AggregatedColumn<>(super.forTable(tableAlias), function, alias, alias);
+  }
+
+  @Override
+  String getSelectKeyword() {
+    return sqlKeyword + " AS " + alias;
+  }
+
+  @Override
+  String getSelectAlias() {
+    return alias;
+  }
+
+  @Override
   public String getSqlKeyword() {
-    return function.toString() + "(" + super.getSqlKeyword() + ")";
+    return sqlKeyword;
   }
 }

--- a/jack-core/src/com/rapleaf/jack/queries/AggregatedColumn.java
+++ b/jack-core/src/com/rapleaf/jack/queries/AggregatedColumn.java
@@ -10,18 +10,15 @@ public class AggregatedColumn<T> extends Column<T> {
   private final String sqlKeyword;
   private final String alias;
 
-  private AggregatedColumn(Column column, Function function) {
-    super(column.table, column.field, column.type);
-    this.function = function;
-    this.sqlKeyword = function.toString() + "(" + column.getSqlKeyword() + ")";
-    this.alias = column.getSqlKeyword().replaceAll("\\.", "_") + "_" + function.name().toLowerCase();
-  }
-
   private AggregatedColumn(Column column, Function function, String sqlKeyword, String alias) {
     super(column.table, column.field, column.type);
     this.function = function;
     this.sqlKeyword = sqlKeyword;
     this.alias = alias;
+  }
+
+  private AggregatedColumn(Column column, Function function) {
+    this(column, function, createSqlKeyword(column, function), createAlias(column, function));
   }
 
   public static <T> AggregatedColumn<Integer> COUNT(Column<T> column) {
@@ -70,5 +67,21 @@ public class AggregatedColumn<T> extends Column<T> {
   @Override
   public String getSqlKeyword() {
     return sqlKeyword;
+  }
+
+  /**
+   * @return the sql expression that applies the function on the column.
+   * E.g. MAX(users.id)
+   */
+  private static String createSqlKeyword(Column column, Function function) {
+    return String.format("%s(%s)", function.toString(), column.getSqlKeyword());
+  }
+
+  /**
+   * @return an alias that concatenate function and column name with underscore.
+   * E.g. MAX(users.id) => users_id_max
+   */
+  private static String createAlias(Column column, Function function) {
+    return column.getSqlKeyword().replaceAll("\\.", "_") + "_" + function.name().toLowerCase();
   }
 }

--- a/jack-core/src/com/rapleaf/jack/queries/AggregatedColumn.java
+++ b/jack-core/src/com/rapleaf/jack/queries/AggregatedColumn.java
@@ -49,11 +49,19 @@ public class AggregatedColumn<T> extends Column<T> {
     return new AggregatedColumn<>(super.forTable(tableAlias), function, alias, alias);
   }
 
+  /**
+   * @return SQL keyword for select clause. For aggregated column,
+   * it is in the form of "column AS alias".
+   */
   @Override
   String getSelectKeyword() {
     return sqlKeyword + " AS " + alias;
   }
 
+  /**
+   * @return column alias for select clause. For aggregated column,
+   * it is just the alias.
+   */
   @Override
   String getSelectAlias() {
     return alias;

--- a/jack-core/src/com/rapleaf/jack/queries/Column.java
+++ b/jack-core/src/com/rapleaf/jack/queries/Column.java
@@ -92,14 +92,16 @@ public class Column<T> {
   }
 
   /**
-   * @return SQL keyword for select clause.
+   * @return SQL keyword for select clause. For ordinary column,
+   * it is the same as {@link #getSqlKeyword()}.
    */
   String getSelectKeyword() {
     return getSqlKeyword();
   }
 
   /**
-   * @return column alias for select clause.
+   * @return column alias for select clause. For ordinary column,
+   * it is the same as {@link #getSqlKeyword()}.
    */
   String getSelectAlias() {
     return getSqlKeyword();

--- a/jack-core/src/com/rapleaf/jack/queries/Column.java
+++ b/jack-core/src/com/rapleaf/jack/queries/Column.java
@@ -34,12 +34,6 @@ public class Column<T> {
     this.type = type;
   }
 
-  protected <M> Column(Column<M> that) {
-    this.table = that.table;
-    this.field = that.field;
-    this.type = that.type;
-  }
-
   /**
    * Construct ID column. This constructor is mainly for internal use.
    */
@@ -81,7 +75,7 @@ public class Column<T> {
   /**
    * Change table alias.
    */
-  <K> Column<K> forTable(String tableAlias) {
+  Column<T> forTable(String tableAlias) {
     return new Column<>(tableAlias, this.field, type);
   }
 
@@ -95,6 +89,20 @@ public class Column<T> {
 
   public Class getType() {
     return type;
+  }
+
+  /**
+   * @return SQL keyword for select clause.
+   */
+  String getSelectKeyword() {
+    return getSqlKeyword();
+  }
+
+  /**
+   * @return column alias for select clause.
+   */
+  String getSelectAlias() {
+    return getSqlKeyword();
   }
 
   public String getSqlKeyword() {
@@ -311,7 +319,7 @@ public class Column<T> {
 
   public GenericConstraint notIn(T value, T... otherValues) {
     if (isDateColumn()) {
-      return createDateConstraint(new NotIn<>((Long) value, Arrays.copyOf(otherValues, otherValues.length, Long[].class)));
+      return createDateConstraint(new NotIn<>((Long)value, Arrays.copyOf(otherValues, otherValues.length, Long[].class)));
     } else {
       return new GenericConstraint<>(this, new NotIn<>(value, otherValues));
     }

--- a/jack-core/src/com/rapleaf/jack/queries/GenericInsertion.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericInsertion.java
@@ -131,7 +131,7 @@ public class GenericInsertion extends AbstractExecution {
   }
 
   private String getColumnsClause() {
-    return getClauseFromColumns(values.keySet(), "(", ", ", ") ");
+    return getClauseFromColumns(values.keySet(), Column::getSqlKeyword, "(", ", ", ") ");
   }
 
   private String getValuesClause() {

--- a/jack-core/src/com/rapleaf/jack/queries/GenericQuery.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericQuery.java
@@ -156,7 +156,7 @@ public class GenericQuery extends AbstractExecution {
     return this;
   }
 
-  public GenericQuery select(AbstractTable table, AbstractTable... tbls){
+  public GenericQuery select(AbstractTable table, AbstractTable... tbls) {
     this.selectedColumns.addAll(table.getAllColumns());
     for (AbstractTable tbl : tbls) {
       this.selectedColumns.addAll(tbl.getAllColumns());
@@ -290,7 +290,7 @@ public class GenericQuery extends AbstractExecution {
       }
     }
     String initialKeyword = selectDistinct ? "SELECT DISTINCT " : "SELECT ";
-    return getClauseFromColumns(selectedColumns, initialKeyword, ", ", " ");
+    return getClauseFromColumns(selectedColumns, Column::getSelectKeyword, initialKeyword, ", ", " ");
   }
 
   private String getFromClause() {
@@ -306,7 +306,7 @@ public class GenericQuery extends AbstractExecution {
   }
 
   private String getGroupByClause() {
-    return getClauseFromColumns(groupByColumns, "GROUP BY ", ", ", " ");
+    return getClauseFromColumns(groupByColumns, Column::getSqlKeyword, "GROUP BY ", ", ", " ");
   }
 
   private String getOrderClause() {

--- a/jack-core/src/com/rapleaf/jack/queries/QueryFetcher.java
+++ b/jack-core/src/com/rapleaf/jack/queries/QueryFetcher.java
@@ -5,8 +5,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLRecoverableException;
 import java.sql.Timestamp;
-import java.util.Map;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableMap;
@@ -75,7 +75,7 @@ public class QueryFetcher extends BaseFetcher {
 
     Record record = new Record(selectedColumns.size());
     for (Column column : selectedColumns) {
-      String sqlKeyword = column.getSqlKeyword();
+      String sqlKeyword = column.getSelectAlias();
       Class type = column.getType();
       Object value;
       ItemGetter itemGetter = ITEM_GETTERS.containsKey(type) ? ITEM_GETTERS.get(type) : ResultSet::getObject;

--- a/jack-test/test/java/com/rapleaf/jack/queries/TestAggregatedColumn.java
+++ b/jack-test/test/java/com/rapleaf/jack/queries/TestAggregatedColumn.java
@@ -1,0 +1,36 @@
+package com.rapleaf.jack.queries;
+
+import org.junit.Test;
+
+import com.rapleaf.jack.test_project.database_1.models.User;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestAggregatedColumn {
+  @Test
+  public void testAs() {
+    AggregatedColumn<Long> maxUserId = AggregatedColumn.MAX(User.ID);
+    assertEquals(Long.class, maxUserId.type);
+    assertEquals(Integer.class, maxUserId.as(Integer.class).type);
+  }
+
+  @Test
+  public void testForTable() {
+    AggregatedColumn<Long> maxUserId = AggregatedColumn.MAX(User.ID);
+    assertEquals("users", maxUserId.table);
+
+    AggregatedColumn<Long> aliasedTable = maxUserId.forTable("user_table");
+    // table name is updated
+    assertEquals("user_table", aliasedTable.table);
+    // table field and type are the same
+    assertEquals(maxUserId.field, aliasedTable.field);
+    assertEquals(maxUserId.type, aliasedTable.type);
+  }
+
+  @Test
+  public void testGetSqlKeyword() {
+    assertEquals("MAX(users.id) AS users_id_max", AggregatedColumn.MAX(User.ID).getSelectKeyword());
+    assertEquals("users_id_max", AggregatedColumn.MAX(User.ID).getSelectAlias());
+    assertEquals("MAX(users.id)", AggregatedColumn.MAX(User.ID).getSqlKeyword());
+  }
+}

--- a/jack-test/test/java/com/rapleaf/jack/queries/TestColumn.java
+++ b/jack-test/test/java/com/rapleaf/jack/queries/TestColumn.java
@@ -1,0 +1,54 @@
+package com.rapleaf.jack.queries;
+
+import org.junit.Test;
+
+import com.rapleaf.jack.test_project.database_1.models.User;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestColumn {
+  @Test
+  public void testAs() {
+    assertEquals(Long.class, User.ID.type);
+    assertEquals(Integer.class, User.ID.as(Integer.class).type);
+  }
+
+  @Test
+  public void testForTable() {
+    assertEquals("users", User.ID.table);
+    assertEquals("user_table", User.ID.forTable("user_table").table);
+  }
+
+  @Test
+  public void testSqlKeywordMethods() {
+    // id column
+    Column<Long> nullTableIdColumn = Column.fromId(null);
+    assertEquals("id", nullTableIdColumn.getSelectKeyword());
+    assertEquals("id", nullTableIdColumn.getSelectAlias());
+    assertEquals("id", nullTableIdColumn.getSqlKeyword());
+
+    assertEquals("users.id", User.ID.getSelectKeyword());
+    assertEquals("users.id", User.ID.getSelectAlias());
+    assertEquals("users.id", User.ID.getSqlKeyword());
+
+    Column<Long> aliasedIdColumn = User.Tbl.as("user_table").ID;
+    assertEquals("user_table.id", aliasedIdColumn.getSelectKeyword());
+    assertEquals("user_table.id", aliasedIdColumn.getSelectAlias());
+    assertEquals("user_table.id", aliasedIdColumn.getSqlKeyword());
+
+    // non id column
+    Column<String> nullTableColumn = Column.fromField(null, User._Fields.bio, String.class);
+    assertEquals("bio", nullTableColumn.getSelectKeyword());
+    assertEquals("bio", nullTableColumn.getSelectAlias());
+    assertEquals("bio", nullTableColumn.getSqlKeyword());
+
+    assertEquals("users.bio", User.BIO.getSelectKeyword());
+    assertEquals("users.bio", User.BIO.getSelectAlias());
+    assertEquals("users.bio", User.BIO.getSqlKeyword());
+
+    Column<String> aliasedColumn = User.Tbl.as("user_table").BIO;
+    assertEquals("user_table.bio", aliasedColumn.getSelectKeyword());
+    assertEquals("user_table.bio", aliasedColumn.getSelectAlias());
+    assertEquals("user_table.bio", aliasedColumn.getSqlKeyword());
+  }
+}

--- a/jack-test/test/java/com/rapleaf/jack/queries/TestColumn.java
+++ b/jack-test/test/java/com/rapleaf/jack/queries/TestColumn.java
@@ -16,7 +16,11 @@ public class TestColumn {
   @Test
   public void testForTable() {
     assertEquals("users", User.ID.table);
+    // table name is updated
     assertEquals("user_table", User.ID.forTable("user_table").table);
+    // table field and type are the same
+    assertEquals(User.ID.field, User.ID.forTable("user_table").field);
+    assertEquals(User.ID.type, User.ID.forTable("user_table").type);
   }
 
   @Test

--- a/jack-test/test/java/com/rapleaf/jack/queries/TestSubQuery.java
+++ b/jack-test/test/java/com/rapleaf/jack/queries/TestSubQuery.java
@@ -258,4 +258,26 @@ public class TestSubQuery extends JackTestCase {
     assertEquals(postB, records.get(1).getModel(postTable.model(Post.TBL), db.getDatabases()));
   }
 
+  @Test
+  public void testAggregatedColumnSubQuery() throws Exception {
+    SubTable postTable = db.createQuery()
+        .from(Post.TBL)
+        .groupBy(Post.USER_ID)
+        .select(Post.USER_ID, AggregatedColumn.COUNT(Post.ID))
+        .asSubTable("post_table");
+
+    // both columns refer to "COUNT(posts.id)" for the subquery table
+    Column<Integer> postCountColumn1 = AggregatedColumn.COUNT(Post.ID).forTable("post_table");
+    Column<Integer> postCountColumn2 = postTable.column(AggregatedColumn.COUNT(Post.ID));
+
+    records = db.createQuery()
+        .from(postTable)
+        .select(postCountColumn1)
+        .fetch();
+
+    for (Record record : records) {
+      assertEquals(1, record.get(postCountColumn1).intValue());
+      assertEquals(1, record.get(postCountColumn2).intValue());
+    }
+  }
 }

--- a/jack-test/test/java/com/rapleaf/jack/queries/TestSubQuery.java
+++ b/jack-test/test/java/com/rapleaf/jack/queries/TestSubQuery.java
@@ -166,9 +166,9 @@ public class TestSubQuery extends JackTestCase {
 
     assertEquals(2, records.size());
     assertEquals(userB, records.get(0).getModel(subQuery.model(User.TBL), db.getDatabases()));
-    assertEquals(userB, records.get(0).getModel(User.TBL.alias("subQuery"), db.getDatabases()));
+    assertEquals(userB, records.get(0).getModel(User.Tbl.as("subQuery"), db.getDatabases()));
     assertEquals(userC, records.get(1).getModel(subQuery.model(User.TBL), db.getDatabases()));
-    assertEquals(userC, records.get(1).getModel(User.TBL.alias("subQuery"), db.getDatabases()));
+    assertEquals(userC, records.get(1).getModel(User.Tbl.as("subQuery"), db.getDatabases()));
 
     /*
      * sub query with select clause
@@ -251,10 +251,10 @@ public class TestSubQuery extends JackTestCase {
 
     assertEquals(2, records.size());
     assertEquals(userC, records.get(0).getModel(User.TBL, db.getDatabases()));
-    assertEquals(postC, records.get(0).getModel(Post.TBL.alias("post_table"), db.getDatabases()));
+    assertEquals(postC, records.get(0).getModel(Post.Tbl.as("post_table"), db.getDatabases()));
     assertEquals(postC, records.get(0).getModel(postTable.model(Post.TBL), db.getDatabases()));
     assertEquals(userB, records.get(1).getModel(User.TBL, db.getDatabases()));
-    assertEquals(postB, records.get(1).getModel(Post.TBL.alias("post_table"), db.getDatabases()));
+    assertEquals(postB, records.get(1).getModel(Post.Tbl.as("post_table"), db.getDatabases()));
     assertEquals(postB, records.get(1).getModel(postTable.model(Post.TBL), db.getDatabases()));
   }
 


### PR DESCRIPTION
@mark-idleman, this PR should allow us to use aggregated columns in subqueries and fix your query issue. An example is in `testAggregatedColumnSubQuery`.

The main idea is that the sql expression of a column should be different for different clauses:
1. Normally it is just the column name.
2. In select clause, when an alias is need, it is in the form of "column AS alias". This is necessary for aggregated columns within a subquery.
3. When retrieving the value from a `ResultSet`, it is just the alias.

I've compared a few implementations, and this one is the shortest that requires the least amount of refactoring.
