### PR TITLE
Allow deleting multiple records of a model at once

### DIFF
--- a/jack-core/src/com/rapleaf/jack/IModelPersistence.java
+++ b/jack-core/src/com/rapleaf/jack/IModelPersistence.java
@@ -102,6 +102,11 @@ public interface IModelPersistence<T extends ModelWithId> extends Serializable {
   boolean delete(long id) throws IOException;
 
   /**
+   * @return true if all records deleted, false otherwise
+   */
+  boolean delete(Collection<Long> ids) throws IOException;
+
+  /**
    * Delete all records in this persistence.
    *
    * @return

--- a/jack-test/test/java/com/rapleaf/jack/BaseDatabaseModelTestCase.java
+++ b/jack-test/test/java/com/rapleaf/jack/BaseDatabaseModelTestCase.java
@@ -501,13 +501,23 @@ public abstract class BaseDatabaseModelTestCase {
   }
 
   @Test
-  public void testDelete() throws Exception {
+  public void testDeleteSingle() throws Exception {
     IPostPersistence posts = dbs.getDatabase1().posts();
     Post post = posts.create(null, 10L, 1, 0l);
     long id = post.getId();
     posts.delete(id);
     assertNull(posts.find(id));
   }
+
+  @Test
+  public void testDeleteMultiple() throws Exception {
+    IPostPersistence posts = dbs.getDatabase1().posts();
+    long post1 = posts.create(null, 10L, 1, 0l).getId();
+    long post2 = posts.create(null, 10L, 1, 0l).getId();
+    posts.delete(Arrays.asList(post1, post2));
+    assertTrue(posts.find(Arrays.asList(post1, post2)).isEmpty());
+  }
+
 
   @Test
   public void testSave() throws Exception {


### PR DESCRIPTION
Moving this up to the top-level allows us to write code that abstracts
over all Jack models and supports deletes for multiple IDs. This
seems reasonable since we do have `delete(long id)`.