### PR TITLE
Mark model query & delete constructors as package private

### DIFF
--- a/jack-core/src/com/rapleaf/jack/queries/ModelDelete.java
+++ b/jack-core/src/com/rapleaf/jack/queries/ModelDelete.java
@@ -8,7 +8,10 @@ import java.util.Collection;
 public class ModelDelete {
   private WhereClause whereClause;
 
-  public ModelDelete() {
+  /**
+   * This class should only be constructed in {@link AbstractDeleteBuilder}.
+   */
+  ModelDelete() {
     this.whereClause = new WhereClause();
   }
 

--- a/jack-core/src/com/rapleaf/jack/queries/ModelQuery.java
+++ b/jack-core/src/com/rapleaf/jack/queries/ModelQuery.java
@@ -17,7 +17,10 @@ public class ModelQuery {
   private List<Enum> groupByFields;
   private Optional<LimitCriterion> limitCriterion;
 
-  public ModelQuery() {
+  /**
+   * This class should only be constructed in {@link AbstractQueryBuilder}.
+   */
+  ModelQuery() {
     this.whereClause = new WhereClause();
     this.orderCriteria = new ArrayList<>();
     this.selectedFields = new ArrayList<>();

--- a/jack-test/test/java/com/rapleaf/jack/queries/TestModelDelete.java
+++ b/jack-test/test/java/com/rapleaf/jack/queries/TestModelDelete.java
@@ -1,4 +1,4 @@
-package com.rapleaf.jack;
+package com.rapleaf.jack.queries;
 
 import java.io.IOException;
 import java.sql.SQLException;

--- a/jack-test/test/java/com/rapleaf/jack/queries/TestModelQuery.java
+++ b/jack-test/test/java/com/rapleaf/jack/queries/TestModelQuery.java
@@ -1,4 +1,4 @@
-package com.rapleaf.jack;
+package com.rapleaf.jack.queries;
 
 import java.io.IOException;
 import java.sql.SQLException;


### PR DESCRIPTION
It can be dangerous to expose `ModelDelete` to users directly. This PR hides the constructor and force users to construct query or deletion through the model.
