### PR TITLE
Don't NPE when config option is not specified

### DIFF
--- a/jack-core/src/com/rapleaf/jack/DatabaseConnectionConfiguration.java
+++ b/jack-core/src/com/rapleaf/jack/DatabaseConnectionConfiguration.java
@@ -187,12 +187,18 @@ public class DatabaseConnectionConfiguration {
     if (result.isPresent()) {
       return result.get();
     } else {
+      String foundKeys;
+      if (map == null) {
+        foundKeys = "No keys found";
+      } else {
+        foundKeys = map.keySet().toString();
+      }
       throw new RuntimeException(
           "Unable to find required configuration " + readableName + ". Please set using one of:\n" +
               "Environment Variable: " + envVar + "\n" +
               "Java System Property: " + javaProp + "\n" +
               "Entry in config/" + mapYmlFile + ".yml: " + mapKey + "\n" +
-              "Found following keys: " + map.keySet());
+              "Found following keys: " + foundKeys);
     }
   }
 


### PR DESCRIPTION
When some of the options are incorrectly specified, jack will
throw an NPE when trying to craft a user-friendly error message.

You can see this in the current version by not specifying the
`adaptor` parameter.

This change attempts to avoid such an error by not failing when
crafting an exception error message.

- [ ] Add unit tests