### PR TITLE
Validate connections before using them and expose validation as config.

### DIFF
--- a/jack-core/pom.xml
+++ b/jack-core/pom.xml
@@ -71,6 +71,8 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-pool2</artifactId>
+      <!-- Be careful about updating this dependency to anything greater than 2.4.2. -->
+      <!-- See https://github.com/LiveRamp/jack/issues/195#issuecomment-455738622 -->
       <version>2.4.2</version>
     </dependency>
 

--- a/jack-test/config/database.mysql.yml
+++ b/jack-test/config/database.mysql.yml
@@ -6,3 +6,5 @@ jack_database1:
   host: 127.0.0.1
   pool: 5
   timeout: 5000
+  connection_max_retries: 3
+  connection_validation_timeout: 1

--- a/jack-test/test/test_project/database_1/config/database.mysql.yml
+++ b/jack-test/test/test_project/database_1/config/database.mysql.yml
@@ -6,3 +6,5 @@ development:
   host: 127.0.0.1
   pool: 5
   timeout: 5000
+  connection_max_retries: 3
+  connection_validation_timeout: 1


### PR DESCRIPTION
`isClosed` is not sufficient to validate connections. You need to check that they are actually still usable, which is what `isValid` does. This PR prevents applications from seeing issues when databases failover and connections are no longer valid. 