### PR TITLE
Fix connection leak caused by exceptions during rollback.

### DIFF
--- a/jack-core/src/com/rapleaf/jack/transaction/DbPoolManager.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/DbPoolManager.java
@@ -130,6 +130,19 @@ class DbPoolManager<DB extends IDb> implements IDbManager<DB> {
   }
 
   @Override
+  public void invalidateConnection(final DB connection) {
+    try {
+      if (metricsTrackingEnabled) {
+        metrics.update(false, connectionPool);
+      }
+      connectionPool.invalidateObject(connection);
+      metrics.update(false, connectionPool);
+    } catch (Exception e) {
+      LOG.error("Failed to invalidate connection. This will likely lead to a connection leak!", e);
+    }
+  }
+
+  @Override
   public void close() {
     connectionPool.close();
   }

--- a/jack-core/src/com/rapleaf/jack/transaction/IDbManager.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/IDbManager.java
@@ -8,7 +8,17 @@ interface IDbManager<DB extends IDb> extends Closeable {
 
   DB getConnection();
 
+  /**
+   * Returns a connection to the connection pool, potentially allowing it to be reused in the
+   * future.
+   */
   void returnConnection(DB connection);
+
+  /**
+   * Explicitly signals that the pooled connection is being returned, but should not be used in any
+   * way in the future.
+   */
+  void invalidateConnection(DB connection);
 
   @Override
   void close();

--- a/jack-core/src/com/rapleaf/jack/transaction/TransactorImpl.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/TransactorImpl.java
@@ -7,7 +7,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
-import java.util.Optional;
 import java.util.concurrent.Callable;
 
 /**
@@ -74,6 +73,8 @@ public class TransactorImpl<DB extends IDb> implements ITransactor<DB> {
 
   private <T> T query(IQuery<DB, T> query, boolean asTransaction) {
     DB connection = dbManager.getConnection();
+    boolean connectionSafeToReturn = true;
+
     try {
       connection.setAutoCommit(!asTransaction);
       long startTime = System.currentTimeMillis();
@@ -86,38 +87,43 @@ public class TransactorImpl<DB extends IDb> implements ITransactor<DB> {
         queryMetrics.update(executionTime, Thread.currentThread().getStackTrace()[3]);
       }
 
-      // We don't return the connection in a finally block because we don't want to
-      // do so in the case that a Throwable is thrown. In that case, the JVM is almost certainly
-      // about to exit, so returning the connection isn't important and in some cases can actually
-      // cause harm like committing a half-complete transaction (part of returning the connection is setting
-      // its autocommit property to true, which would commit a half-complete transaction).
-      dbManager.returnConnection(connection);
       return value;
     } catch (Exception e) {
       LOG.error("SQL execution failure", e);
       if (asTransaction) {
-        try {
-          connection.rollback();
-        } catch (Exception e2) {
-          LOG.warn("Failed to rollback an active transaction", e2);
-          // ignore. We can't actually do anything about this, and we need to return the connection
-          // to the pool under all circumstances where the application will continue running
-          // otherwise we will slowly leak connections until all connections are exhausted from the
-          // pool and will never be returned.
-        }
+        connectionSafeToReturn = tryToSafelyRollback(connection);
       }
 
-      dbManager.returnConnection(connection);
       throw new SqlExecutionFailureException(e);
     } catch (Throwable t) {
-
       // We still try to explicitly rollback the transaction if a throwable is thrown.
       if (asTransaction) {
-        connection.rollback();
+        connectionSafeToReturn = tryToSafelyRollback(connection);
       }
 
       throw t;
+    } finally {
+      if (connectionSafeToReturn) {
+        dbManager.returnConnection(connection);
+      } else {
+        dbManager.invalidateConnection(connection);
+      }
     }
+  }
+
+  /**
+   * @param connection The connection to rollback
+   * @return True if the connection was successfully rolled back. False if it failed to rollback.
+   */
+  private boolean tryToSafelyRollback(DB connection) {
+    try {
+      connection.rollback();
+    } catch (Exception e) {
+      LOG.warn("Failed to rollback an active transaction", e);
+      return false;
+    }
+
+    return true;
   }
 
   private void execute(IExecution<DB> execution, boolean asTransaction) {

--- a/jack-test/test/java/com/rapleaf/jack/transaction/TestDbPoolManager.java
+++ b/jack-test/test/java/com/rapleaf/jack/transaction/TestDbPoolManager.java
@@ -194,6 +194,20 @@ public class TestDbPoolManager extends JackTestCase {
     executorService.shutdownNow();
   }
 
+  @Test
+  public void testInvalidatingConnectionRemovesItFromThePool() {
+    maxConnections = 1;
+    initializeDbPoolManager();
+
+    IDatabase1 connection = dbPoolManager.getConnection();
+    assertActiveConnections(maxConnections);
+    assertIdleConnections(0);
+
+    dbPoolManager.invalidateConnection(connection);
+    assertActiveConnections(0);
+    assertIdleConnections(0);
+  }
+
   private void getAllConnections() {
     for (int i = 0; i < maxConnections; ++i) {
       dbPoolManager.getConnection();


### PR DESCRIPTION
If an exception is thrown while attempting to rollback a transaction,
then the connection is never returned to the connection pool. This
slowly leaks connections until there are none left.