### PR TITLE
[WIP] Drop the BUNDLED WITH pin from the jack-core generator lock

### DIFF
--- a/jack-core/src/Gemfile.lock
+++ b/jack-core/src/Gemfile.lock
@@ -24,6 +24,3 @@ DEPENDENCIES
   bigdecimal (= 1.3.5)
   fattr
   i18n (~> 0.9)
-
-BUNDLED WITH
-   1.17.3


### PR DESCRIPTION
Having trouble with the db_schemas build due to bundler versions.

The lock file currently pins bundler 1.17.3, which the jar's consumers don't have installed--db_schemas' Maven build runs Ruby 2.7 with bundler 2.1.4, and rubygems hard-errors "Could not find 'bundler' (1.17.3)" before the generator runs. If we remove these lines, bundler will use whatever version is installed.

Waiting to confirm that this is the issue and we do not need further edits to this library, via a shim in the db_schemas build.