### PR TITLE
Mysql: default to SSL without verification

### DIFF
--- a/jack-mysql/src/com/rapleaf/jack/MysqlDatabaseConnection.java
+++ b/jack-mysql/src/com/rapleaf/jack/MysqlDatabaseConnection.java
@@ -3,12 +3,27 @@ package com.rapleaf.jack;
 import static com.rapleaf.jack.DatabaseConnectionConstants.DEFAULT_EXPIRATION;
 import static com.rapleaf.jack.DatabaseConnectionConstants.MYSQL_JDBC_DRIVER;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class MysqlDatabaseConnection extends DatabaseConnection {
+
+  private static final Map<String, String> sslOptions = new HashMap<>();
+
+  static {
+    sslOptions.put("verifyServerCertificate", "false");
+    sslOptions.put("useSSL", "true");
+  }
+
   public MysqlDatabaseConnection(String dbname_key) {
     this(dbname_key, DEFAULT_EXPIRATION);
   }
 
   public MysqlDatabaseConnection(String dbname_key, long expiration) {
-    super(dbname_key, expiration, MYSQL_JDBC_DRIVER);
+    super(dbname_key, expiration, MYSQL_JDBC_DRIVER, sslOptions);
+  }
+
+  public MysqlDatabaseConnection(String dbname_key, long expiration, Map<String, String> additionalOptions) {
+    super(dbname_key, expiration, MYSQL_JDBC_DRIVER, additionalOptions);
   }
 }


### PR DESCRIPTION
Attempts to silence this warning: 
```WARN: Establishing SSL connection without server's identity verification is not recommended. According to MySQL 5.5.45+, 5.6.26+ and 5.7.6+ requirements SSL connection must be established by default if explicit option isn't set. For compliance with existing applications not using SSL the verifyServerCertificate property is set to 'false'. You need either to explicitly disable SSL by setting useSSL=false, or set useSSL=true and provide truststore for server certificate verification.```

The actual behavior should not change, but specifying it explicitly in the connection string should satisfy the warning. Additionally, future development could make it possible to set a trust store and actually verify the server certs.