### PR TITLE
[OC-56736] parse schemas generated with rails 5

### DIFF
--- a/jack-core/src/rb/schema_rb_parser.rb
+++ b/jack-core/src/rb/schema_rb_parser.rb
@@ -63,14 +63,14 @@ module ActiveRecord
 
   class Table
     include FromHash
-    attr_accessor :name, :force, :id, :schema
+    attr_accessor :name, :force, :id, :limit, :options, :schema
     fattr(:columns) { [] }
 
     def __column(type, name, ops = {})
-      self.columns << Column.new(ops.merge(type: type, name: name)) unless FORBIDDEN_FIELD_NAMES.include?(name)
+      self.columns << Column.new(ops.merge(type: type, name: name)) unless FORBIDDEN_FIELD_NAMES.include?(name) || type == 'index'
     end
 
-    %w(integer text datetime boolean string float binary date decimal varbinary).each do |f|
+    %w(bigint integer index text datetime boolean string float binary date decimal varbinary).each do |f|
       define_method(f) do |*args|
         self.__column(f, *args)
       end
@@ -88,7 +88,7 @@ module ActiveRecord
 
   class Column
     include FromHash
-    attr_accessor :type, :name, :limit, :null, :default, :precision, :scale
+    attr_accessor :type, :name, :length, :limit, :null, :default, :precision, :scale, :unique
 
     def to_model_defn(col_index)
       f = to_h


### PR DESCRIPTION
The `schema.rb` output looks a little different between Rails 4 and Rails 5, so the parser should handle the new properties.

```diff
diff --git a/db/schema.rb b/db/schema.rb
index 7b7531e..f64b9ad 100644
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 
-ActiveRecord::Schema.define(version: 20231024150811) do
+ActiveRecord::Schema.define(version: 2023_10_24_150811) do
 
@@ -69,16 +69,15 @@ ActiveRecord::Schema.define(version: 20231024150811) do
 
-  create_table "entities", id: :bigserial, force: :cascade do |t|
-    t.integer  "entity_uid",  limit: 8, null: false
-    t.integer  "entity_type", limit: 2, null: false
-    t.datetime "created_at",            null: false
-    t.datetime "updated_at",            null: false
+  create_table "entities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "entity_uid", null: false
+    t.integer "entity_type", limit: 2, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["entity_uid", "entity_type"], name: "entity_uid_entity_type_index", unique: true
+    t.index ["entity_uid"], name: "entity_uid_index", unique: true
   end
 
-  add_index "entities", ["entity_uid", "entity_type"], name: "entity_uid_entity_type_index", unique: true, using: :btree
-  add_index "entities", ["entity_uid"], name: "entity_uid_index", unique: true, using: :btree
-

```