### PR TITLE
Create mariadb submodule

### DIFF
--- a/jack-mariadb/pom.xml
+++ b/jack-mariadb/pom.xml
@@ -1,0 +1,61 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>jack-mariadb</artifactId>
+  <version>1.2-SNAPSHOT</version>
+
+  <parent>
+    <groupId>com.liveramp</groupId>
+    <artifactId>jack</artifactId>
+    <version>1.2-SNAPSHOT</version>
+  </parent>
+
+  <properties>
+    <db.user>root</db.user>
+    <db.pass>""</db.pass>
+    <maven.compiler.source>1.8</maven.compiler.source>
+  </properties>
+
+  <scm>
+    <connection>scm:git:git@github.com:LiveRamp/jack.git</connection>
+    <url>scm:git:git@github.com:LiveRamp/jack.git</url>
+    <developerConnection>scm:git:git@github.com:LiveRamp/jack.git</developerConnection>
+    <tag>HEAD</tag>
+  </scm>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>jack-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.vorburger.mariaDB4j</groupId>
+      <artifactId>mariaDB4j</artifactId>
+      <version>2.4.0</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <directory>${basedir}/build</directory>
+    <sourceDirectory>${basedir}/src</sourceDirectory>
+
+    <plugins>
+      <plugin>
+        <artifactId>exec-maven-plugin</artifactId>
+        <groupId>org.codehaus.mojo</groupId>
+        <version>1.3.2</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <failIfNoTests>false</failIfNoTests>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/jack-mariadb/src/com/rapleaf/jack/mariadb/LazyLoadingSingletonFactory.java
+++ b/jack-mariadb/src/com/rapleaf/jack/mariadb/LazyLoadingSingletonFactory.java
@@ -1,0 +1,20 @@
+package com.rapleaf.jack.mariadb;
+
+import java.io.Serializable;
+
+public abstract class LazyLoadingSingletonFactory<T> implements Serializable {
+  volatile T instance;
+
+  protected abstract T create();
+
+  public T get() {
+    if (instance == null) {
+      synchronized (this) {
+        if (instance == null) {
+          instance = create();
+        }
+      }
+    }
+    return instance;
+  }
+}

--- a/jack-mariadb/src/com/rapleaf/jack/mariadb/MariaDatabaseConnection.java
+++ b/jack-mariadb/src/com/rapleaf/jack/mariadb/MariaDatabaseConnection.java
@@ -1,0 +1,28 @@
+package com.rapleaf.jack.mariadb;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+
+import com.rapleaf.jack.BaseDatabaseConnection;
+
+public class MariaDatabaseConnection extends BaseDatabaseConnection {
+  private final String connectionString;
+
+  public MariaDatabaseConnection(String connectionString) {
+    this.connectionString = connectionString;
+  }
+
+  @Override
+  public Connection getConnectionInternal() {
+    try {
+      if (conn == null) {
+        conn = DriverManager.getConnection(connectionString, "root", "");
+      } else if (conn.isClosed()) {
+        resetConnection();
+      }
+      return conn;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/jack-mariadb/src/com/rapleaf/jack/mariadb/MariaDatabaseSingletonProvider.java
+++ b/jack-mariadb/src/com/rapleaf/jack/mariadb/MariaDatabaseSingletonProvider.java
@@ -1,0 +1,26 @@
+package com.rapleaf.jack.mariadb;
+
+import ch.vorburger.exec.ManagedProcessException;
+import ch.vorburger.mariadb4j.DB;
+
+public class MariaDatabaseSingletonProvider extends LazyLoadingSingletonFactory<DB> {
+  private final String dbName;
+
+  public MariaDatabaseSingletonProvider(String dbName) {
+    this.dbName = dbName;
+  }
+
+  @Override
+  protected DB create() {
+    try {
+      DB database = MariaServerSingletonProvider.INSTANCE.get();
+
+      database.createDB(dbName);
+      database.source(dbName + ".dump", dbName);
+
+      return database;
+    } catch (ManagedProcessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/jack-mariadb/src/com/rapleaf/jack/mariadb/MariaDatabasesImpl.java
+++ b/jack-mariadb/src/com/rapleaf/jack/mariadb/MariaDatabasesImpl.java
@@ -1,0 +1,43 @@
+package com.rapleaf.jack.mariadb;
+
+import ch.vorburger.mariadb4j.DB;
+
+import com.rapleaf.jack.BaseDatabaseConnection;
+import com.rapleaf.jack.GenericDatabases;
+import com.rapleaf.jack.IDb;
+import com.rapleaf.jack.transaction.TransactorImpl;
+
+public class MariaDatabasesImpl<Database extends IDb> implements GenericDatabases {
+  private String dbName;
+
+  public interface DbBuilder<Database extends IDb> {
+    Database getDb(BaseDatabaseConnection conn, MariaDatabasesImpl<Database> genericDatabases);
+  }
+
+  private Database db;
+
+  private final DbBuilder<Database> dbBuilder;
+  private final LazyLoadingSingletonFactory<DB> dbSpecificMariaProvider;
+
+  public MariaDatabasesImpl(DbBuilder<Database> dbBuilder, LazyLoadingSingletonFactory<DB> dbSpecificMariaProvider, String dbName) {
+    this.dbBuilder = dbBuilder;
+    this.dbSpecificMariaProvider = dbSpecificMariaProvider;
+    this.dbName = dbName;
+  }
+
+  public Database getDb() {
+    if (db == null) {
+      try {
+        DB database = dbSpecificMariaProvider.get();
+        db = dbBuilder.getDb(new MariaDatabaseConnection(database.getConfiguration().getURL(dbName)), this);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+    return db;
+  }
+
+  public TransactorImpl.Builder<Database> getDbTransactor() {
+    return TransactorImpl.create(() -> new MariaDatabasesImpl<>(dbBuilder, dbSpecificMariaProvider, dbName).getDb());
+  }
+}

--- a/jack-mariadb/src/com/rapleaf/jack/mariadb/MariaServerSingletonProvider.java
+++ b/jack-mariadb/src/com/rapleaf/jack/mariadb/MariaServerSingletonProvider.java
@@ -1,0 +1,48 @@
+package com.rapleaf.jack.mariadb;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.UUID;
+
+import ch.vorburger.mariadb4j.DB;
+import ch.vorburger.mariadb4j.DBConfiguration;
+import ch.vorburger.mariadb4j.DBConfigurationBuilder;
+
+public class MariaServerSingletonProvider extends LazyLoadingSingletonFactory<DB> {
+  public static final MariaServerSingletonProvider INSTANCE = new MariaServerSingletonProvider();
+
+  private MariaServerSingletonProvider() {
+    // no-op, only used to force people to use a single instance per JVM
+  }
+
+  private static int getOpenPort() throws IOException {
+    ServerSocket socket = new ServerSocket(0);
+    int port = socket.getLocalPort();
+    socket.close();
+    return port;
+  }
+
+  @Override
+  public DB create() {
+    try {
+      int port = getOpenPort();
+      String uuid = UUID.randomUUID().toString();
+      String basePath = "/tmp/MariaDB4j/";
+      String tempBaseDir = basePath + "base/" + uuid;
+      String tempDataDir = basePath + "data/" + uuid;
+
+      DBConfiguration config = DBConfigurationBuilder.newBuilder()
+          .setPort(port)
+          .setBaseDir(tempBaseDir)
+          .setDataDir(tempDataDir)
+          .build();
+
+      DB database = DB.newEmbeddedDB(config);
+      database.start();
+
+      return database;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     <module>jack-redshift</module>
     <module>jack-store</module>
     <module>jack-test</module>
+    <module>jack-mariadb</module>
   </modules>
 
   <repositories>


### PR DESCRIPTION
@jrhizor, I think a lot of the boilerplate code for mariadb can be extracted into a submodule in jack. The only thing that is needed from the user is the `InMemoryDb` class. What do you think?
