### PR TITLE
[OC-49258] build with java 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 mvnBuildPipeline {
     agentLabel = 'ubuntu-2004'
     environment {
-        JAVA_HOME = '/usr/lib/jvm/java-8-openjdk-amd64'
+        JAVA_HOME = '/usr/lib/jvm/java-11-openjdk-amd64'
     }
     mavenPropertiesOverride = '-Dmaven.test.failure.ignore=false -Ddb.user=$HUDSON_DB_USER -Ddb.pass=$HUDSON_DB_PASS -Pmysql'
 }

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
+          <release>8</release>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
This more closely matches what we were building with in Travis CI: https://github.com/LiveRamp/jack/blob/a6a6561616db756aec7d2617862df20efc1d1a17/.travis.yml#L6 but uses a jdk that is available in our agents.