### PR TITLE
[OC-49258] add mysql 8 connector on new snapshot

### DIFF
--- a/jack-mysql/pom.xml
+++ b/jack-mysql/pom.xml
@@ -32,8 +32,8 @@
     </dependency>
 
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
     </dependency>
 
   </dependencies>

--- a/jack-test/pom.xml
+++ b/jack-test/pom.xml
@@ -55,8 +55,8 @@
     </dependency>
 
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <db.user>root</db.user>
     <db.pass>""</db.pass>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <revision>1.8-SNAPSHOT</revision>
+    <revision>1.9-SNAPSHOT</revision>
   </properties>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -59,9 +59,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>mysql</groupId>
-        <artifactId>mysql-connector-java</artifactId>
-        <version>5.1.49</version>
+        <groupId>com.mysql</groupId>
+        <artifactId>mysql-connector-j</artifactId>
+        <version>8.0.33</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Introduce a new SNAPSHOT that can use the newer mysql connector library.