### PR TITLE
Normalize Rails 7.1 schema.rb dumps to the 4.2 parse state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,3 @@ target
 **/vendor/bundle
 node_modules
 _book
-scratchpad

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ target
 **/vendor/bundle
 node_modules
 _book
+scratchpad

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('liveramp-base@v2') _
+@Library('liveramp-base@v3.0') _
 
 mvnBuildPipeline {
     agentLabel = 'ubuntu-2004'

--- a/README.md
+++ b/README.md
@@ -79,23 +79,26 @@ Assuming everything is configured correctly, that's it.
 
 _Note: We know that the path thing stinks. We're going to improve this in a future version._
 
-### Schema-dialect parser specs (manual)
+### Schema-dialect parser specs
 
 The parser accepts schema.rb in both the Rails 4.2 dump format and the modern (Rails 5+/7.1)
 format, normalizing the modern forms so both produce identical parse state — and therefore
 byte-identical generated Java, including `serialVersionUID`s. The specs for this live in
-`jack-test/test/rb/` and are **not wired into the Maven build or CI** — the enforced gate is
-downstream, in each consuming repo's generate-and-diff check against its committed generated code.
-
-Run them manually whenever you touch `jack-core/src/rb/` (especially `schema_rb_parser.rb`) or
-anything feeding UID computation (`field_defn.rb`, `model_defn.rb`):
+`jack-test/test/rb/` and run as part of the jack-test Maven build (`run-parser-specs`
+execution, test phase). To run them directly:
 
 ```sh
 cd jack-test
 bundle install   # Ruby 2.7.x
 bundle exec rspec test/rb        # dialect-equivalence, per-rule variants, UID recipe pin
-bash test/diff_rails71.sh        # full generation from both dialects, byte-diffed
+bash test/diff_rails71.sh        # manual only: full generation from both dialects, byte-diffed
 ```
+
+`diff_rails71.sh` is deliberately not in CI: it also compares against the committed golden
+`test/java`, which carries timezone-dependent datetime defaults, so it is only reliable run
+by a person who can eyeball the diff. The load-bearing byte-identity gate for real schemas is
+downstream anyway, in each consuming repo's generate-and-diff check against its committed
+generated code.
 
 If the UID recipe spec fails, the wire-compat stamp of every generated model has moved — treat
 that as a breaking change for any consumer that Java-serializes models, not a spec to update.

--- a/README.md
+++ b/README.md
@@ -97,23 +97,22 @@ bash test/diff_rails71.sh        # manual only: full generation from both dialec
 **What diff_rails71.sh checks.** It generates the full Java model layer twice — once from the
 4.2-format fixture, once from the 7.1-format fixture — and diffs the two outputs. That diff is
 deterministic and must always be empty: same schema meaning, same bytes out. The script also
-diffs against the committed golden `test/java` as a sanity check, and only that comparison is
-machine-dependent: the fixture schema (unlike real schemas) has datetime columns with literal
-defaults, the generator converts those to epoch milliseconds in the machine's local timezone,
-and the goldens were committed from a PST machine — so off PST the golden diff shows shifted
-epoch constants, in both dialects equally. That fixture-only quirk is why this script is run
-by a person rather than CI. For real schemas, byte-identity is additionally enforced
-downstream: each consuming repo regenerates in CI and diffs against its committed code.
+diffs against the committed golden `test/java` as a sanity check. Unfortunately, that comparison is
+somewhat dependent on the machine running it: the existing fixture schema (unlike the real rldb schema)
+has datetime columns with literal defaults, and the generator converts those to epoch milliseconds
+in **the machine's local timezone**. We kept this behavior to minimize the blast radius of the ActiveRecord upgrade.
+Since the fixtures were committed from a PST machine, any time this script is run in a machine that's elsewhere,
+the diff will show different epoch constants. That is a fixture-only quirk, but also makes it inappropriate
+to include this script in CI.
 
 **What the UID recipe spec pins.** Java serialization stamps every class with a
 `serialVersionUID`; when one JVM deserializes bytes another JVM wrote (Spark/Hadoop shuffles,
 caches — anything crossing a process or deploy boundary), the stamps must match or Java throws
 `InvalidClassException`. Jack computes that stamp for each generated model from the schema
-itself — a hash over every column's name, type, position, and options — which is why parse
-state must stay identical across dump dialects. The spec hard-codes one known stamp and
-re-derives it from first principles. If it fails, the derivation changed and every generated
-model gets a new stamp, breaking any consumer that holds serialized models across a deploy.
-The fix is almost always to revert the change, not to update the pinned constant.
+itself — a hash over every column's name, type, position, and options. The spec hard-codes one known stamp and
+re-derives it. If it fails, we know that the derivation method itself has changed, meaning that every generated
+model gets a new stamp, even if the schema has not changed. This would break any consumer that holds serialized models across a deploy.
+The correct fix is most likely to revert the change in serialization method, not to update the constant in the spec.
 
 ### Layout of the Generated Code
 

--- a/README.md
+++ b/README.md
@@ -94,14 +94,26 @@ bundle exec rspec test/rb        # dialect-equivalence, per-rule variants, UID r
 bash test/diff_rails71.sh        # manual only: full generation from both dialects, byte-diffed
 ```
 
-`diff_rails71.sh` is deliberately not in CI: it also compares against the committed golden
-`test/java`, which carries timezone-dependent datetime defaults, so it is only reliable run
-by a person who can eyeball the diff. The load-bearing byte-identity gate for real schemas is
-downstream anyway, in each consuming repo's generate-and-diff check against its committed
-generated code.
+**What diff_rails71.sh checks.** It generates the full Java model layer twice — once from the
+4.2-format fixture, once from the 7.1-format fixture — and diffs the two outputs. That diff is
+deterministic and must always be empty: same schema meaning, same bytes out. The script also
+diffs against the committed golden `test/java` as a sanity check, and only that comparison is
+machine-dependent: the fixture schema (unlike real schemas) has datetime columns with literal
+defaults, the generator converts those to epoch milliseconds in the machine's local timezone,
+and the goldens were committed from a PST machine — so off PST the golden diff shows shifted
+epoch constants, in both dialects equally. That fixture-only quirk is why this script is run
+by a person rather than CI. For real schemas, byte-identity is additionally enforced
+downstream: each consuming repo regenerates in CI and diffs against its committed code.
 
-If the UID recipe spec fails, the wire-compat stamp of every generated model has moved — treat
-that as a breaking change for any consumer that Java-serializes models, not a spec to update.
+**What the UID recipe spec pins.** Java serialization stamps every class with a
+`serialVersionUID`; when one JVM deserializes bytes another JVM wrote (Spark/Hadoop shuffles,
+caches — anything crossing a process or deploy boundary), the stamps must match or Java throws
+`InvalidClassException`. Jack computes that stamp for each generated model from the schema
+itself — a hash over every column's name, type, position, and options — which is why parse
+state must stay identical across dump dialects. The spec hard-codes one known stamp and
+re-derives it from first principles. If it fails, the derivation changed and every generated
+model gets a new stamp, breaking any consumer that holds serialized models across a deploy.
+The fix is almost always to revert the change, not to update the pinned constant.
 
 ### Layout of the Generated Code
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,27 @@ Assuming everything is configured correctly, that's it.
 
 _Note: We know that the path thing stinks. We're going to improve this in a future version._
 
+### Schema-dialect parser specs (manual)
+
+The parser accepts schema.rb in both the Rails 4.2 dump format and the modern (Rails 5+/7.1)
+format, normalizing the modern forms so both produce identical parse state — and therefore
+byte-identical generated Java, including `serialVersionUID`s. The specs for this live in
+`jack-test/test/rb/` and are **not wired into the Maven build or CI** — the enforced gate is
+downstream, in each consuming repo's generate-and-diff check against its committed generated code.
+
+Run them manually whenever you touch `jack-core/src/rb/` (especially `schema_rb_parser.rb`) or
+anything feeding UID computation (`field_defn.rb`, `model_defn.rb`):
+
+```sh
+cd jack-test
+bundle install   # Ruby 2.7.x
+bundle exec rspec test/rb        # dialect-equivalence, per-rule variants, UID recipe pin
+bash test/diff_rails71.sh        # full generation from both dialects, byte-diffed
+```
+
+If the UID recipe spec fails, the wire-compat stamp of every generated model has moved — treat
+that as a breaking change for any consumer that Java-serializes models, not a spec to update.
+
 ### Layout of the Generated Code
 
 The Java code that Jack produces is designed around interfaces so that it is very modular and mockable.

--- a/jack-core/src/rb/schema_rb_parser.rb
+++ b/jack-core/src/rb/schema_rb_parser.rb
@@ -30,6 +30,12 @@ end
 
 module ActiveRecord
   class Schema
+    # Rails >= 6 dumps `ActiveRecord::Schema[7.1].define(...)`.  The [] selector
+    # returns the class itself so the subsequent .define call is unchanged. [S1]
+    def self.[](_version)
+      self
+    end
+
     def self.define(ops = {}, &b)
       $schema = s = new(ops)
       s.instance_eval(&b)
@@ -63,11 +69,50 @@ module ActiveRecord
 
   class Table
     include FromHash
-    attr_accessor :name, :force, :id, :limit, :options, :schema
+    # :charset/:collation/:comment are table-level kwargs emitted by Rails >= 5
+    # dumps (e.g. `create_table "x", charset: "utf8mb4", ...`).  They are
+    # accepted here and ignored downstream (no effect on generated Java). [T1]
+    attr_accessor :name, :force, :id, :limit, :options, :schema, :charset, :collation, :comment
     fattr(:columns) { [] }
 
+    # Rails >= 5 dumpers elide column options that equal the MySQL adapter
+    # default.  These tables re-materialize those defaults so a modern dump
+    # produces byte-identical parse state (and serialVersionUIDs) to the legacy
+    # 4.2 dump, where every sized column carried an explicit limit.
+    DEFAULT_LIMITS = {
+      'integer' => 4, 'string' => 255, 'text' => 65535, 'binary' => 65535, 'float' => 24
+    }.freeze
+    # `size:` is the Rails shorthand for text/binary blob sizing. [C5]
+    SIZE_TO_LIMIT = { tiny: 255, medium: 16_777_215, long: 4_294_967_295 }.freeze
+    # Column options that modern dumps may emit but that the 4.2-era dump never
+    # did; they carry no information used by the Java layer, so they are dropped
+    # (with a warning) before Column construction rather than crashing it. [C9]
+    IGNORED_COLUMN_OPTIONS = [:collation, :charset, :comment, :unsigned,
+                              :auto_increment, :as, :stored].freeze
+
     def __column(type, name, ops = {})
-      self.columns << Column.new(ops.merge(type: type, name: name)) unless FORBIDDEN_FIELD_NAMES.include?(name) || type == 'index'
+      return if FORBIDDEN_FIELD_NAMES.include?(name) || type == 'index'
+      ops = ops.dup
+      # C1: Rails >= 5 renders 8-byte integers as `t.bigint`; the legacy dump
+      # rendered them as `t.integer ..., limit: 8`.  Normalize to the legacy
+      # form so data_type and the UID component are unchanged.
+      if type == 'bigint'
+        type = 'integer'
+        ops[:limit] ||= 8
+      end
+      # C5: map `size: :tiny/:medium/:long` on text/binary to the legacy limit.
+      if (size = ops.delete(:size))
+        ops[:limit] ||= SIZE_TO_LIMIT.fetch(size.to_sym) { raise "unknown size #{size.inspect} on column #{name}" }
+      end
+      # C2/C3/C4/C6: refill an elided limit with the adapter default.
+      ops[:limit] ||= DEFAULT_LIMITS[type] if DEFAULT_LIMITS.key?(type)
+      # C9: drop modern-only column options that Column cannot accept.
+      IGNORED_COLUMN_OPTIONS.each do |opt|
+        next unless ops.key?(opt)
+        puts "Warning: ignoring option #{opt.inspect} on column #{name}"
+        ops.delete(opt)
+      end
+      self.columns << Column.new(ops.merge(type: type, name: name))
     end
 
     %w(bigint integer index text datetime boolean string float binary date decimal varbinary).each do |f|
@@ -97,8 +142,13 @@ module ActiveRecord
       type = f.delete('type').to_sym
       raise "bad" unless name && type
 
-      if default.kind_of?(Numeric) && [:float,:decimal].include?(type)
-        f['default'] = default.to_f
+      # C7: float/decimal defaults must land as a Ruby Float in args.  Legacy
+      # dumps rendered them as a numeric literal (`default: 0.0`); Rails >= 5
+      # renders them as a string (`default: "0.0"`).  Coerce both to Float so
+      # the UID component (":default0.0") is identical either way.  Other string
+      # defaults keep their existing quoted-literal treatment.
+      if [:float, :decimal].include?(type)
+        f['default'] = Float(default) unless default.nil?
       elsif default.kind_of?(String)
         f['default'] = '"' + default + '"'
       end

--- a/jack-core/src/rb/schema_rb_parser.rb
+++ b/jack-core/src/rb/schema_rb_parser.rb
@@ -28,10 +28,39 @@ module FromHash
   end
 end
 
+# How this "parser" works (it is not a text parser):
+# A Rails schema.rb is Ruby source that, when executed, calls into ActiveRecord
+# to build up a schema. We never load real ActiveRecord. Instead the stub
+# classes below stand in for it, so when SchemaRbParser.parse runs `load` on the
+# dump, each line of the dump becomes a method call on one of these stubs, and
+# the stubs record just enough to emit model definitions. For example:
+#
+#     create_table "users" do |t|
+#       t.string "email", limit: 255
+#     end
+#
+# runs Schema#create_table, then Table#string (see the define_method loop that
+# generates one method per column type), which records a column.
+#
+# A few DSL calls take non-obvious forms:
+#   * `ActiveRecord::Schema[7.1].define` — `[]` is just a method, so `Schema[7.1]`
+#     is a method call (see `self.[]` below).
+#   * `attr_accessor`/`fattr` generate getter/setter methods; listing an option
+#     name there is how a stub accepts (and later ignores) that dump option.
+#   * A DSL call with no matching method raises NoMethodError and aborts the
+#     parse, EXCEPT on Schema, whose `method_missing` downgrades unknown calls to
+#     a warning. Tables have no such fallback, so a new table-level directive
+#     needs its own method here (see `check_constraint`).
+#
+# Much of the normalization below exists because newer Rails versions dump the
+# same schema using different DSL calls and option shapes than the 4.2-era dumps
+# this was originally built for. Each case is normalized back so that old and new
+# dumps produce identical model definitions (and identical serialVersionUIDs).
 module ActiveRecord
   class Schema
-    # Rails >= 6 dumps `ActiveRecord::Schema[7.1].define(...)`; accept the
-    # version selector and ignore it.
+    # `[]` is an ordinary Ruby method, so `ActiveRecord::Schema[7.1]` is a call
+    # that passes the version and expects an object back to call `.define` on.
+    # Rails >= 6 dumps this form; return the class itself and ignore the version.
     def self.[](_version)
       self
     end
@@ -118,6 +147,11 @@ module ActiveRecord
       self.columns << Column.new(ops.merge(type: type, name: name))
     end
 
+    # Generate one Table method per column type so that a dump call like
+    # `t.integer` or `t.string` dispatches into __column tagged with that type.
+    # define_method builds these at load time instead of us writing each out by
+    # hand. `timestamp` is dumped by Rails >= 5 (see __column); the rest predate
+    # it, but all route through the same path.
     %w(bigint integer index text datetime timestamp boolean string float binary date decimal varbinary).each do |f|
       define_method(f) do |*args|
         self.__column(f, *args)
@@ -125,8 +159,10 @@ module ActiveRecord
     end
 
     # MySQL 8.0 enforces CHECK constraints (5.7 parsed but ignored them), so
-    # dumps taken against 8.0 include them.  They are not columns and nothing
-    # downstream uses them.
+    # dumps taken against 8.0 include a `t.check_constraint` line. It is not a
+    # column and nothing downstream uses it. A Table has no method_missing
+    # fallback, so without a method here that dump line would raise NoMethodError
+    # and abort the parse; define a no-op that records nothing and just warns.
     def check_constraint(_expression, ops = {})
       puts "Warning: ignoring check constraint #{ops[:name].inspect} on table #{name}"
     end

--- a/jack-core/src/rb/schema_rb_parser.rb
+++ b/jack-core/src/rb/schema_rb_parser.rb
@@ -30,8 +30,8 @@ end
 
 module ActiveRecord
   class Schema
-    # Rails >= 6 dumps `ActiveRecord::Schema[7.1].define(...)`.  The [] selector
-    # returns the class itself so the subsequent .define call is unchanged. [S1]
+    # Rails >= 6 dumps `ActiveRecord::Schema[7.1].define(...)`; accept the
+    # version selector and ignore it.
     def self.[](_version)
       self
     end
@@ -69,58 +69,48 @@ module ActiveRecord
 
   class Table
     include FromHash
-    # :charset/:collation/:comment are table-level kwargs emitted by Rails >= 5
-    # dumps (e.g. `create_table "x", charset: "utf8mb4", ...`).  They are
-    # accepted here and ignored downstream (no effect on generated Java). [T1]
+    # charset/collation/comment/primary_key are table options emitted by
+    # Rails >= 5 dumps; accepted here, unused downstream.
     attr_accessor :name, :force, :id, :limit, :options, :schema, :charset, :collation, :comment, :primary_key
     fattr(:columns) { [] }
 
-    # Rails >= 5 dumpers elide column options that equal the MySQL adapter
-    # default.  These tables re-materialize those defaults so a modern dump
-    # produces byte-identical parse state (and serialVersionUIDs) to the legacy
-    # 4.2 dump, where every sized column carried an explicit limit.
+    # Rails >= 5 dumps elide column options that equal the MySQL adapter
+    # default; 4.2 dumps wrote them out.  Refill them so both dialects parse
+    # to the same state (and the same serialVersionUIDs).
     DEFAULT_LIMITS = {
       'integer' => 4, 'string' => 255, 'text' => 65535, 'binary' => 65535, 'float' => 24
     }.freeze
-    # `size:` is the Rails shorthand for text/binary blob sizing. [C5]
+    # Rails >= 6 dumps text/binary sizes as `size: :tiny/:medium/:long`.
     SIZE_TO_LIMIT = { tiny: 255, medium: 16_777_215, long: 4_294_967_295 }.freeze
-    # Column options that modern dumps may emit but that the 4.2-era dump never
-    # did; they carry no information used by the Java layer, so they are dropped
-    # (with a warning) before Column construction rather than crashing it. [C9]
+    # Column options newer dumps may emit that 4.2 never did.  Nothing
+    # downstream uses them, so drop them (with a warning) instead of crashing.
     IGNORED_COLUMN_OPTIONS = [:collation, :charset, :comment, :unsigned,
                               :auto_increment, :as, :stored].freeze
 
     def __column(type, name, ops = {})
       return if FORBIDDEN_FIELD_NAMES.include?(name) || type == 'index'
       ops = ops.dup
-      # C1: Rails >= 5 renders 8-byte integers as `t.bigint`; the legacy dump
-      # rendered them as `t.integer ..., limit: 8`.  Normalize to the legacy
-      # form so data_type and the UID component are unchanged.
+      # Rails >= 5 dumps 8-byte integers as `t.bigint`; 4.2 wrote
+      # `t.integer ..., limit: 8`.  Normalize to the old form.
       if type == 'bigint'
         type = 'integer'
         ops[:limit] ||= 8
       end
-      # C11: Rails >= 5 renders MySQL TIMESTAMP columns as `t.timestamp`; the 4.2
-      # dumper had no distinct :timestamp type and rendered them as `t.datetime`
-      # (and the committed Java treats them as datetime — Column.fromTimestamp,
-      # Long).  Normalize back to datetime so data_type and the UID are unchanged.
+      # Rails >= 5 dumps MySQL TIMESTAMP columns as `t.timestamp`; 4.2 had no
+      # :timestamp type and wrote `t.datetime`.  Normalize to datetime.
       type = 'datetime' if type == 'timestamp'
-      # C5: map `size: :tiny/:medium/:long` on text/binary to the legacy limit.
+      # Map `size:` to the explicit limit 4.2 would have written.
       if (size = ops.delete(:size))
         ops[:limit] ||= SIZE_TO_LIMIT.fetch(size.to_sym) { raise "unknown size #{size.inspect} on column #{name}" }
       end
-      # C2/C3/C4/C6: refill an elided limit with the adapter default.
       ops[:limit] ||= DEFAULT_LIMITS[type] if DEFAULT_LIMITS.key?(type)
-      # C9: drop modern-only column options that Column cannot accept.
       IGNORED_COLUMN_OPTIONS.each do |opt|
         next unless ops.key?(opt)
         puts "Warning: ignoring option #{opt.inspect} on column #{name}"
         ops.delete(opt)
       end
-      # C12: expression/function defaults (e.g. `default: -> { "CURRENT_TIMESTAMP
-      # ON UPDATE CURRENT_TIMESTAMP" }`) are dumped as a lambda by Rails >= 5; the
-      # 4.2 dumper never captured them, so the committed Java carries no such
-      # default.  Drop them to preserve byte-identity. [C12]
+      # Rails >= 5 dumps expression defaults (`default: -> { "CURRENT_TIMESTAMP" }`)
+      # as a lambda; 4.2 never captured them.  Drop them.
       if ops[:default].is_a?(Proc)
         puts "Warning: ignoring expression default on column #{name}"
         ops.delete(:default)
@@ -155,11 +145,9 @@ module ActiveRecord
       type = f.delete('type').to_sym
       raise "bad" unless name && type
 
-      # C7: float/decimal defaults must land as a Ruby Float in args.  Legacy
-      # dumps rendered them as a numeric literal (`default: 0.0`); Rails >= 5
-      # renders them as a string (`default: "0.0"`).  Coerce both to Float so
-      # the UID component (":default0.0") is identical either way.  Other string
-      # defaults keep their existing quoted-literal treatment.
+      # 4.2 dumped float/decimal defaults as a numeric literal (`default: 0.0`);
+      # Rails >= 5 dumps a string (`default: "0.0"`).  Coerce both to Float so
+      # the default — a serialVersionUID input — is identical either way.
       if [:float, :decimal].include?(type)
         f['default'] = Float(default) unless default.nil?
       elsif default.kind_of?(String)

--- a/jack-core/src/rb/schema_rb_parser.rb
+++ b/jack-core/src/rb/schema_rb_parser.rb
@@ -123,6 +123,14 @@ module ActiveRecord
         self.__column(f, *args)
       end
     end
+
+    # MySQL 8.0 enforces CHECK constraints (5.7 parsed but ignored them), so
+    # dumps taken against 8.0 include them.  They are not columns and nothing
+    # downstream uses them.
+    def check_constraint(_expression, ops = {})
+      puts "Warning: ignoring check constraint #{ops[:name].inspect} on table #{name}"
+    end
+
     def to_model_defn
       return nil if name == 'schema_info'
       res = ModelDefn.new(42)

--- a/jack-core/src/rb/schema_rb_parser.rb
+++ b/jack-core/src/rb/schema_rb_parser.rb
@@ -72,7 +72,7 @@ module ActiveRecord
     # :charset/:collation/:comment are table-level kwargs emitted by Rails >= 5
     # dumps (e.g. `create_table "x", charset: "utf8mb4", ...`).  They are
     # accepted here and ignored downstream (no effect on generated Java). [T1]
-    attr_accessor :name, :force, :id, :limit, :options, :schema, :charset, :collation, :comment
+    attr_accessor :name, :force, :id, :limit, :options, :schema, :charset, :collation, :comment, :primary_key
     fattr(:columns) { [] }
 
     # Rails >= 5 dumpers elide column options that equal the MySQL adapter
@@ -100,6 +100,11 @@ module ActiveRecord
         type = 'integer'
         ops[:limit] ||= 8
       end
+      # C11: Rails >= 5 renders MySQL TIMESTAMP columns as `t.timestamp`; the 4.2
+      # dumper had no distinct :timestamp type and rendered them as `t.datetime`
+      # (and the committed Java treats them as datetime — Column.fromTimestamp,
+      # Long).  Normalize back to datetime so data_type and the UID are unchanged.
+      type = 'datetime' if type == 'timestamp'
       # C5: map `size: :tiny/:medium/:long` on text/binary to the legacy limit.
       if (size = ops.delete(:size))
         ops[:limit] ||= SIZE_TO_LIMIT.fetch(size.to_sym) { raise "unknown size #{size.inspect} on column #{name}" }
@@ -112,10 +117,18 @@ module ActiveRecord
         puts "Warning: ignoring option #{opt.inspect} on column #{name}"
         ops.delete(opt)
       end
+      # C12: expression/function defaults (e.g. `default: -> { "CURRENT_TIMESTAMP
+      # ON UPDATE CURRENT_TIMESTAMP" }`) are dumped as a lambda by Rails >= 5; the
+      # 4.2 dumper never captured them, so the committed Java carries no such
+      # default.  Drop them to preserve byte-identity. [C12]
+      if ops[:default].is_a?(Proc)
+        puts "Warning: ignoring expression default on column #{name}"
+        ops.delete(:default)
+      end
       self.columns << Column.new(ops.merge(type: type, name: name))
     end
 
-    %w(bigint integer index text datetime boolean string float binary date decimal varbinary).each do |f|
+    %w(bigint integer index text datetime timestamp boolean string float binary date decimal varbinary).each do |f|
       define_method(f) do |*args|
         self.__column(f, *args)
       end

--- a/jack-test/pom.xml
+++ b/jack-test/pom.xml
@@ -128,6 +128,23 @@
             </configuration>
 
           </execution>
+          <!--schema-dialect parser specs: dialect equivalence, per-rule
+              variants, serialVersionUID recipe pin-->
+          <execution>
+            <id>run-parser-specs</id>
+            <phase>test</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>/bin/sh</executable>
+              <arguments>
+                <argument>-c</argument>
+                <argument>bundle exec rspec test/rb</argument>
+              </arguments>
+            </configuration>
+
+          </execution>
           <execution>
             <id>configure-ruby-db1</id>
             <phase>generate-test-sources</phase>

--- a/jack-test/test/diff_rails71.sh
+++ b/jack-test/test/diff_rails71.sh
@@ -8,7 +8,8 @@
 # PRE-EXISTING drift there is surfaced separately — the load-bearing check is
 # the A-vs-B (4.2-vs-7.1) diff, which must always be empty.
 #
-# Run from the jack-test directory:  bash test/diff_rails71.sh
+# NOT run by the Maven build/CI — run manually after any parser change.
+# From the jack-test directory:  bash test/diff_rails71.sh
 set -u
 
 HERE="$(cd "$(dirname "$0")" && pwd)"

--- a/jack-test/test/diff_rails71.sh
+++ b/jack-test/test/diff_rails71.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -l
+#
+# Byte-identity proof for the test_project fixture: generate the Java model
+# layer from the Rails 4.2 dump (project.yml) and from the Rails 7.1 dump
+# (project_rails71.yml), then prove the two outputs are byte-identical.
+#
+# Also diffs the 4.2 generation against the committed golden (test/java) so any
+# PRE-EXISTING drift there is surfaced separately — the load-bearing check is
+# the A-vs-B (4.2-vs-7.1) diff, which must always be empty.
+#
+# Run from the jack-test directory:  bash test/diff_rails71.sh
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+JACK_TEST="$(cd "$HERE/.." && pwd)"
+JACK_CORE="$JACK_TEST/../jack-core/src/rb/jack.rb"
+
+TMP="$(mktemp -d)"
+OUT_OLD="$TMP/java_old"
+OUT_71="$TMP/java_71"
+mkdir -p "$OUT_OLD" "$OUT_71"
+
+echo "== generating from Rails 4.2 dump (project.yml) =="
+bundle exec ruby "$JACK_CORE" "$HERE/test_project/project.yml"          "$OUT_OLD" >/dev/null
+echo "== generating from Rails 7.1 dump (project_rails71.yml) =="
+bundle exec ruby "$JACK_CORE" "$HERE/test_project/project_rails71.yml"   "$OUT_71"  >/dev/null
+
+status=0
+
+echo
+echo "== A-vs-B: 4.2 output  vs  7.1 output  (must be empty) =="
+if diff -r "$OUT_OLD" "$OUT_71"; then
+  echo "OK: 4.2 and 7.1 generations are byte-identical"
+else
+  echo "FAIL: 4.2 and 7.1 generations differ"
+  status=1
+fi
+
+GOLD="$JACK_TEST/test/java/com/rapleaf/jack/test_project"
+GEN_OLD="$OUT_OLD/com/rapleaf/jack/test_project"
+echo
+echo "== drift check: 4.2 output  vs  committed golden test/java (informational) =="
+if diff -r "$GEN_OLD" "$GOLD"; then
+  echo "OK: 4.2 generation matches committed golden"
+else
+  echo "NOTE: pre-existing drift vs committed golden (see above)."
+  echo "      This does NOT fail the script; the A-vs-B diff above is the"
+  echo "      byte-identity proof for the format migration."
+fi
+
+rm -rf "$TMP"
+exit $status

--- a/jack-test/test/rb/schema_rb_parser_rails71_spec.rb
+++ b/jack-test/test/rb/schema_rb_parser_rails71_spec.rb
@@ -1,5 +1,8 @@
 require File.expand_path(File.dirname(__FILE__) + "/spec_helper.rb")
 
+# NOT run by the Maven build/CI — run manually from jack-test:
+#   bundle exec rspec test/rb
+#
 # Proves that a Rails 7.1-dialect schema dump normalizes to parse state that is
 # bit-identical to the equivalent Rails 4.2 dump — same version, same per-model
 # serialVersionUID inputs, same field args — and therefore produces byte-

--- a/jack-test/test/rb/schema_rb_parser_rails71_spec.rb
+++ b/jack-test/test/rb/schema_rb_parser_rails71_spec.rb
@@ -1,7 +1,7 @@
 require File.expand_path(File.dirname(__FILE__) + "/spec_helper.rb")
 
-# NOT run by the Maven build/CI — run manually from jack-test:
-#   bundle exec rspec test/rb
+# Run by the Maven build (jack-test pom, run-parser-specs execution) and
+# directly from jack-test with:  bundle exec rspec test/rb
 #
 # Proves that a Rails 7.1-dialect schema dump normalizes to parse state that is
 # bit-identical to the equivalent Rails 4.2 dump — same version, same per-model

--- a/jack-test/test/rb/schema_rb_parser_rails71_spec.rb
+++ b/jack-test/test/rb/schema_rb_parser_rails71_spec.rb
@@ -1,0 +1,48 @@
+require File.expand_path(File.dirname(__FILE__) + "/spec_helper.rb")
+
+# Proves that a Rails 7.1-dialect schema dump normalizes to parse state that is
+# bit-identical to the equivalent Rails 4.2 dump — same version, same per-model
+# serialVersionUID inputs, same field args — and therefore produces byte-
+# identical generated Java.  The two fixtures (schema.rb and schema_rails71.rb)
+# describe the same database in the two dialects.
+describe SchemaRbParser do
+  def full_state(models)
+    models.sort_by(&:table_name).map do |m|
+      [
+        m.table_name,
+        m.migration_number,
+        m.attributes_serial_version_uid,
+        m.fields.map do |f|
+          [f.name, f.data_type, f.ordinal, f.args, f.default_value, f.serial_version_uid_component]
+        end
+      ]
+    end
+  end
+
+  before(:context) do
+    base    = File.expand_path('../../test_project/database_1/db', __FILE__)
+    ignored = ['profiles']
+    @models_42, @version_42 = SchemaRbParser.parse("#{base}/schema.rb", ignored)
+    @models_71, @version_71 = SchemaRbParser.parse("#{base}/schema_rails71.rb", ignored)
+  end
+
+  it 'parses the same version from both dialects' do
+    expect(@version_71).to eq @version_42
+    expect(@version_42).to eq '20180502013029'
+  end
+
+  it 'produces the same set of models' do
+    expect(@models_71.map(&:table_name).sort).to eq @models_42.map(&:table_name).sort
+    expect(@models_42).not_to be_empty
+  end
+
+  it 'produces bit-identical per-model parse state' do
+    expect(full_state(@models_71)).to eq full_state(@models_42)
+  end
+
+  it 'produces identical attributes_serial_version_uid per model' do
+    uids_42 = @models_42.sort_by(&:table_name).map { |m| [m.table_name, m.attributes_serial_version_uid] }
+    uids_71 = @models_71.sort_by(&:table_name).map { |m| [m.table_name, m.attributes_serial_version_uid] }
+    expect(uids_71).to eq uids_42
+  end
+end

--- a/jack-test/test/rb/schema_rb_parser_variants_spec.rb
+++ b/jack-test/test/rb/schema_rb_parser_variants_spec.rb
@@ -152,6 +152,71 @@ describe 'SchemaRbParser normalization variants' do
     expect_equivalent(legacy, modern)
   end
 
+  it 'C11: t.timestamp normalizes to datetime (MySQL TIMESTAMP dumped as datetime by 4.2)' do
+    legacy = <<~RUBY
+      ActiveRecord::Schema.define(version: 1) do
+        create_table "t", force: :cascade do |t|
+          t.datetime "a"
+          t.datetime "b", null: false
+        end
+      end
+    RUBY
+    modern = <<~RUBY
+      ActiveRecord::Schema[7.1].define(version: 1) do
+        create_table "t", charset: "utf8", force: :cascade do |t|
+          t.timestamp "a", precision: nil
+          t.timestamp "b", precision: nil, null: false
+        end
+      end
+    RUBY
+    expect_equivalent(legacy, modern)
+  end
+
+  it 'C12: expression (lambda) defaults are dropped to match the 4.2 dump' do
+    # Rails >= 5 captures CURRENT_TIMESTAMP-style defaults as a lambda; the 4.2
+    # dumper never captured them, so the committed Java carries no such default.
+    legacy = <<~RUBY
+      ActiveRecord::Schema.define(version: 1) do
+        create_table "t", force: :cascade do |t|
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
+        end
+      end
+    RUBY
+    modern = <<~RUBY
+      ActiveRecord::Schema[7.1].define(version: 1) do
+        create_table "t", charset: "utf8", force: :cascade do |t|
+          t.datetime  "created_at", precision: nil, default: -> { "CURRENT_TIMESTAMP" }, null: false
+          t.timestamp "updated_at", precision: nil, default: -> { "CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP" }, null: false
+        end
+      end
+    RUBY
+    expect_equivalent(legacy, modern)
+  end
+
+  it 'T1: modern table-level options (primary_key/options/charset) do not crash' do
+    # Composite-PK partitioned table: `id: false` + explicit "id" column in 4.2,
+    # `primary_key: [...]` + options string in 7.1. The "id" column is forbidden
+    # either way, so both reduce to the same non-id columns.
+    legacy = <<~RUBY
+      ActiveRecord::Schema.define(version: 1) do
+        create_table "t", id: false, force: :cascade do |t|
+          t.integer "id",  limit: 8, null: false
+          t.integer "fk",  limit: 8, null: false
+        end
+      end
+    RUBY
+    modern = <<~RUBY
+      ActiveRecord::Schema[7.1].define(version: 1) do
+        create_table "t", primary_key: ["id", "fk"], charset: "latin1", options: "ENGINE=InnoDB", force: :cascade do |t|
+          t.bigint "id", null: false, auto_increment: true
+          t.bigint "fk", null: false
+        end
+      end
+    RUBY
+    expect_equivalent(legacy, modern)
+  end
+
   it 'C5: an unknown size: value raises loudly' do
     body = <<~RUBY
       ActiveRecord::Schema[7.1].define(version: 1) do

--- a/jack-test/test/rb/schema_rb_parser_variants_spec.rb
+++ b/jack-test/test/rb/schema_rb_parser_variants_spec.rb
@@ -22,7 +22,7 @@ describe 'SchemaRbParser normalization variants' do
     expect(components_for(modern)).to eq(components_for(legacy))
   end
 
-  it 'C5: text size: matches explicit limit:, plain text refills 65535' do
+  it 'text size: matches explicit limit:, plain text refills 65535' do
     legacy = <<~RUBY
       ActiveRecord::Schema.define(version: 1) do
         create_table "t", force: :cascade do |t|
@@ -46,7 +46,7 @@ describe 'SchemaRbParser normalization variants' do
     expect_equivalent(legacy, modern)
   end
 
-  it 'C5: binary/blob size: matches explicit limit:, plain binary refills 65535' do
+  it 'binary/blob size: matches explicit limit:, plain binary refills 65535' do
     legacy = <<~RUBY
       ActiveRecord::Schema.define(version: 1) do
         create_table "t", force: :cascade do |t|
@@ -68,7 +68,7 @@ describe 'SchemaRbParser normalization variants' do
     expect_equivalent(legacy, modern)
   end
 
-  it 'C1: bigint matches integer limit: 8' do
+  it 'bigint matches integer limit: 8' do
     legacy = <<~RUBY
       ActiveRecord::Schema.define(version: 1) do
         create_table "t", force: :cascade do |t|
@@ -88,7 +88,7 @@ describe 'SchemaRbParser normalization variants' do
     expect_equivalent(legacy, modern)
   end
 
-  it 'C2/C3/C6: elided integer/string/float limits refill to adapter defaults' do
+  it 'elided integer/string/float limits refill to adapter defaults' do
     legacy = <<~RUBY
       ActiveRecord::Schema.define(version: 1) do
         create_table "t", force: :cascade do |t|
@@ -110,7 +110,7 @@ describe 'SchemaRbParser normalization variants' do
     expect_equivalent(legacy, modern)
   end
 
-  it 'C7: decimal/float string default matches numeric default' do
+  it 'decimal/float string default matches numeric default' do
     legacy = <<~RUBY
       ActiveRecord::Schema.define(version: 1) do
         create_table "t", force: :cascade do |t|
@@ -130,7 +130,7 @@ describe 'SchemaRbParser normalization variants' do
     expect_equivalent(legacy, modern)
   end
 
-  it 'C9: dropped modern column options leave UID components unchanged' do
+  it 'dropped modern column options leave UID components unchanged' do
     legacy = <<~RUBY
       ActiveRecord::Schema.define(version: 1) do
         create_table "t", force: :cascade do |t|
@@ -152,7 +152,7 @@ describe 'SchemaRbParser normalization variants' do
     expect_equivalent(legacy, modern)
   end
 
-  it 'C11: t.timestamp normalizes to datetime (MySQL TIMESTAMP dumped as datetime by 4.2)' do
+  it 't.timestamp normalizes to datetime (MySQL TIMESTAMP dumped as datetime by 4.2)' do
     legacy = <<~RUBY
       ActiveRecord::Schema.define(version: 1) do
         create_table "t", force: :cascade do |t|
@@ -172,7 +172,7 @@ describe 'SchemaRbParser normalization variants' do
     expect_equivalent(legacy, modern)
   end
 
-  it 'C12: expression (lambda) defaults are dropped to match the 4.2 dump' do
+  it 'expression (lambda) defaults are dropped to match the 4.2 dump' do
     # Rails >= 5 captures CURRENT_TIMESTAMP-style defaults as a lambda; the 4.2
     # dumper never captured them, so the committed Java carries no such default.
     legacy = <<~RUBY
@@ -194,7 +194,7 @@ describe 'SchemaRbParser normalization variants' do
     expect_equivalent(legacy, modern)
   end
 
-  it 'T1: modern table-level options (primary_key/options/charset) do not crash' do
+  it 'modern table-level options (primary_key/options/charset) do not crash' do
     # Composite-PK partitioned table: `id: false` + explicit "id" column in 4.2,
     # `primary_key: [...]` + options string in 7.1. The "id" column is forbidden
     # either way, so both reduce to the same non-id columns.
@@ -217,7 +217,7 @@ describe 'SchemaRbParser normalization variants' do
     expect_equivalent(legacy, modern)
   end
 
-  it 'C5: an unknown size: value raises loudly' do
+  it 'an unknown size: value raises loudly' do
     body = <<~RUBY
       ActiveRecord::Schema[7.1].define(version: 1) do
         create_table "t", force: :cascade do |t|

--- a/jack-test/test/rb/schema_rb_parser_variants_spec.rb
+++ b/jack-test/test/rb/schema_rb_parser_variants_spec.rb
@@ -1,6 +1,9 @@
 require File.expand_path(File.dirname(__FILE__) + "/spec_helper.rb")
 require 'tempfile'
 
+# NOT run by the Maven build/CI — run manually from jack-test:
+#   bundle exec rspec test/rb
+#
 # Per-rule equivalence checks: for each normalization rule, a Rails 7.1 dump
 # form and its Rails 4.2 canonical form must produce identical
 # serial_version_uid_component values (and therefore identical UIDs) for every

--- a/jack-test/test/rb/schema_rb_parser_variants_spec.rb
+++ b/jack-test/test/rb/schema_rb_parser_variants_spec.rb
@@ -1,0 +1,165 @@
+require File.expand_path(File.dirname(__FILE__) + "/spec_helper.rb")
+require 'tempfile'
+
+# Per-rule equivalence checks: for each normalization rule, a Rails 7.1 dump
+# form and its Rails 4.2 canonical form must produce identical
+# serial_version_uid_component values (and therefore identical UIDs) for every
+# column.  These are small standalone schemas parsed in isolation.
+describe 'SchemaRbParser normalization variants' do
+  # Parse a schema.rb body (a full ActiveRecord::Schema.define block) from a
+  # temp file and return the single table's [name, component] pairs.
+  def components_for(body)
+    Tempfile.create(['variant', '.rb']) do |f|
+      f.write(body)
+      f.flush
+      models, _version = SchemaRbParser.parse(f.path, [])
+      models.first.fields.map { |fd| [fd.name, fd.serial_version_uid_component] }
+    end
+  end
+
+  # Assert two schema bodies yield identical per-column UID components.
+  def expect_equivalent(legacy, modern)
+    expect(components_for(modern)).to eq(components_for(legacy))
+  end
+
+  it 'C5: text size: matches explicit limit:, plain text refills 65535' do
+    legacy = <<~RUBY
+      ActiveRecord::Schema.define(version: 1) do
+        create_table "t", force: :cascade do |t|
+          t.text "tiny_t",  limit: 255
+          t.text "med_t",   limit: 16777215
+          t.text "long_t",  limit: 4294967295
+          t.text "plain_t"
+        end
+      end
+    RUBY
+    modern = <<~RUBY
+      ActiveRecord::Schema[7.1].define(version: 1) do
+        create_table "t", charset: "utf8mb4", force: :cascade do |t|
+          t.text "tiny_t",  size: :tiny
+          t.text "med_t",   size: :medium
+          t.text "long_t",  size: :long
+          t.text "plain_t"
+        end
+      end
+    RUBY
+    expect_equivalent(legacy, modern)
+  end
+
+  it 'C5: binary/blob size: matches explicit limit:, plain binary refills 65535' do
+    legacy = <<~RUBY
+      ActiveRecord::Schema.define(version: 1) do
+        create_table "t", force: :cascade do |t|
+          t.binary "med_b",   limit: 16777215
+          t.binary "long_b",  limit: 4294967295
+          t.binary "plain_b"
+        end
+      end
+    RUBY
+    modern = <<~RUBY
+      ActiveRecord::Schema[7.1].define(version: 1) do
+        create_table "t", force: :cascade do |t|
+          t.binary "med_b",   size: :medium
+          t.binary "long_b",  size: :long
+          t.binary "plain_b"
+        end
+      end
+    RUBY
+    expect_equivalent(legacy, modern)
+  end
+
+  it 'C1: bigint matches integer limit: 8' do
+    legacy = <<~RUBY
+      ActiveRecord::Schema.define(version: 1) do
+        create_table "t", force: :cascade do |t|
+          t.integer "big_a", limit: 8
+          t.integer "big_b", limit: 8, null: false
+        end
+      end
+    RUBY
+    modern = <<~RUBY
+      ActiveRecord::Schema[7.1].define(version: 1) do
+        create_table "t", force: :cascade do |t|
+          t.bigint "big_a"
+          t.bigint "big_b", null: false
+        end
+      end
+    RUBY
+    expect_equivalent(legacy, modern)
+  end
+
+  it 'C2/C3/C6: elided integer/string/float limits refill to adapter defaults' do
+    legacy = <<~RUBY
+      ActiveRecord::Schema.define(version: 1) do
+        create_table "t", force: :cascade do |t|
+          t.integer "i", limit: 4
+          t.string  "s", limit: 255
+          t.float   "f", limit: 24
+        end
+      end
+    RUBY
+    modern = <<~RUBY
+      ActiveRecord::Schema[7.1].define(version: 1) do
+        create_table "t", force: :cascade do |t|
+          t.integer "i"
+          t.string  "s"
+          t.float   "f"
+        end
+      end
+    RUBY
+    expect_equivalent(legacy, modern)
+  end
+
+  it 'C7: decimal/float string default matches numeric default' do
+    legacy = <<~RUBY
+      ActiveRecord::Schema.define(version: 1) do
+        create_table "t", force: :cascade do |t|
+          t.decimal "d", precision: 10, scale: 2, default: 0.0
+          t.float   "f", limit: 24,               default: 1.5
+        end
+      end
+    RUBY
+    modern = <<~RUBY
+      ActiveRecord::Schema[7.1].define(version: 1) do
+        create_table "t", force: :cascade do |t|
+          t.decimal "d", precision: 10, scale: 2, default: "0.0"
+          t.float   "f",                          default: "1.5"
+        end
+      end
+    RUBY
+    expect_equivalent(legacy, modern)
+  end
+
+  it 'C9: dropped modern column options leave UID components unchanged' do
+    legacy = <<~RUBY
+      ActiveRecord::Schema.define(version: 1) do
+        create_table "t", force: :cascade do |t|
+          t.integer "n", limit: 4,   null: false
+          t.string  "s", limit: 255
+          t.string  "c", limit: 255
+        end
+      end
+    RUBY
+    modern = <<~RUBY
+      ActiveRecord::Schema[7.1].define(version: 1) do
+        create_table "t", charset: "utf8mb4", collation: "utf8mb4_general_ci", comment: "tbl", force: :cascade do |t|
+          t.integer "n", null: false, unsigned: true
+          t.string  "s", collation: "utf8mb4_bin"
+          t.string  "c", comment: "a comment"
+        end
+      end
+    RUBY
+    expect_equivalent(legacy, modern)
+  end
+
+  it 'C5: an unknown size: value raises loudly' do
+    body = <<~RUBY
+      ActiveRecord::Schema[7.1].define(version: 1) do
+        create_table "t", force: :cascade do |t|
+          t.text "x", size: :gigantic
+        end
+      end
+    RUBY
+    expect { components_for(body) }.to raise_error(/unknown size/)
+  end
+end

--- a/jack-test/test/rb/schema_rb_parser_variants_spec.rb
+++ b/jack-test/test/rb/schema_rb_parser_variants_spec.rb
@@ -1,8 +1,8 @@
 require File.expand_path(File.dirname(__FILE__) + "/spec_helper.rb")
 require 'tempfile'
 
-# NOT run by the Maven build/CI — run manually from jack-test:
-#   bundle exec rspec test/rb
+# Run by the Maven build (jack-test pom, run-parser-specs execution) and
+# directly from jack-test with:  bundle exec rspec test/rb
 #
 # Per-rule equivalence checks: for each normalization rule, a Rails 7.1 dump
 # form and its Rails 4.2 canonical form must produce identical

--- a/jack-test/test/rb/schema_rb_parser_variants_spec.rb
+++ b/jack-test/test/rb/schema_rb_parser_variants_spec.rb
@@ -217,6 +217,25 @@ describe 'SchemaRbParser normalization variants' do
     expect_equivalent(legacy, modern)
   end
 
+  it 'check constraints (dumped by MySQL >= 8.0) are ignored' do
+    legacy = <<~RUBY
+      ActiveRecord::Schema.define(version: 1) do
+        create_table "t", force: :cascade do |t|
+          t.string "kind", limit: 255
+        end
+      end
+    RUBY
+    modern = <<~RUBY
+      ActiveRecord::Schema[7.1].define(version: 1) do
+        create_table "t", charset: "utf8mb3", force: :cascade do |t|
+          t.string "kind"
+          t.check_constraint "\`kind\` in (_utf8mb3'a',_utf8mb3'b')", name: "kind_values"
+        end
+      end
+    RUBY
+    expect_equivalent(legacy, modern)
+  end
+
   it 'an unknown size: value raises loudly' do
     body = <<~RUBY
       ActiveRecord::Schema[7.1].define(version: 1) do

--- a/jack-test/test/rb/schema_rb_uid_recipe_spec.rb
+++ b/jack-test/test/rb/schema_rb_uid_recipe_spec.rb
@@ -10,6 +10,24 @@ require File.expand_path(File.dirname(__FILE__) + "/spec_helper.rb")
 describe 'serialVersionUID recipe' do
   ACS_INPUTS_UID = 3515946867191399219
 
+  # Failure here almost never means this spec is stale — see the README section
+  # "What the UID recipe spec pins" before touching the expected values.
+  def uid_break_message(expected, actual)
+    <<~MSG
+      expected #{expected.inspect}
+           got #{actual.inspect}
+
+      The serialVersionUID derivation has changed. That re-stamps EVERY generated
+      model — including models whose schema did not change — and breaks any consumer
+      that holds serialized models across a deploy boundary (Spark/Hadoop shuffles,
+      caches: they will throw InvalidClassException reading pre-deploy bytes).
+
+      See README.md, "What the UID recipe spec pins". The fix is almost certainly to
+      revert the change to the derivation (FieldDefn/ModelDefn), NOT to update this
+      spec's expected values.
+    MSG
+  end
+
   # acs_inputs, in declaration order (ordinal), as it appears in schema.rb:
   #   t.integer  "store_size", limit: 8
   #   t.datetime "created_at"
@@ -25,22 +43,26 @@ describe 'serialVersionUID recipe' do
   end
 
   it 'reproduces the documented per-field components' do
-    expect(acs_inputs_fields.map(&:serial_version_uid_component)).to eq([
+    expected = [
       "store_sizeinteger0:limit8",
       "created_atdatetime1",
       "updated_atdatetime2",
       "pathstring3:limit255",
-    ])
+    ]
+    actual = acs_inputs_fields.map(&:serial_version_uid_component)
+    expect(actual).to eq(expected), uid_break_message(expected, actual)
   end
 
   it 'reproduces AcsInput.java attributes_serial_version_uid' do
     model = ModelDefn.new(20260609021546)
     model.fields = acs_inputs_fields
-    expect(model.attributes_serial_version_uid).to eq(ACS_INPUTS_UID)
+    actual = model.attributes_serial_version_uid
+    expect(actual).to eq(ACS_INPUTS_UID), uid_break_message(ACS_INPUTS_UID, actual)
   end
 
   it 'digests components with MD5 + unpack(q) little-endian' do
     joined = "store_sizeinteger0:limit8created_atdatetime1updated_atdatetime2pathstring3:limit255"
-    expect(Digest::MD5.digest(joined).unpack('q')[0]).to eq(ACS_INPUTS_UID)
+    actual = Digest::MD5.digest(joined).unpack('q')[0]
+    expect(actual).to eq(ACS_INPUTS_UID), uid_break_message(ACS_INPUTS_UID, actual)
   end
 end

--- a/jack-test/test/rb/schema_rb_uid_recipe_spec.rb
+++ b/jack-test/test/rb/schema_rb_uid_recipe_spec.rb
@@ -1,7 +1,7 @@
 require File.expand_path(File.dirname(__FILE__) + "/spec_helper.rb")
 
-# NOT run by the Maven build/CI — run manually from jack-test:
-#   bundle exec rspec test/rb
+# Run by the Maven build (jack-test pom, run-parser-specs execution) and
+# directly from jack-test with:  bundle exec rspec test/rb
 #
 # Pins the serialVersionUID recipe against future refactors of FieldDefn /
 # ModelDefn.  The acs_inputs model's committed UID is 3515946867191399219

--- a/jack-test/test/rb/schema_rb_uid_recipe_spec.rb
+++ b/jack-test/test/rb/schema_rb_uid_recipe_spec.rb
@@ -1,0 +1,43 @@
+require File.expand_path(File.dirname(__FILE__) + "/spec_helper.rb")
+
+# Pins the serialVersionUID recipe against future refactors of FieldDefn /
+# ModelDefn.  The acs_inputs model's committed UID is 3515946867191399219
+# (AcsInput.java); it is reproduced here from first principles.  If this test
+# breaks, the wire-compat stamp of every generated Java model has moved.
+describe 'serialVersionUID recipe' do
+  ACS_INPUTS_UID = 3515946867191399219
+
+  # acs_inputs, in declaration order (ordinal), as it appears in schema.rb:
+  #   t.integer  "store_size", limit: 8
+  #   t.datetime "created_at"
+  #   t.datetime "updated_at"
+  #   t.string   "path",       limit: 255
+  def acs_inputs_fields
+    [
+      FieldDefn.new("store_size", :integer,  0, { limit: 8 }),
+      FieldDefn.new("created_at", :datetime, 1, {}),
+      FieldDefn.new("updated_at", :datetime, 2, {}),
+      FieldDefn.new("path",       :string,   3, { limit: 255 }),
+    ]
+  end
+
+  it 'reproduces the documented per-field components' do
+    expect(acs_inputs_fields.map(&:serial_version_uid_component)).to eq([
+      "store_sizeinteger0:limit8",
+      "created_atdatetime1",
+      "updated_atdatetime2",
+      "pathstring3:limit255",
+    ])
+  end
+
+  it 'reproduces AcsInput.java attributes_serial_version_uid' do
+    model = ModelDefn.new(20260609021546)
+    model.fields = acs_inputs_fields
+    expect(model.attributes_serial_version_uid).to eq(ACS_INPUTS_UID)
+  end
+
+  it 'digests components with MD5 + unpack(q) little-endian' do
+    joined = "store_sizeinteger0:limit8created_atdatetime1updated_atdatetime2pathstring3:limit255"
+    expect(Digest::MD5.digest(joined).unpack('q')[0]).to eq(ACS_INPUTS_UID)
+  end
+end

--- a/jack-test/test/rb/schema_rb_uid_recipe_spec.rb
+++ b/jack-test/test/rb/schema_rb_uid_recipe_spec.rb
@@ -1,5 +1,8 @@
 require File.expand_path(File.dirname(__FILE__) + "/spec_helper.rb")
 
+# NOT run by the Maven build/CI — run manually from jack-test:
+#   bundle exec rspec test/rb
+#
 # Pins the serialVersionUID recipe against future refactors of FieldDefn /
 # ModelDefn.  The acs_inputs model's committed UID is 3515946867191399219
 # (AcsInput.java); it is reproduced here from first principles.  If this test

--- a/jack-test/test/test_project/database_1/db/schema_rails71.rb
+++ b/jack-test/test/test_project/database_1/db/schema_rails71.rb
@@ -1,0 +1,71 @@
+# encoding: UTF-8
+# Hand-written Rails 7.1 rendition of database_1/db/schema.rb.
+#
+# This is the SAME schema as schema.rb, but expressed the way a Rails 7.1
+# schema dumper renders it against MySQL: the `Schema[7.1]` selector, an
+# underscored version number, `t.bigint` for 8-byte integers, elided
+# adapter-default limits, `precision: nil` on legacy datetimes, table-level
+# charset/collation/comment kwargs, `t.index` inside the create_table block,
+# and a scattering of modern-only column options (unsigned/collation/comment)
+# that the 4.2 dump never carried.
+#
+# The parser normalization in schema_rb_parser.rb must reduce this to parse
+# state that is bit-identical to schema.rb (see schema_rb_parser_rails71_spec).
+# Do NOT "fix" divergences here to match — a divergence means a missing rule.
+
+ActiveRecord::Schema[7.1].define(version: 2018_05_02_013029) do
+
+  create_table "comments", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.text     "content"
+    t.integer  "commenter_id",                                                  null: false
+    t.bigint   "commented_on_id",                                               null: false
+    t.datetime "created_at",      precision: nil, default: "1970-01-01 00:00:00", null: false
+  end
+
+  create_table "images", charset: "utf8mb4", force: :cascade do |t|
+    t.integer "user_id"
+  end
+
+  create_table "lockable_models", charset: "utf8mb4", force: :cascade do |t|
+    t.integer  "lock_version",                default: 0, null: false
+    t.text     "message"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+  end
+
+  create_table "posts", charset: "utf8mb4", force: :cascade do |t|
+    t.string   "title"
+    t.date     "posted_at_millis"
+    t.integer  "user_id"
+    t.datetime "updated_at", precision: nil
+  end
+
+  create_table "profiles", charset: "utf8mb4", force: :cascade do |t|
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+  end
+
+  create_table "test_store", charset: "utf8mb4", force: :cascade do |t|
+    t.integer  "entry_type"
+    t.bigint   "entry_scope"
+    t.string   "entry_key",   limit: 2048
+    t.string   "entry_value", limit: 2048
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.index ["entry_scope", "entry_key", "entry_value"], name: "store_index_on_scope_key_value", length: { "entry_scope" => nil, "entry_key" => 20, "entry_value" => 60 }
+  end
+
+  create_table "users", charset: "utf8mb4", collation: "utf8mb4_general_ci", comment: "application users", force: :cascade do |t|
+    t.string   "handle",                                      null: false, collation: "utf8mb4_bin", comment: "unique handle"
+    t.bigint   "created_at_millis"
+    t.integer  "num_posts",                                   null: false, unsigned: true
+    t.date     "some_date"
+    t.datetime "some_datetime", precision: nil
+    t.text     "bio"
+    t.binary   "some_binary"
+    t.float    "some_float"
+    t.decimal  "some_decimal",  precision: 20, scale: 10
+    t.boolean  "some_boolean"
+  end
+
+end

--- a/jack-test/test/test_project/project_rails71.yml
+++ b/jack-test/test/test_project/project_rails71.yml
@@ -1,0 +1,15 @@
+databases_namespace: com.rapleaf.jack.test_project
+databases:
+  -
+    root_namespace: com.rapleaf.jack.test_project.database_1
+    db_name: Database1
+    schema_rb: database_1/db/schema_rails71.rb
+    models: database_1/app/models
+    ignored_tables:
+      profiles
+
+  # -
+  #   root_namespace: com.rapleaf.jack.test_project.database_2
+  #   db_name: Database2
+  #   schema_rb: database_2/db/schema.rb
+  #   models: database_2/app/models

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <db.user>root</db.user>
     <db.pass>""</db.pass>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <revision>1.9-SNAPSHOT</revision>
+    <revision>1.10-SNAPSHOT</revision>
   </properties>
 
   <scm>


### PR DESCRIPTION
db_schemas is upgrading to Rails 7.1, and the schema.rb dump format changed after 4.2. This teaches the parser to read the new format and normalize it to the exact parse state the 4.2 format produces, so the generated Java — including every serialVersionUID — comes out byte-for-byte identical.

What newer dumps do differently and how the parser handles it:

- Newer actievrecord versions include version tags, e.g. `ActiveRecord::Schema[7.1].define(...)` — the parser now accepts and then ignores this
- `t.bigint` and `t.timestamp` are new names for what 4.2 dumped as `t.integer, limit: 8` and `t.datetime` — the parser renames them back to the old types
- Newer activerecord versions omit limits — the parser adds them back explicitly (integer 4, string 255, text/binary 65535, float 24), including for `size: :tiny/:medium/:long`
- Newer Activerecord dumps float/decimal defaults as strings (`"0.0"`) — parser coerces these to Float
- Activerecord 4.2 never included certain column information in its dumps (`unsigned`, `collation`, `charset`, `comment`, `as`, `stored`, `auto_increment`, expression defaults) but newer versions do; these are dropped with a warning; newer versions also include table-level `charset`/`collation`/`comment`/`primary_key` values, which are accepted and ignored
- When dumping a mysql 8 database, newer activerecord versions can include `t.check_constraint` values — these are accepted and ignored
- Remaining unknown column types still fail loudly

Testing: generated the full production rldb schema from both the current 4.2-format schema.rb and a real Rails 7.1 dump of the same database — 2,926 files byte-identical, parse state identical across all 4,682 columns, serialVersionUIDs unchanged. New specs cover each rule and pin the serialVersionUID recipe itself; existing specs pass unchanged.

We also checked ahead to the eventual MySQL 8 cutover, using a real dump of the full schema taken against a MySQL 8.0 server. The 8.0 dump differs from the 5.7 one in per-table charset annotations (`utf8` → `utf8mb3`), one CHECK constraint 5.7 had been silently ignoring, and one TIMESTAMP column whose implicit default 8.0 no longer applies. All three normalize away: parse state is identical across all 607 models, serialVersionUIDs unchanged. So this parser version covers the MySQL 8 transition too, and no follow-up jack change should be needed for the cutover.

One housekeeping fix rides along: the Jenkins shared-library pin moves from `liveramp-base@v2` to `v3.0`. The v2 tag's `runWithMaven` passes `findbugsPublisher()` to `withMaven`, an option the current Pipeline Maven plugin no longer has, so every build on v2 fails before running anything (jenkins_pipelines removed it in #294). v3.0 is what db_schemas already builds green with, and the deploy/branch logic is identical between the two tags.

Versioning and publish behavior: this bumps `<revision>` to 1.10-SNAPSHOT, since the 1.9-SNAPSHOT stream is in use by a handful of consumers. On merge, the master build starts deploying 1.10-SNAPSHOT to Artifactory instead of 1.9-SNAPSHOT. No consumer is affected: every jack dependent pins an explicit version (pom-db-common and bang_db at 1.9-SNAPSHOT, db_schemas at the 1.8 release, a handful of older pins), and of course nothing anywhere references 1.10-SNAPSHOT yet — nobody picks this up until they bump on their own. The one side effect is that 1.9-SNAPSHOT stops receiving updates; its last-published artifact stays in Artifactory unchanged. And, this will not produce a PUBLIC release, which requires a release branch; master builds automatically append `-SNAPSHOT`.