### PR TITLE
INGEST-2133, Support milliseconds

### DIFF
--- a/jack-core/src/com/rapleaf/jack/util/JackUtility.java
+++ b/jack-core/src/com/rapleaf/jack/util/JackUtility.java
@@ -12,7 +12,7 @@ import org.joda.time.DateTime;
 public final class JackUtility {
 
   private static final String DATE_FORMAT = "yyyy-MM-dd";
-  private static final String TIMESTAMP_FORMAT = "yyyy-MM-dd HH:mm:ss";
+  private static final String TIMESTAMP_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";
 
   public static final Map<Class<?>, Function<Long, String>> FORMATTER_FUNCTION_MAP = ImmutableMap.of(
       java.sql.Date.class, date -> new DateTime(date).toString(DATE_FORMAT),

--- a/jack-test/test/java/com/rapleaf/jack/util/TestJackUtility.java
+++ b/jack-test/test/java/com/rapleaf/jack/util/TestJackUtility.java
@@ -10,9 +10,9 @@ public class TestJackUtility {
   @Test
   public void testDateTimeFormat() {
     assertEquals(
-        "2018-01-15 18:15:23",
+        "2018-01-15 18:15:23.789",
         JackUtility.FORMATTER_FUNCTION_MAP.get(java.sql.Timestamp.class)
-            .apply(new DateTime(2018, 1, 15, 18, 15, 23).getMillis())
+            .apply(new DateTime(2018, 1, 15, 18, 15, 23, 789).getMillis())
     );
   }
 


### PR DESCRIPTION
When building SQL statements for DATETIME and TIMESTAMP columns, include
milliseconds (fractional seconds precision of 3).

Jack represents DATETIME and TIMESTAMP types as ms held in longs, so it
is convenient to support the same level of precision when building SQL
statements.

It's been confirmed that althought MySQL 5.5 does not support storing
fractional seconds in time values, it can parse them; they'll be
truncated in the tables.

Jira: INGEST-2133