### PR TITLE
INGEST-2133, Update mysql-connector-java

### DIFF
--- a/jack-mysql/pom.xml
+++ b/jack-mysql/pom.xml
@@ -35,7 +35,6 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.22</version>
     </dependency>
 
   </dependencies>

--- a/jack-mysql/pom.xml
+++ b/jack-mysql/pom.xml
@@ -59,7 +59,6 @@
       <plugin>
         <artifactId>exec-maven-plugin</artifactId>
         <groupId>org.codehaus.mojo</groupId>
-        <version>1.3.2</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/jack-postgresql/pom.xml
+++ b/jack-postgresql/pom.xml
@@ -60,7 +60,6 @@
       <plugin>
         <artifactId>exec-maven-plugin</artifactId>
         <groupId>org.codehaus.mojo</groupId>
-        <version>1.3.2</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/jack-redshift/pom.xml
+++ b/jack-redshift/pom.xml
@@ -67,7 +67,6 @@
       <plugin>
         <artifactId>exec-maven-plugin</artifactId>
         <groupId>org.codehaus.mojo</groupId>
-        <version>1.3.2</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/jack-store/pom.xml
+++ b/jack-store/pom.xml
@@ -49,7 +49,6 @@
       <plugin>
         <artifactId>exec-maven-plugin</artifactId>
         <groupId>org.codehaus.mojo</groupId>
-        <version>1.3.2</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/jack-test/pom.xml
+++ b/jack-test/pom.xml
@@ -58,7 +58,6 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.22</version>
     </dependency>
 
     <dependency>

--- a/jack-test/pom.xml
+++ b/jack-test/pom.xml
@@ -97,7 +97,6 @@
       <plugin>
         <artifactId>exec-maven-plugin</artifactId>
         <groupId>org.codehaus.mojo</groupId>
-        <version>1.3.2</version>
         <executions>
           <!--run method+interface patcher-->
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,6 @@
       <plugin>
         <artifactId>exec-maven-plugin</artifactId>
         <groupId>org.codehaus.mojo</groupId>
-        <version>1.3.2</version>
       </plugin>
 
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,16 @@
     <module>jack-test</module>
   </modules>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>mysql</groupId>
+        <artifactId>mysql-connector-java</artifactId>
+        <version>5.1.49</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <build>
     <plugins>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <db.user>root</db.user>
     <db.pass>""</db.pass>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <scm>
@@ -76,6 +76,21 @@
       </plugin>
 
     </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>exec-maven-plugin</artifactId>
+          <groupId>org.codehaus.mojo</groupId>
+          <version>1.3.2</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.2</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <profiles>


### PR DESCRIPTION
The previous version being used is five years old and numerous bug fixes
have been applied since.  Chief among them is re-enabled support for
fractional seconds.

Jira: INGEST-2133
