### PR TITLE
Fix sonatype branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 source "http://rubygems.org"
+
+ruby '2.3.0'
+
 gem "activesupport", "~> 4.1"
 gem "i18n", "~> 0.9"
 gem 'fattr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,5 +40,8 @@ DEPENDENCIES
   i18n (~> 0.9)
   rspec (~> 3.7)
 
+RUBY VERSION
+   ruby 2.3.0p0
+
 BUNDLED WITH
    1.16.1

--- a/jack-core/src/Gemfile
+++ b/jack-core/src/Gemfile
@@ -1,4 +1,7 @@
 source "http://rubygems.org"
+
+ruby '2.3.0'
+
 gem "activesupport", "~> 4.1"
 gem "i18n", "~> 0.9"
 gem 'fattr'

--- a/jack-core/src/Gemfile.lock
+++ b/jack-core/src/Gemfile.lock
@@ -25,5 +25,8 @@ DEPENDENCIES
   fattr
   i18n (~> 0.9)
 
+RUBY VERSION
+   ruby 2.3.0p0
+
 BUNDLED WITH
    1.16.1


### PR DESCRIPTION
There are two ways to fix it.
1. Enforce the build and deploy to use ruby `2.3.0`.
2. Upgrade `activesupport` to `4.2.8`.
