### PR TITLE
add fetchAsStream method comment

### DIFF
--- a/jack-core/src/com/rapleaf/jack/queries/GenericQuery.java
+++ b/jack-core/src/com/rapleaf/jack/queries/GenericQuery.java
@@ -219,6 +219,11 @@ public class GenericQuery extends AbstractExecution {
     }
   }
 
+  /***
+   * For cases where you don't want sql to send all the records at once. This is NOT just a convenience method to use
+   * java streams, this is using JDBC built-in streaming
+   * https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-implementation-notes.html
+   */
   public Stream<Record> fetchAsStream() throws IOException {
     int retryCount = 0;
     final QueryStatistics.Measurer statTracker = new QueryStatistics.Measurer();


### PR DESCRIPTION
I've seen this method being used as a convenience method to use java streams, but in fact, it's doing way more than that. Added a comment to be more specific on what this method is doing.