### PR TITLE
Allow clients to request the transactor to retry queries

### DIFF
--- a/jack-core/src/com/rapleaf/jack/transaction/ITransactor.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/ITransactor.java
@@ -6,12 +6,18 @@ import com.rapleaf.jack.IDb;
 
 public interface ITransactor<DB extends IDb> extends Closeable {
 
-  <T> T query(IQuery<DB, T> query);
+  ITransactor<DB> asTransaction();
 
-  <T> T queryAsTransaction(IQuery<DB, T> query);
+  ITransactor<DB> allowRetries(RetryPolicy retryPolicy);
+
+  <T> T query(IQuery<DB, T> query);
 
   void execute(IExecution<DB> execution);
 
+  @Deprecated
+  <T> T queryAsTransaction(IQuery<DB, T> query);
+
+  @Deprecated
   void executeAsTransaction(IExecution<DB> execution);
 
   @Override
@@ -23,4 +29,14 @@ public interface ITransactor<DB extends IDb> extends Closeable {
     Impl get();
   }
 
+  interface RetryPolicy {
+
+    boolean shouldRetry();
+
+    void updateOnFailure();
+
+    void updateOnSuccess();
+
+    void execute();
+  }
 }

--- a/jack-core/src/com/rapleaf/jack/transaction/ITransactor.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/ITransactor.java
@@ -31,12 +31,10 @@ public interface ITransactor<DB extends IDb> extends Closeable {
 
   interface RetryPolicy {
 
-    boolean shouldRetry();
+    void onFailure(Exception cause);
 
-    void updateOnFailure();
+    void onSuccess();
 
-    void updateOnSuccess();
-
-    void execute();
+    boolean execute();
   }
 }

--- a/jack-core/src/com/rapleaf/jack/transaction/TransactorImpl.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/TransactorImpl.java
@@ -126,6 +126,10 @@ public class TransactorImpl<DB extends IDb> implements ITransactor<DB> {
         } else {
           dbManager.invalidateConnection(connection);
         }
+        /*
+         * {@link RetryPolicy.execute} is very likely to block (sleep or perform a long running task);
+         * We make sure it is called only after the connection has been invalidated/returned to the pool.
+         */
         context.retryPolicy.execute();
       }
     }

--- a/jack-core/src/com/rapleaf/jack/transaction/TransactorImpl.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/TransactorImpl.java
@@ -9,7 +9,6 @@ import org.slf4j.LoggerFactory;
 
 import com.rapleaf.jack.IDb;
 import com.rapleaf.jack.exception.SqlExecutionFailureException;
-import com.rapleaf.jack.util.ExponentialBackoffRetryPolicy;
 
 /**
  * If there is any exception while executing the query, throws
@@ -177,6 +176,7 @@ public class TransactorImpl<DB extends IDb> implements ITransactor<DB> {
 
     @Override
     public ITransactor<DB> allowRetries(RetryPolicy retryPolicy) {
+      Preconditions.checkArgument(retryPolicy != null);
       this.retryPolicy = retryPolicy;
       return this;
     }
@@ -217,7 +217,25 @@ public class TransactorImpl<DB extends IDb> implements ITransactor<DB> {
     }
   }
 
-  class NoRetryPolicy extends ExponentialBackoffRetryPolicy {}
+  public static class NoRetryPolicy implements ITransactor.RetryPolicy {
+
+    @Override
+    public boolean shouldRetry() {
+      return false;
+    }
+
+    @Override
+    public void updateOnFailure() {
+    }
+
+    @Override
+    public void updateOnSuccess() {
+    }
+
+    @Override
+    public void execute() {
+    }
+  }
 
   public static class Builder<DB extends IDb> implements ITransactor.Builder<DB, TransactorImpl<DB>> {
 

--- a/jack-core/src/com/rapleaf/jack/transaction/TransactorImpl.java
+++ b/jack-core/src/com/rapleaf/jack/transaction/TransactorImpl.java
@@ -163,7 +163,7 @@ public class TransactorImpl<DB extends IDb> implements ITransactor<DB> {
     return this.dbManager.getDbPoolStatus();
   }
 
-  class ExecutionContext implements ITransactor<DB> {
+  private class ExecutionContext implements ITransactor<DB> {
 
     boolean asTransaction = false;
     RetryPolicy retryPolicy = new NoRetryPolicy();

--- a/jack-core/src/com/rapleaf/jack/util/ExponentialBackoffRetryPolicy.java
+++ b/jack-core/src/com/rapleaf/jack/util/ExponentialBackoffRetryPolicy.java
@@ -1,0 +1,75 @@
+package com.rapleaf.jack.util;
+
+import java.util.Random;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.rapleaf.jack.transaction.ITransactor;
+
+public class ExponentialBackoffRetryPolicy implements ITransactor.RetryPolicy {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ExponentialBackoffRetryPolicy.class);
+
+  private int maxRetries = 0;
+  private int numFailures = 0;
+  private int retryInterval = 0;
+  private boolean succeeded = false;
+
+  public ExponentialBackoffRetryPolicy() {
+  }
+
+  public ExponentialBackoffRetryPolicy(int maxRetries) {
+    this(maxRetries, new Random().nextInt(5000) + 10000);
+  }
+
+  public ExponentialBackoffRetryPolicy(int maxRetries, int retryIntervalMs) {
+    Preconditions.checkArgument(retryIntervalMs > 0, "Retry interval must be greater than 0 ms.");
+    Preconditions.checkArgument(maxRetries > 0, "Number of retries must be greater than 0.");
+    this.maxRetries = maxRetries;
+    this.retryInterval = retryIntervalMs;
+  }
+
+  @Override
+  public boolean shouldRetry() {
+    return (!succeeded && numFailures > 0 && numFailures <= maxRetries);
+  }
+
+  @Override
+  public void updateOnFailure() {
+    ++numFailures;
+  }
+
+  @Override
+  public void updateOnSuccess() {
+    succeeded = true;
+  }
+
+  @Override
+  public void execute() {
+    if (shouldRetry()) {
+      LOG.warn("Retry #" + numFailures + ": Going to sleep for " + retryInterval + " milliseconds.");
+      sleep(retryInterval);
+      retryInterval <<= 1;
+    }
+  }
+
+  @VisibleForTesting
+  protected void sleep(int duration) {
+    try {
+      Thread.sleep(duration);
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  protected int getMaxRetries() {
+    return maxRetries;
+  }
+
+  protected int getRetryInterval() {
+    return retryInterval;
+  }
+}

--- a/jack-test/test/java/com/rapleaf/jack/transaction/TestDbTransactorImplRetry.java
+++ b/jack-test/test/java/com/rapleaf/jack/transaction/TestDbTransactorImplRetry.java
@@ -1,0 +1,75 @@
+package com.rapleaf.jack.transaction;
+
+import java.sql.SQLRecoverableException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.rapleaf.jack.IDb;
+import com.rapleaf.jack.exception.SqlExecutionFailureException;
+import com.rapleaf.jack.test_project.DatabasesImpl;
+import com.rapleaf.jack.test_project.database_1.IDatabase1;
+import com.rapleaf.jack.util.TestQueryRetryPolicy;
+
+public class TestDbTransactorImplRetry extends TestQueryRetryPolicy {
+
+  private TransactorImpl.Builder<IDatabase1> transactorBuilder = new DatabasesImpl().getDatabase1Transactor();
+
+  @Before
+  public void prepare() throws Exception {
+    transactorBuilder.get().query(IDb::deleteAll);
+  }
+
+  @Override
+  @Test(expected = SqlExecutionFailureException.class)
+  public void testNoRetriesOnFailure() {
+    super.testNoRetriesOnFailure();
+  }
+
+  @Override
+  @Test(expected = SqlExecutionFailureException.class)
+  public void testFailuresExceedingMaxRetries() {
+    super.testFailuresExceedingMaxRetries();
+  }
+
+  @Override
+  @Test(expected = SqlExecutionFailureException.class)
+  public void testTwiceTheFailuresAsMaxRetries() {
+    super.testTwiceTheFailuresAsMaxRetries();
+  }
+
+  @Override
+  protected void testRetriesInternal(int numFailures, int maxRetries) {
+    AtomicInteger failCount = new AtomicInteger(0);
+    AtomicInteger queryCount = new AtomicInteger(0);
+    TransactorImpl<IDatabase1> transactor = transactorBuilder.get();
+    ITransactor.RetryPolicy policy = Mockito.mock(ITransactor.RetryPolicy.class);
+    IQuery<IDatabase1, Integer> query = Mockito.mock(IQuery.class);
+
+    Mockito.doAnswer(x -> failCount.incrementAndGet()).when(policy).updateOnFailure();
+    Mockito.doAnswer(x -> (failCount.get() <= maxRetries)).when(policy).shouldRetry();
+    try {
+      Mockito.doAnswer(x -> {
+        if (queryCount.getAndIncrement() < numFailures) {
+          throw new SQLRecoverableException("Query Failed");
+        }
+        return 0;
+      }).when(query).query(Mockito.any(IDatabase1.class));
+    } catch (Exception e) {
+      /* Do Nothing */
+    }
+    try {
+      transactor.allowRetries(policy).query(query);
+      Mockito.verify(policy, Mockito.times(numFailures)).updateOnFailure();
+      Mockito.verify(policy, Mockito.times(1)).updateOnSuccess();
+    } catch (SqlExecutionFailureException se) {
+      Mockito.verify(policy, Mockito.times(maxRetries + 1)).updateOnFailure();
+      throw se;
+    } finally {
+      final int numExecutions = Math.min(numFailures, maxRetries) + 1;
+      Mockito.verify(policy, Mockito.times(numExecutions)).execute();
+    }
+  }
+}

--- a/jack-test/test/java/com/rapleaf/jack/transaction/TestDbTransactorImplRetry.java
+++ b/jack-test/test/java/com/rapleaf/jack/transaction/TestDbTransactorImplRetry.java
@@ -58,7 +58,8 @@ public class TestDbTransactorImplRetry extends TestQueryRetryPolicy {
         return 0;
       }).when(query).query(Mockito.any(IDatabase1.class));
     } catch (Exception e) {
-      /* Do Nothing */
+      /* This should not really happen */
+      throw new RuntimeException(e);
     }
     try {
       transactor.allowRetries(policy).query(query);
@@ -68,7 +69,7 @@ public class TestDbTransactorImplRetry extends TestQueryRetryPolicy {
       Mockito.verify(policy, Mockito.times(maxRetries + 1)).updateOnFailure();
       throw se;
     } finally {
-      final int numExecutions = Math.min(numFailures, maxRetries) + 1;
+      int numExecutions = Math.min(numFailures, maxRetries) + 1;
       Mockito.verify(policy, Mockito.times(numExecutions)).execute();
     }
   }

--- a/jack-test/test/java/com/rapleaf/jack/util/TestExponentialBackoffPolicy.java
+++ b/jack-test/test/java/com/rapleaf/jack/util/TestExponentialBackoffPolicy.java
@@ -1,0 +1,56 @@
+package com.rapleaf.jack.util;
+
+import org.junit.Assert;
+
+public class TestExponentialBackoffPolicy extends TestQueryRetryPolicy {
+
+  @Override
+  protected void testRetriesInternal(int numFailures, int maxRetries) {
+    int numRetries = Math.min(numFailures, maxRetries);
+    MockRetryPolicy policy = maxRetries == 0 ? new MockRetryPolicy() : new MockRetryPolicy(maxRetries);
+    int duration = numRetries == 0 ? 0 : (policy.getRetryInterval() << (numRetries - 1));
+
+    /* Policy should not execute when no failure has occurred (Initial Condition) */
+    Assert.assertFalse(policy.shouldRetry());
+    policy.execute();
+    Assert.assertEquals(0, policy.numSleepCalled);
+    Assert.assertEquals(0, policy.lastSleptDuration);
+
+    for (int i = 0; i < numFailures; ++i) {
+      policy.updateOnFailure();
+      Assert.assertEquals("Retry : " + (i + 1), i < maxRetries, policy.shouldRetry());
+      policy.execute();
+    }
+    if (numFailures <= maxRetries) {
+      policy.updateOnSuccess();
+    }
+    Assert.assertEquals(numRetries, policy.numSleepCalled);
+    Assert.assertEquals(duration, policy.lastSleptDuration);
+
+    /* Policy should not execute after a successful attempt or when retries have been exhausted (Final Condition) */
+    Assert.assertFalse(policy.shouldRetry());
+    policy.execute();
+    Assert.assertEquals(numRetries, policy.numSleepCalled);
+    Assert.assertEquals(duration, policy.lastSleptDuration);
+  }
+
+  private static class MockRetryPolicy extends ExponentialBackoffRetryPolicy {
+
+    int numSleepCalled = 0;
+    int lastSleptDuration = 0;
+
+    MockRetryPolicy() {
+      super();
+    }
+
+    MockRetryPolicy(int maxRetries) {
+      super(maxRetries);
+    }
+
+    @Override
+    protected void sleep(int duration) {
+      ++numSleepCalled;
+      lastSleptDuration = duration;
+    }
+  }
+}

--- a/jack-test/test/java/com/rapleaf/jack/util/TestExponentialBackoffPolicy.java
+++ b/jack-test/test/java/com/rapleaf/jack/util/TestExponentialBackoffPolicy.java
@@ -5,21 +5,33 @@ import java.util.Random;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.rapleaf.jack.exception.SqlExecutionFailureException;
+
 public class TestExponentialBackoffPolicy extends TestQueryRetryPolicy {
 
+  @Override
   @Test(expected = IllegalArgumentException.class)
   public void testNoRetriesAndNoFailures() {
     super.testNoRetriesAndNoFailures();
   }
 
+  @Override
   @Test(expected = IllegalArgumentException.class)
   public void testNoRetriesOnFailure() {
     super.testNoRetriesOnFailure();
   }
 
+  @Test(expected = IllegalStateException.class)
+  public void testRegisterFailureAfterSuccess() {
+    MockRetryPolicy policy = new MockRetryPolicy();
+    policy.onSuccess();
+    policy.onFailure(new Exception("Query Failed"));
+  }
+
   @Override
   protected void testRetriesInternal(int numFailures, int maxRetries) {
 
+    Exception exception = new Exception("Query Failed");
     int numRetries = Math.min(numFailures, maxRetries);
     MockRetryPolicy policy = new MockRetryPolicy();
     int duration = numRetries == 0 ? 0 : policy.getRetryInterval();
@@ -27,39 +39,38 @@ public class TestExponentialBackoffPolicy extends TestQueryRetryPolicy {
     policy.setMaxRetries(maxRetries);
     /* Set multiplier randomly in the range [1, 3] */
     policy.setMultiplier(1 + new Random().nextInt(2000) / 2000.0);
-
-    /* Policy should not execute when no failure has occurred (Initial Condition) */
-    Assert.assertFalse(policy.shouldRetry());
-    policy.execute();
-    Assert.assertEquals(0, policy.numSleepCalled);
-    Assert.assertEquals(0, policy.lastSleptDuration);
-
-    for (int i = 0; i < numFailures; ++i) {
-      policy.updateOnFailure();
-      Assert.assertEquals("Retry : " + (i + 1), i < maxRetries, policy.shouldRetry());
-      policy.execute();
-    }
-
     /* Cannot use Math.pow() here due to rounding errors */
     for (int i = 0; i < numRetries - 1; ++i) {
       duration *= policy.getMultiplier();
     }
 
-    if (numFailures <= maxRetries) {
-      policy.updateOnSuccess();
+    /* Policy should not execute when no failure has occurred (Initial Condition) */
+    Assert.assertFalse(policy.execute());
+    Assert.assertEquals(0, policy.numSleepCalled);
+    Assert.assertEquals(0, policy.lastSleptDuration);
+
+    try {
+      for (int i = 0; i < numFailures; ++i) {
+        policy.onFailure(exception);
+        Assert.assertTrue(policy.execute());
+      }
+      policy.onSuccess();
+    } catch (SqlExecutionFailureException se) {
+      Assert.assertEquals(se.getCause(), exception);
+      Assert.assertEquals(numRetries + 1, policy.numExecuteCalled);
     }
     Assert.assertEquals(numRetries, policy.numSleepCalled);
     Assert.assertEquals(duration, policy.lastSleptDuration);
 
     /* Policy should not execute after a successful attempt or when retries have been exhausted (Final Condition) */
-    Assert.assertFalse(policy.shouldRetry());
-    policy.execute();
+    Assert.assertFalse(policy.execute());
     Assert.assertEquals(numRetries, policy.numSleepCalled);
-    Assert.assertEquals("Multiplier: " + policy.getMultiplier(), duration, policy.lastSleptDuration);
+    Assert.assertEquals(duration, policy.lastSleptDuration);
   }
 
   private static class MockRetryPolicy extends ExponentialBackoffRetryPolicy {
 
+    int numExecuteCalled = 0;
     int numSleepCalled = 0;
     int lastSleptDuration = 0;
 
@@ -67,6 +78,12 @@ public class TestExponentialBackoffPolicy extends TestQueryRetryPolicy {
     protected void sleep(int duration) {
       ++numSleepCalled;
       lastSleptDuration = duration;
+    }
+
+    @Override
+    public boolean execute() {
+      ++numExecuteCalled;
+      return super.execute();
     }
   }
 }

--- a/jack-test/test/java/com/rapleaf/jack/util/TestQueryRetryPolicy.java
+++ b/jack-test/test/java/com/rapleaf/jack/util/TestQueryRetryPolicy.java
@@ -1,0 +1,52 @@
+package com.rapleaf.jack.util;
+
+import org.junit.Test;
+
+import com.rapleaf.jack.JackTestCase;
+
+public abstract class TestQueryRetryPolicy extends JackTestCase {
+
+  public final int RETRIES = 10;
+
+  @Test
+  public void testNoRetriesAndNoFailures() {
+    testRetriesInternal(0, 0);
+  }
+
+  @Test
+  public void testNoRetriesOnFailure() {
+    testRetriesInternal(RETRIES, 0);
+  }
+
+  @Test
+  public void testSuccessAtFirstAttempt() {
+    testRetriesInternal(0, RETRIES);
+  }
+
+  @Test
+  public void testFailuresEqualsRetries() {
+    testRetriesInternal(RETRIES, RETRIES);
+  }
+
+  @Test
+  public void testFailuresExceedingMaxRetries() {
+    testRetriesInternal(RETRIES + 1, RETRIES);
+  }
+
+  @Test
+  public void testTwiceTheFailuresAsMaxRetries() {
+    testRetriesInternal(RETRIES * 2, RETRIES);
+  }
+
+  @Test
+  public void testFailuresLowerThanMaxRetries() {
+    testRetriesInternal(RETRIES - 1, RETRIES);
+  }
+
+  @Test
+  public void testHalfTheFailuresAsMaxRetries() {
+    testRetriesInternal(RETRIES / 2, RETRIES);
+  }
+
+  protected abstract void testRetriesInternal(int numFailures, int maxRetries);
+}


### PR DESCRIPTION
This patch is inspired by #210 - It introduces `ExecutionContext` that allows clients to specify options for every query/update. Currently the two options supported are to run as a transaction (deprecates `queryAsTransaction` and `executeAsTransaction` methods) and set a retry policy on failure. The default behavior remains unchanged, namely, no retries on failure. However, clients can now use the new exponential backoff policy with tunable number of retries and sleep intervals. Users could potentially create their own advanced retry policies by implementing the `ITransactor.RetryPolicy` interface. The policy is executed on failure only after the connection has been invalidated or returned to the pool manager.  

*Example:*
```java
transactor
  .asTransaction()
  .allowRetries(new ExponentialBackoffRetryPolicy(numRetries, sleepInterval))
  .query(myQuery);
```
https://liveramp.atlassian.net/browse/DIST-2702