### PR TITLE
Resolve revision property in POMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .bundle
+# Created by flatten-maven-plugin
+.flattened-pom.xml
 build
 src/java/com/rapleaf/jack/util/MysqlFlex.java
 *.iml

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,31 @@
         </configuration>
       </plugin>
 
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <updatePomFile>true</updatePomFile>
+              <flattenMode>resolveCiFriendliesOnly</flattenMode>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
 
     <pluginManagement>
@@ -98,6 +123,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.22.2</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>flatten-maven-plugin</artifactId>
+          <version>1.2.2</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
The `revision` property is used to consolidate the configuration of the
modules' versions.  Since we want to deploy these artifacts, that
property must be resolved in order for Maven to find the parents later.

See [Maven CI Friendly Versions][1]

[1]: https://maven.apache.org/maven-ci-friendly.html